### PR TITLE
Makefile,cmd/api/main.go: fix folder import path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,4 +127,4 @@ ui/src/client: api.yaml
 .PHONY: ui
 ui:
 	cd ui && npm run build
-	rm -rf ./cmd/api/ui/build && cp -r ./ui/build/ ./cmd/api/ui/
+	rm -rf ./cmd/api/ui/build && cp -r ./ui/build ./cmd/api/ui/

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -33,7 +33,7 @@ import (
 var ui embed.FS
 
 func main() {
-	build, err := fs.Sub(ui, "ui/build")
+	build, err := fs.Sub(ui, "cmd/ui/build")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
As observed on MacOS, the command `make` was failing due to a problem in the Makefile and the corresponding reference of said folder in main.go.

This adjusts both the copy inside the Makefile and the reference in main.go.

Before:

```
rm -rf ./cmd/api/ui/build && cp -r ./ui/build/ ./cmd/api/ui/
go fmt ./...
go vet ./...
cmd/api/main.go:32:12: pattern ui/build: no matching files found
make: *** [Makefile:66: vet] Error 1
```

After:

```
rm -rf ./cmd/api/ui/build && cp -r ./ui/build ./cmd/api/ui/
go fmt ./...
go vet ./...
go build -o bin/api ./cmd/api/main.go
/Users/rrackow/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=pyrra-kubernetes webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/Users/rrackow/go/bin/controller-gen object:headerFile="kubernetes/hack/boilerplate.go.txt" paths="./..."
go build -o bin/kubernetes ./cmd/kubernetes/main.go
go build -o bin/filesystem ./cmd/filesystem/main.go
```