### PR TITLE
Makefile improvements and multi-stage container builds

### DIFF
--- a/cmd/api/Dockerfile
+++ b/cmd/api/Dockerfile
@@ -1,21 +1,23 @@
-# Build the manager binary
+# Build UI
+FROM node:16 as uibuilder
+
+WORKDIR /workspace
+COPY ui ui
+COPY Makefile Makefile
+RUN make ui/node_modules ui/build
+
+# Build the kubernetes binary
 FROM golang:1.16 as builder
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY . .
+COPY --from=uibuilder /workspace/ui/build /workspace/cmd/api/ui/build
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
-COPY cmd/api/ cmd/api/
-COPY openapi/ openapi/
-COPY slo/ slo/
-
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/api cmd/api/main.go
+RUN make api
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/cmd/kubernetes/Dockerfile
+++ b/cmd/kubernetes/Dockerfile
@@ -1,23 +1,23 @@
+# Build UI
+FROM node:16 as uibuilder
+
+WORKDIR /workspace
+COPY ui ui
+COPY Makefile Makefile
+RUN make ui/node_modules ui/build
+
 # Build the kubernetes binary
 FROM golang:1.16 as builder
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY . .
+COPY --from=uibuilder /workspace/ui/build /workspace/cmd/api/ui/build
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
-COPY /cmd/kubernetes/main.go cmd/kubernetes/main.go
-COPY kubernetes/api/ kubernetes/api/
-COPY kubernetes/controllers/ kubernetes/controllers/
-COPY openapi/ openapi/
-COPY slo/ slo/
-
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/kubernetes cmd/kubernetes/main.go
+RUN make kubernetes
 
 # Use distroless as minimal base image to package the kubernetes binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
List of changes:
- Use `${PWD}` instead of shelling out with `$(shell pwd)` in Makefile
- Use common make targets like `lint`, `build`, `clean`
- Add `clean` target to remove installed and built assets. This one may be improved later on.
- split building UI into multiple targets based on directories they provide (`ui/build`, `ui/node_modules`)
- Remove recursive removal where not necessary in Makefile
- Refactor both Dockerfiles to use provided Makefile and allow building UI in a container. This should allow specifying build directives only once in Makefile instead of duplicating it in multiple places.
- Unify Dockerfiles by copying the whole codebase into an intermediary build container.

Signed-off-by: paulfantom <pawel@krupa.net.pl>