### PR TITLE
bump controller-gen tool version to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
+++ b/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: servicelevelobjectives.pyrra.dev
 spec:
@@ -15,109 +15,111 @@ spec:
     plural: servicelevelobjectives
     singular: servicelevelobjective
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: ServiceLevelObjective is the Schema for the ServiceLevelObjectives
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ServiceLevelObjectiveSpec defines the desired state of ServiceLevelObjective
-          properties:
-            description:
-              description: Description describes the ServiceLevelObjective in more
-                detail and gives extra context for engineers that might not directly
-                work on the service.
-              type: string
-            indicator:
-              description: ServiceLevelIndicator is the underlying data source that
-                indicates how the service is doing. This will be a Prometheus metric
-                with specific selectors for your service.
-              properties:
-                latency:
-                  description: Latency is the indicator that measures a certain percentage
-                    to be fast than.
-                  properties:
-                    success:
-                      description: Success is the metric that returns how many errors
-                        there are.
-                      properties:
-                        metric:
-                          type: string
-                      required:
-                      - metric
-                      type: object
-                    total:
-                      description: Total is the metric that returns how many requests
-                        there are in total.
-                      properties:
-                        metric:
-                          type: string
-                      required:
-                      - metric
-                      type: object
-                  required:
-                  - success
-                  - total
-                  type: object
-                ratio:
-                  description: Ratio is the indicator that measures against errors
-                    / total events.
-                  properties:
-                    errors:
-                      description: Errors is the metric that returns how many errors
-                        there are.
-                      properties:
-                        metric:
-                          type: string
-                      required:
-                      - metric
-                      type: object
-                    total:
-                      description: Total is the metric that returns how many requests
-                        there are in total.
-                      properties:
-                        metric:
-                          type: string
-                      required:
-                      - metric
-                      type: object
-                  required:
-                  - errors
-                  - total
-                  type: object
-              type: object
-            target:
-              description: 'Target is a string that''s casted to a float64 between
-                0 - 100. It represents the desired availability of the service in
-                the given window. float64 are not supported: https://github.com/kubernetes-sigs/controller-tools/issues/245'
-              type: string
-            window:
-              description: Window within which the Target is supposed to be kept.
-                Usually something like 1d, 7d or 28d.
-          required:
-          - indicator
-          - target
-          - window
-          type: object
-        status:
-          description: ServiceLevelObjectiveStatus defines the observed state of ServiceLevelObjective
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceLevelObjective is the Schema for the ServiceLevelObjectives
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceLevelObjectiveSpec defines the desired state of ServiceLevelObjective
+            properties:
+              description:
+                description: Description describes the ServiceLevelObjective in more
+                  detail and gives extra context for engineers that might not directly
+                  work on the service.
+                type: string
+              indicator:
+                description: ServiceLevelIndicator is the underlying data source that
+                  indicates how the service is doing. This will be a Prometheus metric
+                  with specific selectors for your service.
+                properties:
+                  latency:
+                    description: Latency is the indicator that measures a certain
+                      percentage to be fast than.
+                    properties:
+                      success:
+                        description: Success is the metric that returns how many errors
+                          there are.
+                        properties:
+                          metric:
+                            type: string
+                        required:
+                        - metric
+                        type: object
+                      total:
+                        description: Total is the metric that returns how many requests
+                          there are in total.
+                        properties:
+                          metric:
+                            type: string
+                        required:
+                        - metric
+                        type: object
+                    required:
+                    - success
+                    - total
+                    type: object
+                  ratio:
+                    description: Ratio is the indicator that measures against errors
+                      / total events.
+                    properties:
+                      errors:
+                        description: Errors is the metric that returns how many errors
+                          there are.
+                        properties:
+                          metric:
+                            type: string
+                        required:
+                        - metric
+                        type: object
+                      total:
+                        description: Total is the metric that returns how many requests
+                          there are in total.
+                        properties:
+                          metric:
+                            type: string
+                        required:
+                        - metric
+                        type: object
+                    required:
+                    - errors
+                    - total
+                    type: object
+                type: object
+              target:
+                description: 'Target is a string that''s casted to a float64 between
+                  0 - 100. It represents the desired availability of the service in
+                  the given window. float64 are not supported: https://github.com/kubernetes-sigs/controller-tools/issues/245'
+                type: string
+              window:
+                description: Window within which the Target is supposed to be kept.
+                  Usually something like 1d, 7d or 28d.
+                format: int64
+                type: integer
+            required:
+            - indicator
+            - target
+            - window
+            type: object
+          status:
+            description: ServiceLevelObjectiveStatus defines the observed state of
+              ServiceLevelObjective
+            type: object
+        type: object
     served: true
     storage: true
 status:


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

`controller-gen` version is a little bit out of date and I can see the warning below when applying CRD to my local k8s cluster.

```
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
```