### PR TITLE
ui: Show spinner for loading Availabiltiy & Error Budget

### DIFF
--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -121,7 +121,14 @@ const Detail = (params: RouteComponentProps<DetailRouteParams>) => {
               ) : (
                 <div>
                   <h6>Availability</h6>
-                  <h2>&nbsp;</h2>
+                  <Spinner animation={'border'} style={{
+                    width: 50,
+                    height: 50,
+                    padding: 0,
+                    borderRadius: 50,
+                    borderWidth: 2,
+                    opacity: 0.25
+                  }}/>
                 </div>
               )}
               {errorBudget != null ? (
@@ -134,7 +141,14 @@ const Detail = (params: RouteComponentProps<DetailRouteParams>) => {
               ) : (
                 <div>
                   <h6>Error Budget</h6>
-                  <h2>&nbsp;</h2>
+                  <Spinner animation={'border'} style={{
+                    width: 50,
+                    height: 50,
+                    padding: 0,
+                    borderRadius: 50,
+                    borderWidth: 2,
+                    opacity: 0.25
+                  }}/>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Spinner is now shown when still loading status. 
![Screenshot from 2021-09-12 23-50-29](https://user-images.githubusercontent.com/872251/133003855-6f4691fe-37f5-49f6-bc89-bde960155aa8.png)

Closes #15 