### PR TITLE
k8s: allow limiting k8s instance to a particular namespace

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -48,7 +48,7 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-func cmdKubernetes(metricsAddr string) {
+func cmdKubernetes(metricsAddr string, namespace string) {
 	setupLog := ctrl.Log.WithName("setup")
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -58,6 +58,7 @@ func cmdKubernetes(metricsAddr string) {
 		Port:               9443,
 		LeaderElection:     false,
 		LeaderElectionID:   "9d76195a.metalmatze.de",
+		Namespace:          namespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ var CLI struct {
 	} `cmd:"" help:"Runs Pyrra's filesystem operator and backend for the API."`
 	Kubernetes struct {
 		MetricsAddr string `default:":8080" help:"The address the metric endpoint binds to."`
+		Namespace   string `default:"" help:"Read ServiceLevelObjective from specific namespace only"`
 	} `cmd:"" help:"Runs Pyrra's Kubernetes operator and backend for the API."`
 }
 
@@ -57,7 +58,7 @@ func main() {
 	case "filesystem":
 		cmdFilesystem(CLI.Filesystem.ConfigFiles, CLI.Filesystem.PrometheusFolder)
 	case "kubernetes":
-		cmdKubernetes(CLI.Kubernetes.MetricsAddr)
+		cmdKubernetes(CLI.Kubernetes.MetricsAddr, CLI.Kubernetes.Namespace)
 	}
 
 	return


### PR DESCRIPTION
By default pyrra-k8s attempts to read ServiceLevelObjectives on cluster scope. We might want to scope these to a particular namespace, so that
a) multiple pyrras could be deployed
b) each instance would require less privileges