### PR TITLE
examples: change namespace to allow easy application of examples

### DIFF
--- a/examples/pyrra-filesystem-errors.yaml
+++ b/examples/pyrra-filesystem-errors.yaml
@@ -2,7 +2,7 @@ apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective
 metadata:
   name: pyrra-filesystem-errors
-  namespace: parca
+  namespace: monitoring
   labels:
     prometheus: k8s
     role: alert-rules

--- a/examples/pyrra-http-errors.yaml
+++ b/examples/pyrra-http-errors.yaml
@@ -2,7 +2,7 @@ apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective
 metadata:
   name: pyrra-api-errors
-  namespace: parca
+  namespace: monitoring
   labels:
     prometheus: k8s
     role: alert-rules

--- a/examples/pyrra-kubernetes-errors.yaml
+++ b/examples/pyrra-kubernetes-errors.yaml
@@ -2,7 +2,7 @@ apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective
 metadata:
   name: pyrra-kubernetes-errors
-  namespace: parca
+  namespace: monitoring
   labels:
     prometheus: k8s
     role: alert-rules


### PR DESCRIPTION
Unifying namespace names in examples.

That hint was here long enough :stuck_out_tongue: 