### PR TITLE
Support grouping SLOs by labels

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -194,6 +194,10 @@ components:
               $ref: '#/components/schemas/Query'
             total:
               $ref: '#/components/schemas/Query'
+            grouping:
+              type: array
+              items:
+                type: string
         latency:
           type: object
           required:
@@ -204,6 +208,10 @@ components:
               $ref: '#/components/schemas/Query'
             total:
               $ref: '#/components/schemas/Query'
+            grouping:
+              type: array
+              items:
+                type: string
     Query:
       type: object
       required:

--- a/api.yaml
+++ b/api.yaml
@@ -57,6 +57,10 @@ paths:
           schema:
             type: string
         - in: query
+          name: grouping
+          schema:
+            type: string
+        - in: query
           name: start
           schema:
             type: integer
@@ -85,6 +89,10 @@ paths:
           required: true
           schema:
             type: string
+        - in: query
+          name: grouping
+          schema:
+            type: string
       responses:
         '200':
           description: Get GetMultiBurnrateAlerts for the Objective
@@ -104,6 +112,10 @@ paths:
         - in: query
           name: expr
           required: true
+          schema:
+            type: string
+        - in: query
+          name: grouping
           schema:
             type: string
         - in: query
@@ -133,6 +145,10 @@ paths:
         - in: query
           name: expr
           required: true
+          schema:
+            type: string
+        - in: query
+          name: grouping
           schema:
             type: string
         - in: query
@@ -242,6 +258,8 @@ components:
       properties:
         labels:
           type: object
+          additionalProperties:
+            type: string
         availability:
           type: object
           required:

--- a/api.yaml
+++ b/api.yaml
@@ -41,7 +41,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ObjectiveStatus'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ObjectiveStatus'
   /objectives/errorbudget:
     get:
       summary: Get ErrorBudget graph sample pairs
@@ -238,6 +240,8 @@ components:
         - availability
         - budget
       properties:
+        labels:
+          type: object
         availability:
           type: object
           required:

--- a/api.yaml
+++ b/api.yaml
@@ -35,6 +35,10 @@ paths:
           required: true
           schema:
             type: string
+        - in: query
+          name: grouping
+          schema:
+            type: string
       responses:
         '200':
           description: Get objective status

--- a/examples/prometheus-http.yaml
+++ b/examples/prometheus-http.yaml
@@ -12,6 +12,8 @@ spec:
   indicator:
     ratio:
       errors:
-        metric: prometheus_http_requests_total{handler="/api/v1/query",code=~"5.."}
+        metric: prometheus_http_requests_total{handler=~"/api.*",code=~"5.."}
       total:
-        metric: prometheus_http_requests_total{handler="/api/v1/query"}
+        metric: prometheus_http_requests_total{handler=~"/api.*"}
+      grouping:
+        - handler

--- a/examples/pyrra-http-errors.yaml
+++ b/examples/pyrra-http-errors.yaml
@@ -16,3 +16,5 @@ spec:
         metric: http_requests_total{job="pyrra",code=~"5.."}
       total:
         metric: http_requests_total{job="pyrra"}
+      grouping:
+        - route

--- a/filesystem.go
+++ b/filesystem.go
@@ -266,7 +266,7 @@ func (f FilesystemObjectiveServer) GetObjectiveErrorBudget(ctx context.Context, 
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
-func (f FilesystemObjectiveServer) GetObjectiveStatus(ctx context.Context, expr string) (openapiserver.ImplResponse, error) {
+func (f FilesystemObjectiveServer) GetObjectiveStatus(ctx context.Context, expr string, grouping string) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 

--- a/filesystem.go
+++ b/filesystem.go
@@ -258,11 +258,11 @@ func (f FilesystemObjectiveServer) GetObjective(ctx context.Context, expr string
 	}, nil
 }
 
-func (f FilesystemObjectiveServer) GetMultiBurnrateAlerts(ctx context.Context, expr string) (openapiserver.ImplResponse, error) {
+func (f FilesystemObjectiveServer) GetMultiBurnrateAlerts(ctx context.Context, expr string, grouping string) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
-func (f FilesystemObjectiveServer) GetObjectiveErrorBudget(ctx context.Context, expr string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
+func (f FilesystemObjectiveServer) GetObjectiveErrorBudget(ctx context.Context, expr string, grouping string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
@@ -270,10 +270,10 @@ func (f FilesystemObjectiveServer) GetObjectiveStatus(ctx context.Context, expr 
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
-func (f FilesystemObjectiveServer) GetREDRequests(ctx context.Context, expr string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
+func (f FilesystemObjectiveServer) GetREDRequests(ctx context.Context, expr string, grouping string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
-func (f FilesystemObjectiveServer) GetREDErrors(ctx context.Context, expr string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
+func (f FilesystemObjectiveServer) GetREDErrors(ctx context.Context, expr string, grouping string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -174,11 +174,11 @@ func (o *ObjectiveServer) ListObjectives(ctx context.Context, expr string) (open
 	}, nil
 }
 
-func (o *ObjectiveServer) GetMultiBurnrateAlerts(ctx context.Context, expr string) (openapiserver.ImplResponse, error) {
+func (o *ObjectiveServer) GetMultiBurnrateAlerts(ctx context.Context, expr string, grouping string) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
-func (o *ObjectiveServer) GetObjectiveErrorBudget(ctx context.Context, expr string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
+func (o *ObjectiveServer) GetObjectiveErrorBudget(ctx context.Context, expr string, grouping string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
@@ -186,10 +186,10 @@ func (o *ObjectiveServer) GetObjectiveStatus(ctx context.Context, expr string) (
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
-func (o *ObjectiveServer) GetREDErrors(ctx context.Context, expr string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
+func (o *ObjectiveServer) GetREDErrors(ctx context.Context, expr string, grouping string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
-func (o *ObjectiveServer) GetREDRequests(ctx context.Context, expr string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
+func (o *ObjectiveServer) GetREDRequests(ctx context.Context, expr string, grouping string, i int32, i2 int32) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -182,7 +182,7 @@ func (o *ObjectiveServer) GetObjectiveErrorBudget(ctx context.Context, expr stri
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 
-func (o *ObjectiveServer) GetObjectiveStatus(ctx context.Context, expr string) (openapiserver.ImplResponse, error) {
+func (o *ObjectiveServer) GetObjectiveStatus(ctx context.Context, expr string, grouping string) (openapiserver.ImplResponse, error) {
 	return openapiserver.ImplResponse{}, fmt.Errorf("endpoint not implement")
 }
 

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -159,6 +159,7 @@ func (in ServiceLevelObjective) Internal() (slo.Objective, error) {
 				Name:          totalVec.Name,
 				LabelMatchers: totalVec.LabelMatchers,
 			},
+			Grouping: in.Spec.ServiceLevelIndicator.Ratio.Grouping,
 		}
 	}
 
@@ -205,6 +206,7 @@ func (in ServiceLevelObjective) Internal() (slo.Objective, error) {
 				Name:          totalVec.Name,
 				LabelMatchers: totalMatchers,
 			},
+			Grouping: in.Spec.ServiceLevelIndicator.Latency.Grouping,
 		}
 	}
 

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -91,6 +91,8 @@ type RatioIndicator struct {
 	Errors Query `json:"errors"`
 	// Total is the metric that returns how many requests there are in total.
 	Total Query `json:"total"`
+	// Grouping allows an SLO to be defined for many SLI at once, like HTTP handlers for example.
+	Grouping []string `json:"grouping"`
 }
 
 type LatencyIndicator struct {
@@ -98,6 +100,8 @@ type LatencyIndicator struct {
 	Success Query `json:"success"`
 	// Total is the metric that returns how many requests there are in total.
 	Total Query `json:"total"`
+	// Grouping allows an SLO to be defined for many SLI at once, like HTTP handlers for example.
+	Grouping []string `json:"grouping"`
 }
 
 // Query contains a PromQL metric

--- a/main.go
+++ b/main.go
@@ -400,9 +400,9 @@ func (o *ObjectivesServer) GetObjectiveErrorBudget(ctx context.Context, expr str
 		return openapiserver.ImplResponse{Code: http.StatusInternalServerError}, fmt.Errorf("no matrix returned")
 	}
 
-	if len(matrix) != 1 {
-		return openapiserver.ImplResponse{Code: http.StatusNotFound}, fmt.Errorf("no data")
-	}
+	//if len(matrix) != 1 {
+	//	return openapiserver.ImplResponse{Code: http.StatusNotFound}, fmt.Errorf("no data")
+	//}
 
 	if len(matrix) == 0 {
 		return openapiserver.ImplResponse{Code: http.StatusNotFound}, fmt.Errorf("no data")

--- a/openapi/client/api/openapi.yaml
+++ b/openapi/client/api/openapi.yaml
@@ -42,7 +42,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ObjectiveStatus'
+                items:
+                  $ref: '#/components/schemas/ObjectiveStatus'
+                type: array
           description: Get objective status
       summary: Get objective status
       tags:
@@ -353,11 +355,14 @@ components:
           total: 6.027456183070403
           percentage: 0.8008281904610115
           errors: 1.4658129805029452
+        labels: '{}'
         budget:
           total: 5.962133916683182
           max: 2.3021358869347655
           remaining: 5.637376656633329
       properties:
+        labels:
+          type: object
         availability:
           $ref: '#/components/schemas/ObjectiveStatus_availability'
         budget:

--- a/openapi/client/api/openapi.yaml
+++ b/openapi/client/api/openapi.yaml
@@ -211,6 +211,9 @@ components:
                 value: value
               metric: metric
               name: name
+            grouping:
+            - grouping
+            - grouping
           ratio:
             total:
               matchers:
@@ -222,6 +225,9 @@ components:
                 value: value
               metric: metric
               name: name
+            grouping:
+            - grouping
+            - grouping
             errors:
               matchers:
               - name: name
@@ -285,6 +291,9 @@ components:
               value: value
             metric: metric
             name: name
+          grouping:
+          - grouping
+          - grouping
         ratio:
           total:
             matchers:
@@ -296,6 +305,9 @@ components:
               value: value
             metric: metric
             name: name
+          grouping:
+          - grouping
+          - grouping
           errors:
             matchers:
             - name: name
@@ -456,6 +468,9 @@ components:
             value: value
           metric: metric
           name: name
+        grouping:
+        - grouping
+        - grouping
         errors:
           matchers:
           - name: name
@@ -471,6 +486,10 @@ components:
           $ref: '#/components/schemas/Query'
         total:
           $ref: '#/components/schemas/Query'
+        grouping:
+          items:
+            type: string
+          type: array
       required:
       - errors
       - total
@@ -497,11 +516,18 @@ components:
             value: value
           metric: metric
           name: name
+        grouping:
+        - grouping
+        - grouping
       properties:
         success:
           $ref: '#/components/schemas/Query'
         total:
           $ref: '#/components/schemas/Query'
+        grouping:
+          items:
+            type: string
+          type: array
       required:
       - success
       - total

--- a/openapi/client/api/openapi.yaml
+++ b/openapi/client/api/openapi.yaml
@@ -37,6 +37,13 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:

--- a/openapi/client/api/openapi.yaml
+++ b/openapi/client/api/openapi.yaml
@@ -60,6 +60,13 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
+        schema:
+          type: string
+        style: form
       - description: The timestamp to start the query range at
         explode: true
         in: query
@@ -97,6 +104,13 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:
@@ -117,6 +131,13 @@ paths:
         in: query
         name: expr
         required: true
+        schema:
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
         schema:
           type: string
         style: form
@@ -154,6 +175,13 @@ paths:
         in: query
         name: expr
         required: true
+        schema:
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
         schema:
           type: string
         style: form
@@ -355,13 +383,16 @@ components:
           total: 6.027456183070403
           percentage: 0.8008281904610115
           errors: 1.4658129805029452
-        labels: '{}'
+        labels:
+          key: labels
         budget:
           total: 5.962133916683182
           max: 2.3021358869347655
           remaining: 5.637376656633329
       properties:
         labels:
+          additionalProperties:
+            type: string
           type: object
         availability:
           $ref: '#/components/schemas/ObjectiveStatus_availability'

--- a/openapi/client/api_objectives.go
+++ b/openapi/client/api_objectives.go
@@ -30,10 +30,15 @@ type ApiGetMultiBurnrateAlertsRequest struct {
 	ctx        _context.Context
 	ApiService *ObjectivesApiService
 	expr       *string
+	grouping   *string
 }
 
 func (r ApiGetMultiBurnrateAlertsRequest) Expr(expr string) ApiGetMultiBurnrateAlertsRequest {
 	r.expr = &expr
+	return r
+}
+func (r ApiGetMultiBurnrateAlertsRequest) Grouping(grouping string) ApiGetMultiBurnrateAlertsRequest {
+	r.grouping = &grouping
 	return r
 }
 
@@ -82,6 +87,9 @@ func (a *ObjectivesApiService) GetMultiBurnrateAlertsExecute(r ApiGetMultiBurnra
 	}
 
 	localVarQueryParams.Add("expr", parameterToString(*r.expr, ""))
+	if r.grouping != nil {
+		localVarQueryParams.Add("grouping", parameterToString(*r.grouping, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -140,12 +148,17 @@ type ApiGetObjectiveErrorBudgetRequest struct {
 	ctx        _context.Context
 	ApiService *ObjectivesApiService
 	expr       *string
+	grouping   *string
 	start      *int32
 	end        *int32
 }
 
 func (r ApiGetObjectiveErrorBudgetRequest) Expr(expr string) ApiGetObjectiveErrorBudgetRequest {
 	r.expr = &expr
+	return r
+}
+func (r ApiGetObjectiveErrorBudgetRequest) Grouping(grouping string) ApiGetObjectiveErrorBudgetRequest {
+	r.grouping = &grouping
 	return r
 }
 func (r ApiGetObjectiveErrorBudgetRequest) Start(start int32) ApiGetObjectiveErrorBudgetRequest {
@@ -202,6 +215,9 @@ func (a *ObjectivesApiService) GetObjectiveErrorBudgetExecute(r ApiGetObjectiveE
 	}
 
 	localVarQueryParams.Add("expr", parameterToString(*r.expr, ""))
+	if r.grouping != nil {
+		localVarQueryParams.Add("grouping", parameterToString(*r.grouping, ""))
+	}
 	if r.start != nil {
 		localVarQueryParams.Add("start", parameterToString(*r.start, ""))
 	}
@@ -376,12 +392,17 @@ type ApiGetREDErrorsRequest struct {
 	ctx        _context.Context
 	ApiService *ObjectivesApiService
 	expr       *string
+	grouping   *string
 	start      *int32
 	end        *int32
 }
 
 func (r ApiGetREDErrorsRequest) Expr(expr string) ApiGetREDErrorsRequest {
 	r.expr = &expr
+	return r
+}
+func (r ApiGetREDErrorsRequest) Grouping(grouping string) ApiGetREDErrorsRequest {
+	r.grouping = &grouping
 	return r
 }
 func (r ApiGetREDErrorsRequest) Start(start int32) ApiGetREDErrorsRequest {
@@ -438,6 +459,9 @@ func (a *ObjectivesApiService) GetREDErrorsExecute(r ApiGetREDErrorsRequest) (Qu
 	}
 
 	localVarQueryParams.Add("expr", parameterToString(*r.expr, ""))
+	if r.grouping != nil {
+		localVarQueryParams.Add("grouping", parameterToString(*r.grouping, ""))
+	}
 	if r.start != nil {
 		localVarQueryParams.Add("start", parameterToString(*r.start, ""))
 	}
@@ -502,12 +526,17 @@ type ApiGetREDRequestsRequest struct {
 	ctx        _context.Context
 	ApiService *ObjectivesApiService
 	expr       *string
+	grouping   *string
 	start      *int32
 	end        *int32
 }
 
 func (r ApiGetREDRequestsRequest) Expr(expr string) ApiGetREDRequestsRequest {
 	r.expr = &expr
+	return r
+}
+func (r ApiGetREDRequestsRequest) Grouping(grouping string) ApiGetREDRequestsRequest {
+	r.grouping = &grouping
 	return r
 }
 func (r ApiGetREDRequestsRequest) Start(start int32) ApiGetREDRequestsRequest {
@@ -564,6 +593,9 @@ func (a *ObjectivesApiService) GetREDRequestsExecute(r ApiGetREDRequestsRequest)
 	}
 
 	localVarQueryParams.Add("expr", parameterToString(*r.expr, ""))
+	if r.grouping != nil {
+		localVarQueryParams.Add("grouping", parameterToString(*r.grouping, ""))
+	}
 	if r.start != nil {
 		localVarQueryParams.Add("start", parameterToString(*r.start, ""))
 	}

--- a/openapi/client/api_objectives.go
+++ b/openapi/client/api_objectives.go
@@ -282,10 +282,15 @@ type ApiGetObjectiveStatusRequest struct {
 	ctx        _context.Context
 	ApiService *ObjectivesApiService
 	expr       *string
+	grouping   *string
 }
 
 func (r ApiGetObjectiveStatusRequest) Expr(expr string) ApiGetObjectiveStatusRequest {
 	r.expr = &expr
+	return r
+}
+func (r ApiGetObjectiveStatusRequest) Grouping(grouping string) ApiGetObjectiveStatusRequest {
+	r.grouping = &grouping
 	return r
 }
 
@@ -334,6 +339,9 @@ func (a *ObjectivesApiService) GetObjectiveStatusExecute(r ApiGetObjectiveStatus
 	}
 
 	localVarQueryParams.Add("expr", parameterToString(*r.expr, ""))
+	if r.grouping != nil {
+		localVarQueryParams.Add("grouping", parameterToString(*r.grouping, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/openapi/client/api_objectives.go
+++ b/openapi/client/api_objectives.go
@@ -273,7 +273,7 @@ func (r ApiGetObjectiveStatusRequest) Expr(expr string) ApiGetObjectiveStatusReq
 	return r
 }
 
-func (r ApiGetObjectiveStatusRequest) Execute() (ObjectiveStatus, *_nethttp.Response, error) {
+func (r ApiGetObjectiveStatusRequest) Execute() ([]ObjectiveStatus, *_nethttp.Response, error) {
 	return r.ApiService.GetObjectiveStatusExecute(r)
 }
 
@@ -291,16 +291,16 @@ func (a *ObjectivesApiService) GetObjectiveStatus(ctx _context.Context) ApiGetOb
 
 /*
  * Execute executes the request
- * @return ObjectiveStatus
+ * @return []ObjectiveStatus
  */
-func (a *ObjectivesApiService) GetObjectiveStatusExecute(r ApiGetObjectiveStatusRequest) (ObjectiveStatus, *_nethttp.Response, error) {
+func (a *ObjectivesApiService) GetObjectiveStatusExecute(r ApiGetObjectiveStatusRequest) ([]ObjectiveStatus, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		localVarReturnValue  ObjectiveStatus
+		localVarReturnValue  []ObjectiveStatus
 	)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ObjectivesApiService.GetObjectiveStatus")

--- a/openapi/client/model_indicator_latency.go
+++ b/openapi/client/model_indicator_latency.go
@@ -16,8 +16,9 @@ import (
 
 // IndicatorLatency struct for IndicatorLatency
 type IndicatorLatency struct {
-	Success Query `json:"success"`
-	Total   Query `json:"total"`
+	Success  Query     `json:"success"`
+	Total    Query     `json:"total"`
+	Grouping *[]string `json:"grouping,omitempty"`
 }
 
 // NewIndicatorLatency instantiates a new IndicatorLatency object
@@ -87,6 +88,38 @@ func (o *IndicatorLatency) SetTotal(v Query) {
 	o.Total = v
 }
 
+// GetGrouping returns the Grouping field value if set, zero value otherwise.
+func (o *IndicatorLatency) GetGrouping() []string {
+	if o == nil || o.Grouping == nil {
+		var ret []string
+		return ret
+	}
+	return *o.Grouping
+}
+
+// GetGroupingOk returns a tuple with the Grouping field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IndicatorLatency) GetGroupingOk() (*[]string, bool) {
+	if o == nil || o.Grouping == nil {
+		return nil, false
+	}
+	return o.Grouping, true
+}
+
+// HasGrouping returns a boolean if a field has been set.
+func (o *IndicatorLatency) HasGrouping() bool {
+	if o != nil && o.Grouping != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetGrouping gets a reference to the given []string and assigns it to the Grouping field.
+func (o *IndicatorLatency) SetGrouping(v []string) {
+	o.Grouping = &v
+}
+
 func (o IndicatorLatency) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
@@ -94,6 +127,9 @@ func (o IndicatorLatency) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["total"] = o.Total
+	}
+	if o.Grouping != nil {
+		toSerialize["grouping"] = o.Grouping
 	}
 	return json.Marshal(toSerialize)
 }

--- a/openapi/client/model_indicator_ratio.go
+++ b/openapi/client/model_indicator_ratio.go
@@ -16,8 +16,9 @@ import (
 
 // IndicatorRatio struct for IndicatorRatio
 type IndicatorRatio struct {
-	Errors Query `json:"errors"`
-	Total  Query `json:"total"`
+	Errors   Query     `json:"errors"`
+	Total    Query     `json:"total"`
+	Grouping *[]string `json:"grouping,omitempty"`
 }
 
 // NewIndicatorRatio instantiates a new IndicatorRatio object
@@ -87,6 +88,38 @@ func (o *IndicatorRatio) SetTotal(v Query) {
 	o.Total = v
 }
 
+// GetGrouping returns the Grouping field value if set, zero value otherwise.
+func (o *IndicatorRatio) GetGrouping() []string {
+	if o == nil || o.Grouping == nil {
+		var ret []string
+		return ret
+	}
+	return *o.Grouping
+}
+
+// GetGroupingOk returns a tuple with the Grouping field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IndicatorRatio) GetGroupingOk() (*[]string, bool) {
+	if o == nil || o.Grouping == nil {
+		return nil, false
+	}
+	return o.Grouping, true
+}
+
+// HasGrouping returns a boolean if a field has been set.
+func (o *IndicatorRatio) HasGrouping() bool {
+	if o != nil && o.Grouping != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetGrouping gets a reference to the given []string and assigns it to the Grouping field.
+func (o *IndicatorRatio) SetGrouping(v []string) {
+	o.Grouping = &v
+}
+
 func (o IndicatorRatio) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
@@ -94,6 +127,9 @@ func (o IndicatorRatio) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["total"] = o.Total
+	}
+	if o.Grouping != nil {
+		toSerialize["grouping"] = o.Grouping
 	}
 	return json.Marshal(toSerialize)
 }

--- a/openapi/client/model_objective_status.go
+++ b/openapi/client/model_objective_status.go
@@ -16,7 +16,7 @@ import (
 
 // ObjectiveStatus struct for ObjectiveStatus
 type ObjectiveStatus struct {
-	Labels       *map[string]interface{}     `json:"labels,omitempty"`
+	Labels       *map[string]string          `json:"labels,omitempty"`
 	Availability ObjectiveStatusAvailability `json:"availability"`
 	Budget       ObjectiveStatusBudget       `json:"budget"`
 }
@@ -41,9 +41,9 @@ func NewObjectiveStatusWithDefaults() *ObjectiveStatus {
 }
 
 // GetLabels returns the Labels field value if set, zero value otherwise.
-func (o *ObjectiveStatus) GetLabels() map[string]interface{} {
+func (o *ObjectiveStatus) GetLabels() map[string]string {
 	if o == nil || o.Labels == nil {
-		var ret map[string]interface{}
+		var ret map[string]string
 		return ret
 	}
 	return *o.Labels
@@ -51,7 +51,7 @@ func (o *ObjectiveStatus) GetLabels() map[string]interface{} {
 
 // GetLabelsOk returns a tuple with the Labels field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ObjectiveStatus) GetLabelsOk() (*map[string]interface{}, bool) {
+func (o *ObjectiveStatus) GetLabelsOk() (*map[string]string, bool) {
 	if o == nil || o.Labels == nil {
 		return nil, false
 	}
@@ -67,8 +67,8 @@ func (o *ObjectiveStatus) HasLabels() bool {
 	return false
 }
 
-// SetLabels gets a reference to the given map[string]interface{} and assigns it to the Labels field.
-func (o *ObjectiveStatus) SetLabels(v map[string]interface{}) {
+// SetLabels gets a reference to the given map[string]string and assigns it to the Labels field.
+func (o *ObjectiveStatus) SetLabels(v map[string]string) {
 	o.Labels = &v
 }
 

--- a/openapi/client/model_objective_status.go
+++ b/openapi/client/model_objective_status.go
@@ -16,6 +16,7 @@ import (
 
 // ObjectiveStatus struct for ObjectiveStatus
 type ObjectiveStatus struct {
+	Labels       *map[string]interface{}     `json:"labels,omitempty"`
 	Availability ObjectiveStatusAvailability `json:"availability"`
 	Budget       ObjectiveStatusBudget       `json:"budget"`
 }
@@ -37,6 +38,38 @@ func NewObjectiveStatus(availability ObjectiveStatusAvailability, budget Objecti
 func NewObjectiveStatusWithDefaults() *ObjectiveStatus {
 	this := ObjectiveStatus{}
 	return &this
+}
+
+// GetLabels returns the Labels field value if set, zero value otherwise.
+func (o *ObjectiveStatus) GetLabels() map[string]interface{} {
+	if o == nil || o.Labels == nil {
+		var ret map[string]interface{}
+		return ret
+	}
+	return *o.Labels
+}
+
+// GetLabelsOk returns a tuple with the Labels field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ObjectiveStatus) GetLabelsOk() (*map[string]interface{}, bool) {
+	if o == nil || o.Labels == nil {
+		return nil, false
+	}
+	return o.Labels, true
+}
+
+// HasLabels returns a boolean if a field has been set.
+func (o *ObjectiveStatus) HasLabels() bool {
+	if o != nil && o.Labels != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetLabels gets a reference to the given map[string]interface{} and assigns it to the Labels field.
+func (o *ObjectiveStatus) SetLabels(v map[string]interface{}) {
+	o.Labels = &v
 }
 
 // GetAvailability returns the Availability field value
@@ -89,6 +122,9 @@ func (o *ObjectiveStatus) SetBudget(v ObjectiveStatusBudget) {
 
 func (o ObjectiveStatus) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
+	if o.Labels != nil {
+		toSerialize["labels"] = o.Labels
+	}
 	if true {
 		toSerialize["availability"] = o.Availability
 	}

--- a/openapi/internal.go
+++ b/openapi/internal.go
@@ -13,8 +13,9 @@ func InternalFromClient(o client.Objective) slo.Objective {
 	var ratio *slo.RatioIndicator
 	if o.HasIndicator() && o.Indicator.HasRatio() {
 		ratio = &slo.RatioIndicator{
-			Errors: slo.Metric{Name: o.Indicator.Ratio.Errors.GetName()},
-			Total:  slo.Metric{Name: o.Indicator.Ratio.Total.GetName()},
+			Errors:   slo.Metric{Name: o.Indicator.Ratio.Errors.GetName()},
+			Total:    slo.Metric{Name: o.Indicator.Ratio.Total.GetName()},
+			Grouping: o.Indicator.Ratio.GetGrouping(),
 		}
 		for _, m := range o.Indicator.Ratio.Errors.GetMatchers() {
 			ratio.Errors.LabelMatchers = append(ratio.Errors.LabelMatchers, &labels.Matcher{
@@ -35,8 +36,9 @@ func InternalFromClient(o client.Objective) slo.Objective {
 	var latency *slo.LatencyIndicator
 	if o.HasIndicator() && o.Indicator.HasLatency() {
 		latency = &slo.LatencyIndicator{
-			Success: slo.Metric{Name: o.Indicator.Latency.Success.GetName()},
-			Total:   slo.Metric{Name: o.Indicator.Latency.Total.GetName()},
+			Success:  slo.Metric{Name: o.Indicator.Latency.Success.GetName()},
+			Total:    slo.Metric{Name: o.Indicator.Latency.Total.GetName()},
+			Grouping: o.Indicator.Latency.GetGrouping(),
 		}
 		for _, m := range o.Indicator.Latency.Success.GetMatchers() {
 			latency.Success.LabelMatchers = append(latency.Success.LabelMatchers, &labels.Matcher{

--- a/openapi/server.go
+++ b/openapi/server.go
@@ -84,6 +84,7 @@ func ServerFromClient(o client.Objective) server.Objective {
 		ratio.Total.Metric = o.Indicator.Ratio.Total.GetMetric()
 		ratio.Errors.Name = o.Indicator.Ratio.Errors.GetName()
 		ratio.Errors.Metric = o.Indicator.Ratio.Errors.GetMetric()
+		ratio.Grouping = o.Indicator.Ratio.GetGrouping()
 
 		for _, m := range o.Indicator.Ratio.Total.GetMatchers() {
 			ratio.Total.Matchers = append(ratio.Total.Matchers, server.QueryMatchers{
@@ -106,6 +107,7 @@ func ServerFromClient(o client.Objective) server.Objective {
 		latency.Total.Metric = o.Indicator.Latency.Total.GetMetric()
 		latency.Success.Name = o.Indicator.Latency.Success.GetName()
 		latency.Success.Metric = o.Indicator.Latency.Success.GetMetric()
+		latency.Grouping = o.Indicator.Latency.GetGrouping()
 
 		for _, m := range o.Indicator.Latency.Total.GetMatchers() {
 			latency.Total.Matchers = append(latency.Total.Matchers, server.QueryMatchers{

--- a/openapi/server.go
+++ b/openapi/server.go
@@ -16,6 +16,8 @@ import (
 func ServerFromInternal(objective slo.Objective) server.Objective {
 	var ratio server.IndicatorRatio
 	if objective.Indicator.Ratio != nil {
+		ratio.Grouping = objective.Indicator.Ratio.Grouping
+
 		ratio.Total.Name = objective.Indicator.Ratio.Total.Name
 		for _, m := range objective.Indicator.Ratio.Total.LabelMatchers {
 			ratio.Total.Matchers = append(ratio.Total.Matchers, server.QueryMatchers{
@@ -39,6 +41,8 @@ func ServerFromInternal(objective slo.Objective) server.Objective {
 
 	var latency server.IndicatorLatency
 	if objective.Indicator.Latency != nil {
+		latency.Grouping = objective.Indicator.Latency.Grouping
+
 		latency.Total.Name = objective.Indicator.Latency.Total.Name
 		for _, m := range objective.Indicator.Latency.Total.LabelMatchers {
 			latency.Total.Matchers = append(latency.Total.Matchers, server.QueryMatchers{

--- a/openapi/server/api/openapi.yaml
+++ b/openapi/server/api/openapi.yaml
@@ -42,7 +42,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ObjectiveStatus'
+                items:
+                  $ref: '#/components/schemas/ObjectiveStatus'
+                type: array
           description: Get objective status
       summary: Get objective status
       tags:
@@ -353,11 +355,14 @@ components:
           total: 6.027456183070403
           percentage: 0.8008281904610115
           errors: 1.4658129805029452
+        labels: '{}'
         budget:
           total: 5.962133916683182
           max: 2.3021358869347655
           remaining: 5.637376656633329
       properties:
+        labels:
+          type: object
         availability:
           $ref: '#/components/schemas/ObjectiveStatus_availability'
         budget:

--- a/openapi/server/api/openapi.yaml
+++ b/openapi/server/api/openapi.yaml
@@ -211,6 +211,9 @@ components:
                 value: value
               metric: metric
               name: name
+            grouping:
+            - grouping
+            - grouping
           ratio:
             total:
               matchers:
@@ -222,6 +225,9 @@ components:
                 value: value
               metric: metric
               name: name
+            grouping:
+            - grouping
+            - grouping
             errors:
               matchers:
               - name: name
@@ -285,6 +291,9 @@ components:
               value: value
             metric: metric
             name: name
+          grouping:
+          - grouping
+          - grouping
         ratio:
           total:
             matchers:
@@ -296,6 +305,9 @@ components:
               value: value
             metric: metric
             name: name
+          grouping:
+          - grouping
+          - grouping
           errors:
             matchers:
             - name: name
@@ -456,6 +468,9 @@ components:
             value: value
           metric: metric
           name: name
+        grouping:
+        - grouping
+        - grouping
         errors:
           matchers:
           - name: name
@@ -471,6 +486,10 @@ components:
           $ref: '#/components/schemas/Query'
         total:
           $ref: '#/components/schemas/Query'
+        grouping:
+          items:
+            type: string
+          type: array
       required:
       - errors
       - total
@@ -497,11 +516,18 @@ components:
             value: value
           metric: metric
           name: name
+        grouping:
+        - grouping
+        - grouping
       properties:
         success:
           $ref: '#/components/schemas/Query'
         total:
           $ref: '#/components/schemas/Query'
+        grouping:
+          items:
+            type: string
+          type: array
       required:
       - success
       - total

--- a/openapi/server/api/openapi.yaml
+++ b/openapi/server/api/openapi.yaml
@@ -37,6 +37,13 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:

--- a/openapi/server/api/openapi.yaml
+++ b/openapi/server/api/openapi.yaml
@@ -60,6 +60,13 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
+        schema:
+          type: string
+        style: form
       - description: The timestamp to start the query range at
         explode: true
         in: query
@@ -97,6 +104,13 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:
@@ -117,6 +131,13 @@ paths:
         in: query
         name: expr
         required: true
+        schema:
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
         schema:
           type: string
         style: form
@@ -154,6 +175,13 @@ paths:
         in: query
         name: expr
         required: true
+        schema:
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: grouping
+        required: false
         schema:
           type: string
         style: form
@@ -355,13 +383,16 @@ components:
           total: 6.027456183070403
           percentage: 0.8008281904610115
           errors: 1.4658129805029452
-        labels: '{}'
+        labels:
+          key: labels
         budget:
           total: 5.962133916683182
           max: 2.3021358869347655
           remaining: 5.637376656633329
       properties:
         labels:
+          additionalProperties:
+            type: string
           type: object
         availability:
           $ref: '#/components/schemas/ObjectiveStatus_availability'

--- a/openapi/server/go/api.go
+++ b/openapi/server/go/api.go
@@ -31,10 +31,10 @@ type ObjectivesApiRouter interface {
 // while the service implementation can ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type ObjectivesApiServicer interface {
-	GetMultiBurnrateAlerts(context.Context, string) (ImplResponse, error)
-	GetObjectiveErrorBudget(context.Context, string, int32, int32) (ImplResponse, error)
+	GetMultiBurnrateAlerts(context.Context, string, string) (ImplResponse, error)
+	GetObjectiveErrorBudget(context.Context, string, string, int32, int32) (ImplResponse, error)
 	GetObjectiveStatus(context.Context, string) (ImplResponse, error)
-	GetREDErrors(context.Context, string, int32, int32) (ImplResponse, error)
-	GetREDRequests(context.Context, string, int32, int32) (ImplResponse, error)
+	GetREDErrors(context.Context, string, string, int32, int32) (ImplResponse, error)
+	GetREDRequests(context.Context, string, string, int32, int32) (ImplResponse, error)
 	ListObjectives(context.Context, string) (ImplResponse, error)
 }

--- a/openapi/server/go/api.go
+++ b/openapi/server/go/api.go
@@ -33,7 +33,7 @@ type ObjectivesApiRouter interface {
 type ObjectivesApiServicer interface {
 	GetMultiBurnrateAlerts(context.Context, string, string) (ImplResponse, error)
 	GetObjectiveErrorBudget(context.Context, string, string, int32, int32) (ImplResponse, error)
-	GetObjectiveStatus(context.Context, string) (ImplResponse, error)
+	GetObjectiveStatus(context.Context, string, string) (ImplResponse, error)
 	GetREDErrors(context.Context, string, string, int32, int32) (ImplResponse, error)
 	GetREDRequests(context.Context, string, string, int32, int32) (ImplResponse, error)
 	ListObjectives(context.Context, string) (ImplResponse, error)

--- a/openapi/server/go/api_objectives.go
+++ b/openapi/server/go/api_objectives.go
@@ -112,7 +112,8 @@ func (c *ObjectivesApiController) GetObjectiveErrorBudget(w http.ResponseWriter,
 func (c *ObjectivesApiController) GetObjectiveStatus(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	expr := query.Get("expr")
-	result, err := c.service.GetObjectiveStatus(r.Context(), expr)
+	grouping := query.Get("grouping")
+	result, err := c.service.GetObjectiveStatus(r.Context(), expr, grouping)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		EncodeJSONResponse(err.Error(), &result.Code, w)

--- a/openapi/server/go/api_objectives.go
+++ b/openapi/server/go/api_objectives.go
@@ -70,7 +70,8 @@ func (c *ObjectivesApiController) Routes() Routes {
 func (c *ObjectivesApiController) GetMultiBurnrateAlerts(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	expr := query.Get("expr")
-	result, err := c.service.GetMultiBurnrateAlerts(r.Context(), expr)
+	grouping := query.Get("grouping")
+	result, err := c.service.GetMultiBurnrateAlerts(r.Context(), expr, grouping)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		EncodeJSONResponse(err.Error(), &result.Code, w)
@@ -85,6 +86,7 @@ func (c *ObjectivesApiController) GetMultiBurnrateAlerts(w http.ResponseWriter, 
 func (c *ObjectivesApiController) GetObjectiveErrorBudget(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	expr := query.Get("expr")
+	grouping := query.Get("grouping")
 	start, err := parseInt32Parameter(query.Get("start"), false)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -95,7 +97,7 @@ func (c *ObjectivesApiController) GetObjectiveErrorBudget(w http.ResponseWriter,
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	result, err := c.service.GetObjectiveErrorBudget(r.Context(), expr, start, end)
+	result, err := c.service.GetObjectiveErrorBudget(r.Context(), expr, grouping, start, end)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		EncodeJSONResponse(err.Error(), &result.Code, w)
@@ -125,6 +127,7 @@ func (c *ObjectivesApiController) GetObjectiveStatus(w http.ResponseWriter, r *h
 func (c *ObjectivesApiController) GetREDErrors(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	expr := query.Get("expr")
+	grouping := query.Get("grouping")
 	start, err := parseInt32Parameter(query.Get("start"), false)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -135,7 +138,7 @@ func (c *ObjectivesApiController) GetREDErrors(w http.ResponseWriter, r *http.Re
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	result, err := c.service.GetREDErrors(r.Context(), expr, start, end)
+	result, err := c.service.GetREDErrors(r.Context(), expr, grouping, start, end)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		EncodeJSONResponse(err.Error(), &result.Code, w)
@@ -150,6 +153,7 @@ func (c *ObjectivesApiController) GetREDErrors(w http.ResponseWriter, r *http.Re
 func (c *ObjectivesApiController) GetREDRequests(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	expr := query.Get("expr")
+	grouping := query.Get("grouping")
 	start, err := parseInt32Parameter(query.Get("start"), false)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -160,7 +164,7 @@ func (c *ObjectivesApiController) GetREDRequests(w http.ResponseWriter, r *http.
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	result, err := c.service.GetREDRequests(r.Context(), expr, start, end)
+	result, err := c.service.GetREDRequests(r.Context(), expr, grouping, start, end)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		EncodeJSONResponse(err.Error(), &result.Code, w)

--- a/openapi/server/go/api_objectives_service.go
+++ b/openapi/server/go/api_objectives_service.go
@@ -49,7 +49,7 @@ func (s *ObjectivesApiService) GetObjectiveErrorBudget(ctx context.Context, expr
 }
 
 // GetObjectiveStatus - Get objective status
-func (s *ObjectivesApiService) GetObjectiveStatus(ctx context.Context, expr string) (ImplResponse, error) {
+func (s *ObjectivesApiService) GetObjectiveStatus(ctx context.Context, expr string, grouping string) (ImplResponse, error) {
 	// TODO - update GetObjectiveStatus with the required logic for this service method.
 	// Add api_objectives_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/openapi/server/go/api_objectives_service.go
+++ b/openapi/server/go/api_objectives_service.go
@@ -53,8 +53,8 @@ func (s *ObjectivesApiService) GetObjectiveStatus(ctx context.Context, expr stri
 	// TODO - update GetObjectiveStatus with the required logic for this service method.
 	// Add api_objectives_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
-	//TODO: Uncomment the next line to return response Response(200, ObjectiveStatus{}) or use other options such as http.Ok ...
-	//return Response(200, ObjectiveStatus{}), nil
+	//TODO: Uncomment the next line to return response Response(200, []ObjectiveStatus{}) or use other options such as http.Ok ...
+	//return Response(200, []ObjectiveStatus{}), nil
 
 	return Response(http.StatusNotImplemented, nil), errors.New("GetObjectiveStatus method not implemented")
 }

--- a/openapi/server/go/api_objectives_service.go
+++ b/openapi/server/go/api_objectives_service.go
@@ -27,7 +27,7 @@ func NewObjectivesApiService() ObjectivesApiServicer {
 }
 
 // GetMultiBurnrateAlerts - Get the MultiBurnrateAlerts for the Objective
-func (s *ObjectivesApiService) GetMultiBurnrateAlerts(ctx context.Context, expr string) (ImplResponse, error) {
+func (s *ObjectivesApiService) GetMultiBurnrateAlerts(ctx context.Context, expr string, grouping string) (ImplResponse, error) {
 	// TODO - update GetMultiBurnrateAlerts with the required logic for this service method.
 	// Add api_objectives_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -38,7 +38,7 @@ func (s *ObjectivesApiService) GetMultiBurnrateAlerts(ctx context.Context, expr 
 }
 
 // GetObjectiveErrorBudget - Get ErrorBudget graph sample pairs
-func (s *ObjectivesApiService) GetObjectiveErrorBudget(ctx context.Context, expr string, start int32, end int32) (ImplResponse, error) {
+func (s *ObjectivesApiService) GetObjectiveErrorBudget(ctx context.Context, expr string, grouping string, start int32, end int32) (ImplResponse, error) {
 	// TODO - update GetObjectiveErrorBudget with the required logic for this service method.
 	// Add api_objectives_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -60,7 +60,7 @@ func (s *ObjectivesApiService) GetObjectiveStatus(ctx context.Context, expr stri
 }
 
 // GetREDErrors - Get a matrix of error percentage by label
-func (s *ObjectivesApiService) GetREDErrors(ctx context.Context, expr string, start int32, end int32) (ImplResponse, error) {
+func (s *ObjectivesApiService) GetREDErrors(ctx context.Context, expr string, grouping string, start int32, end int32) (ImplResponse, error) {
 	// TODO - update GetREDErrors with the required logic for this service method.
 	// Add api_objectives_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 
@@ -71,7 +71,7 @@ func (s *ObjectivesApiService) GetREDErrors(ctx context.Context, expr string, st
 }
 
 // GetREDRequests - Get a matrix of requests by label
-func (s *ObjectivesApiService) GetREDRequests(ctx context.Context, expr string, start int32, end int32) (ImplResponse, error) {
+func (s *ObjectivesApiService) GetREDRequests(ctx context.Context, expr string, grouping string, start int32, end int32) (ImplResponse, error) {
 	// TODO - update GetREDRequests with the required logic for this service method.
 	// Add api_objectives_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/openapi/server/go/model_indicator_latency.go
+++ b/openapi/server/go/model_indicator_latency.go
@@ -14,5 +14,5 @@ type IndicatorLatency struct {
 
 	Total Query `json:"total"`
 
-	Grouping []string `json:"grouping"`
+	Grouping []string `json:"grouping,omitempty"`
 }

--- a/openapi/server/go/model_indicator_latency.go
+++ b/openapi/server/go/model_indicator_latency.go
@@ -13,4 +13,6 @@ type IndicatorLatency struct {
 	Success Query `json:"success"`
 
 	Total Query `json:"total"`
+
+	Grouping []string `json:"grouping"`
 }

--- a/openapi/server/go/model_indicator_ratio.go
+++ b/openapi/server/go/model_indicator_ratio.go
@@ -13,4 +13,6 @@ type IndicatorRatio struct {
 	Errors Query `json:"errors"`
 
 	Total Query `json:"total"`
+
+	Grouping []string `json:"grouping"`
 }

--- a/openapi/server/go/model_indicator_ratio.go
+++ b/openapi/server/go/model_indicator_ratio.go
@@ -14,5 +14,5 @@ type IndicatorRatio struct {
 
 	Total Query `json:"total"`
 
-	Grouping []string `json:"grouping"`
+	Grouping []string `json:"grouping,omitempty"`
 }

--- a/openapi/server/go/model_objective_status.go
+++ b/openapi/server/go/model_objective_status.go
@@ -10,6 +10,8 @@
 package openapi
 
 type ObjectiveStatus struct {
+	Labels map[string]string `json:"labels,omitempty"`
+
 	Availability ObjectiveStatusAvailability `json:"availability"`
 
 	Budget ObjectiveStatusBudget `json:"budget"`

--- a/slo/promql_test.go
+++ b/slo/promql_test.go
@@ -10,133 +10,168 @@ import (
 )
 
 var (
-	objectiveHTTPRatio = Objective{
-		Labels: labels.FromStrings(labels.MetricName, "monitoring-http-errors"),
-		Target: 0.99,
-		Window: model.Duration(28 * 24 * time.Hour),
-		Indicator: Indicator{
-			Ratio: &RatioIndicator{
-				Errors: Metric{
-					Name: "http_requests_total",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "thanos-receive-default"},
-						{Type: labels.MatchRegexp, Name: "code", Value: "5.."},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
+	objectiveHTTPRatio = func() Objective {
+		return Objective{
+			Labels: labels.FromStrings(labels.MetricName, "monitoring-http-errors"),
+			Target: 0.99,
+			Window: model.Duration(28 * 24 * time.Hour),
+			Indicator: Indicator{
+				Ratio: &RatioIndicator{
+					Errors: Metric{
+						Name: "http_requests_total",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "thanos-receive-default"},
+							{Type: labels.MatchRegexp, Name: "code", Value: "5.."},
+							{Type: labels.MatchEqual, Name: "__name__", Value: "http_requests_total"},
+						},
 					},
-				},
-				Total: Metric{
-					Name: "http_requests_total",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "thanos-receive-default"},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
+					Total: Metric{
+						Name: "http_requests_total",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "thanos-receive-default"},
+							{Type: labels.MatchEqual, Name: "__name__", Value: "http_requests_total"},
+						},
 					},
 				},
 			},
-		},
+		}
 	}
-	objectiveGRPCRatio = Objective{
-		Labels:      labels.FromStrings(labels.MetricName, "monitoring-grpc-errors"),
-		Description: "",
-		Target:      0.999,
-		Window:      model.Duration(28 * 24 * time.Hour),
-		Indicator: Indicator{
-			Ratio: &RatioIndicator{
-				Errors: Metric{
-					Name: "grpc_server_handled_total",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "api"},
-						{Type: labels.MatchEqual, Name: "grpc_service", Value: "conprof.WritableProfileStore"},
-						{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
-						{Type: labels.MatchRegexp, Name: "grpc_code", Value: "Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss"},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "grpc_server_handled_total"},
-					},
-				},
-				Total: Metric{
-					Name: "grpc_server_handled_total",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "api"},
-						{Type: labels.MatchEqual, Name: "grpc_service", Value: "conprof.WritableProfileStore"},
-						{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "grpc_server_handled_total"},
-					},
-				},
-			},
-		},
+	objectiveHTTPRatioGrouping = func() Objective {
+		o := objectiveHTTPRatio()
+		o.Indicator.Ratio.Grouping = []string{"job", "handler"}
+		return o
 	}
-	objectiveHTTPLatency = Objective{
-		Labels: labels.FromStrings(labels.MetricName, "monitoring-http-latency"),
-		Target: 0.995,
-		Window: model.Duration(28 * 24 * time.Hour),
-		Indicator: Indicator{
-			Latency: &LatencyIndicator{
-				Success: Metric{
-					Name: "http_request_duration_seconds_bucket",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
-						{Type: labels.MatchRegexp, Name: "code", Value: "2.."},
-						{Type: labels.MatchEqual, Name: "le", Value: "1"},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_request_duration_seconds_bucket"},
+	objectiveGRPCRatio = func() Objective {
+		return Objective{
+			Labels:      labels.FromStrings(labels.MetricName, "monitoring-grpc-errors"),
+			Description: "",
+			Target:      0.999,
+			Window:      model.Duration(28 * 24 * time.Hour),
+			Indicator: Indicator{
+				Ratio: &RatioIndicator{
+					Errors: Metric{
+						Name: "grpc_server_handled_total",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "api"},
+							{Type: labels.MatchEqual, Name: "grpc_service", Value: "conprof.WritableProfileStore"},
+							{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
+							{Type: labels.MatchRegexp, Name: "grpc_code", Value: "Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss"},
+							{Type: labels.MatchEqual, Name: "__name__", Value: "grpc_server_handled_total"},
+						},
 					},
-				},
-				Total: Metric{
-					Name: "http_request_duration_seconds_count",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
-						{Type: labels.MatchRegexp, Name: "code", Value: "2.."},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_request_duration_seconds_count"},
+					Total: Metric{
+						Name: "grpc_server_handled_total",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "api"},
+							{Type: labels.MatchEqual, Name: "grpc_service", Value: "conprof.WritableProfileStore"},
+							{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
+							{Type: labels.MatchEqual, Name: "__name__", Value: "grpc_server_handled_total"},
+						},
 					},
 				},
 			},
-		},
+		}
 	}
-	objectiveGRPCLatency = Objective{
-		Labels: labels.FromStrings(labels.MetricName, "monitoring-grpc-latency"),
-		Target: 0.995,
-		Window: model.Duration(7 * 24 * time.Hour),
-		Indicator: Indicator{
-			Latency: &LatencyIndicator{
-				Success: Metric{
-					Name: "grpc_server_handling_seconds_bucket",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "api"},
-						{Type: labels.MatchEqual, Name: "grpc_service", Value: "conprof.WritableProfileStore"},
-						{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
-						{Type: labels.MatchEqual, Name: "le", Value: "0.6"},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "grpc_server_handling_seconds_bucket"},
-					},
-				},
-				Total: Metric{
-					Name: "grpc_server_handling_seconds_count",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "api"},
-						{Type: labels.MatchEqual, Name: "grpc_service", Value: "conprof.WritableProfileStore"},
-						{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "grpc_server_handling_seconds_count"},
-					},
-				},
-			},
-		},
+	objectiveGRPCRatioGrouping = func() Objective {
+		o := objectiveGRPCRatio()
+		o.Indicator.Ratio.Grouping = []string{"job", "handler"}
+		return o
 	}
-	objectiveOperator = Objective{
-		Labels: labels.FromStrings(labels.MetricName, "monitoring-prometheus-operator-errors"),
-		Target: 0.99,
-		Window: model.Duration(14 * 24 * time.Hour),
-		Indicator: Indicator{
-			Ratio: &RatioIndicator{
-				Errors: Metric{
-					Name: "prometheus_operator_reconcile_errors_total",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "prometheus_operator_reconcile_errors_total"},
+	objectiveHTTPLatency = func() Objective {
+		return Objective{
+			Labels: labels.FromStrings(labels.MetricName, "monitoring-http-latency"),
+			Target: 0.995,
+			Window: model.Duration(28 * 24 * time.Hour),
+			Indicator: Indicator{
+				Latency: &LatencyIndicator{
+					Success: Metric{
+						Name: "http_request_duration_seconds_bucket",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
+							{Type: labels.MatchRegexp, Name: "code", Value: "2.."},
+							{Type: labels.MatchEqual, Name: "le", Value: "1"},
+							{Type: labels.MatchEqual, Name: "__name__", Value: "http_request_duration_seconds_bucket"},
+						},
 					},
-				},
-				Total: Metric{
-					Name: "prometheus_operator_reconcile_operations_total",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "prometheus_operator_reconcile_operations_total"},
+					Total: Metric{
+						Name: "http_request_duration_seconds_count",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
+							{Type: labels.MatchRegexp, Name: "code", Value: "2.."},
+							{Type: labels.MatchEqual, Name: "__name__", Value: "http_request_duration_seconds_count"},
+						},
 					},
 				},
 			},
-		},
+		}
+	}
+	objectiveHTTPLatencyGrouping = func() Objective {
+		o := objectiveHTTPLatency()
+		o.Indicator.Latency.Grouping = []string{"job", "handler"}
+		return o
+	}
+	objectiveGRPCLatency = func() Objective {
+		return Objective{
+			Labels: labels.FromStrings(labels.MetricName, "monitoring-grpc-latency"),
+			Target: 0.995,
+			Window: model.Duration(7 * 24 * time.Hour),
+			Indicator: Indicator{
+				Latency: &LatencyIndicator{
+					Success: Metric{
+						Name: "grpc_server_handling_seconds_bucket",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "api"},
+							{Type: labels.MatchEqual, Name: "grpc_service", Value: "conprof.WritableProfileStore"},
+							{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
+							{Type: labels.MatchEqual, Name: "le", Value: "0.6"},
+							{Type: labels.MatchEqual, Name: "__name__", Value: "grpc_server_handling_seconds_bucket"},
+						},
+					},
+					Total: Metric{
+						Name: "grpc_server_handling_seconds_count",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "api"},
+							{Type: labels.MatchEqual, Name: "grpc_service", Value: "conprof.WritableProfileStore"},
+							{Type: labels.MatchEqual, Name: "grpc_method", Value: "Write"},
+							{Type: labels.MatchEqual, Name: "__name__", Value: "grpc_server_handling_seconds_count"},
+						},
+					},
+				},
+			},
+		}
+	}
+	objectiveGRPCLatencyGrouping = func() Objective {
+		o := objectiveGRPCLatency()
+		o.Indicator.Latency.Grouping = []string{"job", "handler"}
+		return o
+	}
+	objectiveOperator = func() Objective {
+		return Objective{
+			Labels: labels.FromStrings(labels.MetricName, "monitoring-prometheus-operator-errors"),
+			Target: 0.99,
+			Window: model.Duration(14 * 24 * time.Hour),
+			Indicator: Indicator{
+				Ratio: &RatioIndicator{
+					Errors: Metric{
+						Name: "prometheus_operator_reconcile_errors_total",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "__name__", Value: "prometheus_operator_reconcile_errors_total"},
+						},
+					},
+					Total: Metric{
+						Name: "prometheus_operator_reconcile_operations_total",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "__name__", Value: "prometheus_operator_reconcile_operations_total"},
+						},
+					},
+				},
+			},
+		}
+	}
+	objectiveOperatorGrouping = func() Objective {
+		o := objectiveOperator()
+		o.Indicator.Ratio.Grouping = []string{"namespace"}
+		return o
 	}
 )
 
@@ -147,24 +182,44 @@ func TestObjective_QueryTotal(t *testing.T) {
 		expected  string
 	}{{
 		name:      "http-ratio",
-		objective: objectiveHTTPRatio,
+		objective: objectiveHTTPRatio(),
 		expected:  `sum(increase(http_requests_total{job="thanos-receive-default"}[4w]))`,
 	}, {
+		name:      "http-ratio-grouping",
+		objective: objectiveHTTPRatioGrouping(),
+		expected:  `sum by(job, handler) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`,
+	}, {
 		name:      "grpc-ratio",
-		objective: objectiveGRPCRatio,
+		objective: objectiveGRPCRatio(),
 		expected:  `sum(increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`,
 	}, {
+		name:      "grpc-ratio-grouping",
+		objective: objectiveGRPCRatioGrouping(),
+		expected:  `sum by(job, handler) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`,
+	}, {
 		name:      "http-latency",
-		objective: objectiveHTTPLatency,
+		objective: objectiveHTTPLatency(),
 		expected:  `sum(increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w]))`,
 	}, {
+		name:      "http-latency-grouping",
+		objective: objectiveHTTPLatencyGrouping(),
+		expected:  `sum by(job, handler) (increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w]))`,
+	}, {
 		name:      "grpc-latency",
-		objective: objectiveGRPCLatency,
+		objective: objectiveGRPCLatency(),
 		expected:  `sum(increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w]))`,
 	}, {
+		name:      "grpc-latency-grouping",
+		objective: objectiveGRPCLatencyGrouping(),
+		expected:  `sum by(job, handler) (increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w]))`,
+	}, {
 		name:      "operator-ratio",
-		objective: objectiveOperator,
+		objective: objectiveOperator(),
 		expected:  `sum(increase(prometheus_operator_reconcile_operations_total[2w]))`,
+	}, {
+		name:      "operator-ratio-grouping",
+		objective: objectiveOperatorGrouping(),
+		expected:  `sum by(namespace) (increase(prometheus_operator_reconcile_operations_total[2w]))`,
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -180,24 +235,44 @@ func TestObjective_QueryErrors(t *testing.T) {
 		expected  string
 	}{{
 		name:      "http-ratio",
-		objective: objectiveHTTPRatio,
+		objective: objectiveHTTPRatio(),
 		expected:  `sum(increase(http_requests_total{code=~"5..",job="thanos-receive-default"}[4w]))`,
 	}, {
+		name:      "http-ratio-grouping",
+		objective: objectiveHTTPRatioGrouping(),
+		expected:  `sum by(job, handler) (increase(http_requests_total{code=~"5..",job="thanos-receive-default"}[4w]))`,
+	}, {
 		name:      "grpc-ratio",
-		objective: objectiveGRPCRatio,
+		objective: objectiveGRPCRatio(),
 		expected:  `sum(increase(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`,
 	}, {
+		name:      "grpc-ratio-grouping",
+		objective: objectiveGRPCRatioGrouping(),
+		expected:  `sum by(job, handler) (increase(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`,
+	}, {
 		name:      "http-latency",
-		objective: objectiveHTTPLatency,
+		objective: objectiveHTTPLatency(),
 		expected:  `sum(increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w])) - sum(increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]))`,
 	}, {
+		name:      "http-latency-grouping",
+		objective: objectiveHTTPLatencyGrouping(),
+		expected:  `sum by(job, handler) (increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w])) - sum by(job, handler) (increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]))`,
+	}, {
 		name:      "grpc-latency",
-		objective: objectiveGRPCLatency,
+		objective: objectiveGRPCLatency(),
 		expected:  `sum(increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w])) - sum(increase(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1w]))`,
 	}, {
+		name:      "grpc-latency-grouping",
+		objective: objectiveGRPCLatencyGrouping(),
+		expected:  `sum by(job, handler) (increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w])) - sum by(job, handler) (increase(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1w]))`,
+	}, {
 		name:      "operator-ratio",
-		objective: objectiveOperator,
+		objective: objectiveOperator(),
 		expected:  `sum(increase(prometheus_operator_reconcile_errors_total[2w]))`,
+	}, {
+		name:      "operator-ratio-grouping",
+		objective: objectiveOperatorGrouping(),
+		expected:  `sum by(namespace) (increase(prometheus_operator_reconcile_errors_total[2w]))`,
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -213,23 +288,35 @@ func TestObjective_QueryErrorBudget(t *testing.T) {
 		expected  string
 	}{{
 		name:      "http-ratio",
-		objective: objectiveHTTPRatio,
+		objective: objectiveHTTPRatio(),
 		expected:  `((1 - 0.99) - (sum(increase(http_requests_total{code=~"5..",job="thanos-receive-default"}[4w]) or vector(0)) / sum(increase(http_requests_total{job="thanos-receive-default"}[4w])))) / (1 - 0.99)`,
 	}, {
+		name:      "http-ratio-grouping",
+		objective: objectiveHTTPRatioGrouping(),
+		expected:  `((1 - 0.99) - (sum by(job, handler) (increase(http_requests_total{code=~"5..",job="thanos-receive-default"}[4w]) or vector(0)) / sum by(job, handler) (increase(http_requests_total{job="thanos-receive-default"}[4w])))) / (1 - 0.99)`,
+	}, {
 		name:      "grpc-ratio",
-		objective: objectiveGRPCRatio,
+		objective: objectiveGRPCRatio(),
 		expected:  `((1 - 0.999) - (sum(increase(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]) or vector(0)) / sum(increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w])))) / (1 - 0.999)`,
 	}, {
+		name:      "grpc-ratio-grouping",
+		objective: objectiveGRPCRatioGrouping(),
+		expected:  `((1 - 0.999) - (sum by(job, handler) (increase(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]) or vector(0)) / sum by(job, handler) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w])))) / (1 - 0.999)`,
+	}, {
 		name:      "http-latency",
-		objective: objectiveHTTPLatency,
+		objective: objectiveHTTPLatency(),
+		expected:  `((1 - 0.995) - (1 - sum(increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]) or vector(0)) / sum(increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w])))) / (1 - 0.995)`,
+	}, {
+		name:      "http-latency-grouping",
+		objective: objectiveHTTPLatencyGrouping(),
 		expected:  `((1 - 0.995) - (1 - sum(increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]) or vector(0)) / sum(increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w])))) / (1 - 0.995)`,
 	}, {
 		name:      "grpc-latency",
-		objective: objectiveGRPCLatency,
+		objective: objectiveGRPCLatency(),
 		expected:  `((1 - 0.995) - (1 - sum(increase(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1w]) or vector(0)) / sum(increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w])))) / (1 - 0.995)`,
 	}, {
 		name:      "operator-ratio",
-		objective: objectiveOperator,
+		objective: objectiveOperator(),
 		expected:  `((1 - 0.99) - (sum(increase(prometheus_operator_reconcile_errors_total[2w]) or vector(0)) / sum(increase(prometheus_operator_reconcile_operations_total[2w])))) / (1 - 0.99)`,
 	}}
 	for _, tc := range testcases {
@@ -247,27 +334,27 @@ func TestObjective_RequestRange(t *testing.T) {
 		expected  string
 	}{{
 		name:      "http-ratio",
-		objective: objectiveHTTPRatio,
+		objective: objectiveHTTPRatio(),
 		timerange: 6 * time.Hour,
 		expected:  `sum by(code) (rate(http_requests_total{job="thanos-receive-default"}[6h])) > 0`,
 	}, {
 		name:      "grpc-ratio",
-		objective: objectiveGRPCRatio,
+		objective: objectiveGRPCRatio(),
 		timerange: 6 * time.Hour,
 		expected:  `sum by(grpc_code) (rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[6h])) > 0`,
 	}, {
 		name:      "operator-ratio",
-		objective: objectiveOperator,
+		objective: objectiveOperator(),
 		timerange: 5 * time.Minute,
 		expected:  `sum(rate(prometheus_operator_reconcile_operations_total[5m])) > 0`,
 	}, {
 		name:      "http-latency",
-		objective: objectiveHTTPLatency,
+		objective: objectiveHTTPLatency(),
 		timerange: 2 * time.Hour,
 		expected:  `sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[2h]))`,
 	}, {
 		name:      "grpc-latency",
-		objective: objectiveGRPCLatency,
+		objective: objectiveGRPCLatency(),
 		timerange: 3 * time.Hour,
 		expected:  `sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[3h]))`,
 	}}
@@ -286,27 +373,27 @@ func TestObjective_ErrorsRange(t *testing.T) {
 		expected  string
 	}{{
 		name:      "http-ratio",
-		objective: objectiveHTTPRatio,
+		objective: objectiveHTTPRatio(),
 		timerange: 6 * time.Hour,
 		expected:  `sum by(code) (rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[6h])) / scalar(sum(rate(http_requests_total{job="thanos-receive-default"}[6h])))`,
 	}, {
 		name:      "grpc-ratio",
-		objective: objectiveGRPCRatio,
+		objective: objectiveGRPCRatio(),
 		timerange: 6 * time.Hour,
 		expected:  `sum by(grpc_code) (rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[6h])) / scalar(sum(rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[6h])))`,
 	}, {
 		name:      "operator-ratio",
-		objective: objectiveOperator,
+		objective: objectiveOperator(),
 		timerange: 5 * time.Minute,
 		expected:  `sum(rate(prometheus_operator_reconcile_errors_total[5m])) / scalar(sum(rate(prometheus_operator_reconcile_operations_total[5m])))`,
 	}, {
 		name:      "http-latency",
-		objective: objectiveHTTPLatency,
+		objective: objectiveHTTPLatency(),
 		timerange: time.Hour,
 		expected:  `sum(rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[1h])) - sum(rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[1h]))`,
 	}, {
 		name:      "grpc-latency",
-		objective: objectiveGRPCLatency,
+		objective: objectiveGRPCLatency(),
 		timerange: time.Hour,
 		expected:  `sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1h])) - sum(rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1h]))`,
 	}}

--- a/slo/rules.go
+++ b/slo/rules.go
@@ -188,7 +188,7 @@ func burnrateName(metric string, rate time.Duration) string {
 
 func (o Objective) Burnrate(timerange time.Duration) string {
 	if o.Indicator.Ratio != nil && o.Indicator.Ratio.Total.Name != "" {
-		expr, err := parser.ParseExpr(`sum(rate(errorMetric{matchers="errors"}[1s])) / sum(rate(metric{matchers="total"}[1s]))`)
+		expr, err := parser.ParseExpr(`sum by(grouping) (rate(errorMetric{matchers="errors"}[1s])) / sum by(grouping) (rate(metric{matchers="total"}[1s]))`)
 		if err != nil {
 			return err.Error()
 		}
@@ -198,11 +198,8 @@ func (o Objective) Burnrate(timerange time.Duration) string {
 			matchers:      o.Indicator.Ratio.Total.LabelMatchers,
 			errorMetric:   o.Indicator.Ratio.Errors.Name,
 			errorMatchers: o.Indicator.Ratio.Errors.LabelMatchers,
-			grouping: groupingLabels(
-				o.Indicator.Ratio.Errors.LabelMatchers,
-				o.Indicator.Ratio.Total.LabelMatchers,
-			),
-			window: timerange,
+			grouping:      o.Indicator.Ratio.Grouping,
+			window:        timerange,
 		}.replace(expr)
 
 		return expr.String()

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -96,6 +96,66 @@ func TestObjective_Burnrates(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "http-ratio-grouping",
+		slo:  objectiveHTTPRatioGrouping(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-errors",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "http_requests:burnrate5m",
+				Expr:   intstr.FromString(`sum by(job, handler) (rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[5m])) / sum by(job, handler) (rate(http_requests_total{job="thanos-receive-default"}[5m]))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate30m",
+				Expr:   intstr.FromString(`sum by(job, handler) (rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[30m])) / sum by(job, handler) (rate(http_requests_total{job="thanos-receive-default"}[30m]))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate1h",
+				Expr:   intstr.FromString(`sum by(job, handler) (rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[1h])) / sum by(job, handler) (rate(http_requests_total{job="thanos-receive-default"}[1h]))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate2h",
+				Expr:   intstr.FromString(`sum by(job, handler) (rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[2h])) / sum by(job, handler) (rate(http_requests_total{job="thanos-receive-default"}[2h]))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate6h",
+				Expr:   intstr.FromString(`sum by(job, handler) (rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[6h])) / sum by(job, handler) (rate(http_requests_total{job="thanos-receive-default"}[6h]))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate1d",
+				Expr:   intstr.FromString(`sum by(job, handler) (rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[1d])) / sum by(job, handler) (rate(http_requests_total{job="thanos-receive-default"}[1d]))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Record: "http_requests:burnrate4d",
+				Expr:   intstr.FromString(`sum by(job, handler) (rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[4d])) / sum by(job, handler) (rate(http_requests_total{job="thanos-receive-default"}[4d]))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Alert:       "ErrorBudgetBurn",
+				For:         "2m",
+				Expr:        intstr.FromString(`http_requests:burnrate5m{job="thanos-receive-default",slo="monitoring-http-errors"} > (14 * (1-0.99)) and http_requests:burnrate1h{job="thanos-receive-default",slo="monitoring-http-errors"} > (14 * (1-0.99))`),
+				Annotations: map[string]string{"severity": "critical"},
+				Labels:      map[string]string{"job": "thanos-receive-default", "long": "1h", "slo": "monitoring-http-errors", "short": "5m"},
+			}, {
+				Alert:       "ErrorBudgetBurn",
+				For:         "15m",
+				Expr:        intstr.FromString(`http_requests:burnrate30m{job="thanos-receive-default",slo="monitoring-http-errors"} > (7 * (1-0.99)) and http_requests:burnrate6h{job="thanos-receive-default",slo="monitoring-http-errors"} > (7 * (1-0.99))`),
+				Annotations: map[string]string{"severity": "critical"},
+				Labels:      map[string]string{"job": "thanos-receive-default", "long": "6h", "slo": "monitoring-http-errors", "short": "30m"},
+			}, {
+				Alert:       "ErrorBudgetBurn",
+				For:         "1h",
+				Expr:        intstr.FromString(`http_requests:burnrate2h{job="thanos-receive-default",slo="monitoring-http-errors"} > (2 * (1-0.99)) and http_requests:burnrate1d{job="thanos-receive-default",slo="monitoring-http-errors"} > (2 * (1-0.99))`),
+				Annotations: map[string]string{"severity": "warning"},
+				Labels:      map[string]string{"job": "thanos-receive-default", "long": "1d", "slo": "monitoring-http-errors", "short": "2h"},
+			}, {
+				Alert:       "ErrorBudgetBurn",
+				For:         "3h",
+				Expr:        intstr.FromString(`http_requests:burnrate6h{job="thanos-receive-default",slo="monitoring-http-errors"} > (1 * (1-0.99)) and http_requests:burnrate4d{job="thanos-receive-default",slo="monitoring-http-errors"} > (1 * (1-0.99))`),
+				Annotations: map[string]string{"severity": "warning"},
+				Labels:      map[string]string{"job": "thanos-receive-default", "long": "4d", "slo": "monitoring-http-errors", "short": "6h"},
+			}},
+		},
+	}, {
 		name: "operator-ratio",
 		slo:  objectiveOperator(),
 		rules: monitoringv1.RuleGroup{

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -16,7 +16,7 @@ func TestObjective_Burnrates(t *testing.T) {
 		rules monitoringv1.RuleGroup
 	}{{
 		name: "http-ratio", // super similar to gRPC and therefore only HTTP
-		slo:  objectiveHTTPRatio,
+		slo:  objectiveHTTPRatio(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-errors",
 			Interval: "30s",
@@ -97,7 +97,7 @@ func TestObjective_Burnrates(t *testing.T) {
 		},
 	}, {
 		name: "operator-ratio",
-		slo:  objectiveOperator,
+		slo:  objectiveOperator(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-prometheus-operator-errors",
 			Interval: "30s",
@@ -157,7 +157,7 @@ func TestObjective_Burnrates(t *testing.T) {
 		},
 	}, {
 		name: "http-latency", // super similar to gRPC and therefore only HTTP
-		slo:  objectiveHTTPLatency,
+		slo:  objectiveHTTPLatency(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-latency",
 			Interval: "30s",
@@ -269,7 +269,7 @@ func TestObjective_Alerts(t *testing.T) {
 		alerts []MultiBurnRateAlert
 	}{{
 		name: "http-ratio",
-		slo:  objectiveHTTPRatio,
+		slo:  objectiveHTTPRatio(),
 		alerts: []MultiBurnRateAlert{{
 			Severity:   "critical",
 			Short:      5 * time.Minute,
@@ -305,7 +305,7 @@ func TestObjective_Alerts(t *testing.T) {
 		}},
 	}, {
 		name: "http-latency",
-		slo:  objectiveHTTPLatency,
+		slo:  objectiveHTTPLatency(),
 		alerts: []MultiBurnRateAlert{{
 			Severity:   "critical",
 			Short:      5 * time.Minute,

--- a/slo/slo.go
+++ b/slo/slo.go
@@ -22,13 +22,15 @@ type Indicator struct {
 }
 
 type RatioIndicator struct {
-	Errors Metric
-	Total  Metric
+	Errors   Metric
+	Total    Metric
+	Grouping []string
 }
 
 type LatencyIndicator struct {
-	Success Metric
-	Total   Metric
+	Success  Metric
+	Total    Metric
+	Grouping []string
 }
 
 type Metric struct {

--- a/ui/src/client/apis/ObjectivesApi.ts
+++ b/ui/src/client/apis/ObjectivesApi.ts
@@ -143,7 +143,7 @@ export class ObjectivesApi extends runtime.BaseAPI {
     /**
      * Get objective status
      */
-    async getObjectiveStatusRaw(requestParameters: GetObjectiveStatusRequest): Promise<runtime.ApiResponse<ObjectiveStatus>> {
+    async getObjectiveStatusRaw(requestParameters: GetObjectiveStatusRequest): Promise<runtime.ApiResponse<Array<ObjectiveStatus>>> {
         if (requestParameters.expr === null || requestParameters.expr === undefined) {
             throw new runtime.RequiredError('expr','Required parameter requestParameters.expr was null or undefined when calling getObjectiveStatus.');
         }
@@ -163,13 +163,13 @@ export class ObjectivesApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.JSONApiResponse(response, (jsonValue) => ObjectiveStatusFromJSON(jsonValue));
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(ObjectiveStatusFromJSON));
     }
 
     /**
      * Get objective status
      */
-    async getObjectiveStatus(requestParameters: GetObjectiveStatusRequest): Promise<ObjectiveStatus> {
+    async getObjectiveStatus(requestParameters: GetObjectiveStatusRequest): Promise<Array<ObjectiveStatus>> {
         const response = await this.getObjectiveStatusRaw(requestParameters);
         return await response.value();
     }

--- a/ui/src/client/apis/ObjectivesApi.ts
+++ b/ui/src/client/apis/ObjectivesApi.ts
@@ -31,10 +31,12 @@ import {
 
 export interface GetMultiBurnrateAlertsRequest {
     expr: string;
+    grouping?: string;
 }
 
 export interface GetObjectiveErrorBudgetRequest {
     expr: string;
+    grouping?: string;
     start?: number;
     end?: number;
 }
@@ -45,12 +47,14 @@ export interface GetObjectiveStatusRequest {
 
 export interface GetREDErrorsRequest {
     expr: string;
+    grouping?: string;
     start?: number;
     end?: number;
 }
 
 export interface GetREDRequestsRequest {
     expr: string;
+    grouping?: string;
     start?: number;
     end?: number;
 }
@@ -76,6 +80,10 @@ export class ObjectivesApi extends runtime.BaseAPI {
 
         if (requestParameters.expr !== undefined) {
             queryParameters['expr'] = requestParameters.expr;
+        }
+
+        if (requestParameters.grouping !== undefined) {
+            queryParameters['grouping'] = requestParameters.grouping;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -110,6 +118,10 @@ export class ObjectivesApi extends runtime.BaseAPI {
 
         if (requestParameters.expr !== undefined) {
             queryParameters['expr'] = requestParameters.expr;
+        }
+
+        if (requestParameters.grouping !== undefined) {
+            queryParameters['grouping'] = requestParameters.grouping;
         }
 
         if (requestParameters.start !== undefined) {
@@ -188,6 +200,10 @@ export class ObjectivesApi extends runtime.BaseAPI {
             queryParameters['expr'] = requestParameters.expr;
         }
 
+        if (requestParameters.grouping !== undefined) {
+            queryParameters['grouping'] = requestParameters.grouping;
+        }
+
         if (requestParameters.start !== undefined) {
             queryParameters['start'] = requestParameters.start;
         }
@@ -228,6 +244,10 @@ export class ObjectivesApi extends runtime.BaseAPI {
 
         if (requestParameters.expr !== undefined) {
             queryParameters['expr'] = requestParameters.expr;
+        }
+
+        if (requestParameters.grouping !== undefined) {
+            queryParameters['grouping'] = requestParameters.grouping;
         }
 
         if (requestParameters.start !== undefined) {

--- a/ui/src/client/apis/ObjectivesApi.ts
+++ b/ui/src/client/apis/ObjectivesApi.ts
@@ -43,6 +43,7 @@ export interface GetObjectiveErrorBudgetRequest {
 
 export interface GetObjectiveStatusRequest {
     expr: string;
+    grouping?: string;
 }
 
 export interface GetREDErrorsRequest {
@@ -164,6 +165,10 @@ export class ObjectivesApi extends runtime.BaseAPI {
 
         if (requestParameters.expr !== undefined) {
             queryParameters['expr'] = requestParameters.expr;
+        }
+
+        if (requestParameters.grouping !== undefined) {
+            queryParameters['grouping'] = requestParameters.grouping;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/ui/src/client/models/IndicatorLatency.ts
+++ b/ui/src/client/models/IndicatorLatency.ts
@@ -38,6 +38,12 @@ export interface IndicatorLatency {
      * @memberof IndicatorLatency
      */
     total: Query;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof IndicatorLatency
+     */
+    grouping?: Array<string>;
 }
 
 export function IndicatorLatencyFromJSON(json: any): IndicatorLatency {
@@ -52,6 +58,7 @@ export function IndicatorLatencyFromJSONTyped(json: any, ignoreDiscriminator: bo
         
         'success': QueryFromJSON(json['success']),
         'total': QueryFromJSON(json['total']),
+        'grouping': !exists(json, 'grouping') ? undefined : json['grouping'],
     };
 }
 
@@ -66,6 +73,7 @@ export function IndicatorLatencyToJSON(value?: IndicatorLatency | null): any {
         
         'success': QueryToJSON(value.success),
         'total': QueryToJSON(value.total),
+        'grouping': value.grouping,
     };
 }
 

--- a/ui/src/client/models/IndicatorRatio.ts
+++ b/ui/src/client/models/IndicatorRatio.ts
@@ -38,6 +38,12 @@ export interface IndicatorRatio {
      * @memberof IndicatorRatio
      */
     total: Query;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof IndicatorRatio
+     */
+    grouping?: Array<string>;
 }
 
 export function IndicatorRatioFromJSON(json: any): IndicatorRatio {
@@ -52,6 +58,7 @@ export function IndicatorRatioFromJSONTyped(json: any, ignoreDiscriminator: bool
         
         'errors': QueryFromJSON(json['errors']),
         'total': QueryFromJSON(json['total']),
+        'grouping': !exists(json, 'grouping') ? undefined : json['grouping'],
     };
 }
 
@@ -66,6 +73,7 @@ export function IndicatorRatioToJSON(value?: IndicatorRatio | null): any {
         
         'errors': QueryToJSON(value.errors),
         'total': QueryToJSON(value.total),
+        'grouping': value.grouping,
     };
 }
 

--- a/ui/src/client/models/ObjectiveStatus.ts
+++ b/ui/src/client/models/ObjectiveStatus.ts
@@ -32,6 +32,12 @@ import {
 export interface ObjectiveStatus {
     /**
      * 
+     * @type {object}
+     * @memberof ObjectiveStatus
+     */
+    labels?: object;
+    /**
+     * 
      * @type {ObjectiveStatusAvailability}
      * @memberof ObjectiveStatus
      */
@@ -54,6 +60,7 @@ export function ObjectiveStatusFromJSONTyped(json: any, ignoreDiscriminator: boo
     }
     return {
         
+        'labels': !exists(json, 'labels') ? undefined : json['labels'],
         'availability': ObjectiveStatusAvailabilityFromJSON(json['availability']),
         'budget': ObjectiveStatusBudgetFromJSON(json['budget']),
     };
@@ -68,6 +75,7 @@ export function ObjectiveStatusToJSON(value?: ObjectiveStatus | null): any {
     }
     return {
         
+        'labels': value.labels,
         'availability': ObjectiveStatusAvailabilityToJSON(value.availability),
         'budget': ObjectiveStatusBudgetToJSON(value.budget),
     };

--- a/ui/src/client/models/ObjectiveStatus.ts
+++ b/ui/src/client/models/ObjectiveStatus.ts
@@ -32,10 +32,10 @@ import {
 export interface ObjectiveStatus {
     /**
      * 
-     * @type {object}
+     * @type {{ [key: string]: string; }}
      * @memberof ObjectiveStatus
      */
-    labels?: object;
+    labels?: { [key: string]: string; };
     /**
      * 
      * @type {ObjectiveStatusAvailability}

--- a/ui/src/components/AlertsTable.tsx
+++ b/ui/src/components/AlertsTable.tsx
@@ -7,6 +7,7 @@ import {labelsString} from "../labels";
 
 interface AlertsTableProps {
   objective: Objective
+  grouping: { [key: string]: string }
 }
 
 const AlertsTable = ({ objective }: AlertsTableProps): JSX.Element => {

--- a/ui/src/components/AlertsTable.tsx
+++ b/ui/src/components/AlertsTable.tsx
@@ -3,14 +3,14 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { formatDuration, PROMETHEUS_URL, PUBLIC_API } from '../App'
 import { Configuration, MultiBurnrateAlert, Objective, ObjectivesApi } from '../client'
 import { IconExternal } from './Icons'
-import {labelsString} from "../labels";
+import { labelsString } from "../labels";
 
 interface AlertsTableProps {
   objective: Objective
   grouping: { [key: string]: string }
 }
 
-const AlertsTable = ({ objective }: AlertsTableProps): JSX.Element => {
+const AlertsTable = ({ objective, grouping }: AlertsTableProps): JSX.Element => {
   const api = useMemo(() => {
     return new ObjectivesApi(new Configuration({ basePath: `${PUBLIC_API}api/v1` }))
   }, [])
@@ -20,13 +20,13 @@ const AlertsTable = ({ objective }: AlertsTableProps): JSX.Element => {
   useEffect(() => {
     const controller = new AbortController()
 
-    api.getMultiBurnrateAlerts({ expr: labelsString(objective.labels) })
+    api.getMultiBurnrateAlerts({ expr: labelsString(objective.labels), grouping: labelsString(grouping) })
       .then((alerts: MultiBurnrateAlert[]) => setAlerts(alerts))
 
     return () => {
       controller.abort()
     }
-  }, [api, objective])
+  }, [api, objective, grouping])
 
   return (
     <div className="table-responsive">

--- a/ui/src/components/graphs/ErrorBudgetGraph.tsx
+++ b/ui/src/components/graphs/ErrorBudgetGraph.tsx
@@ -1,20 +1,21 @@
-import React, {useEffect, useState} from 'react'
-import {Spinner} from 'react-bootstrap'
-import {Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, TooltipProps, XAxis, YAxis} from 'recharts'
+import React, { useEffect, useState } from 'react'
+import { Spinner } from 'react-bootstrap'
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, TooltipProps, XAxis, YAxis } from 'recharts'
 
-import {dateFormatter, dateFormatterFull, formatDuration, PROMETHEUS_URL} from '../../App'
-import {ObjectivesApi, QueryRange} from '../../client'
-import {IconExternal} from '../Icons'
-import {greens, reds} from '../colors'
-import {labelsString} from "../../labels";
+import { dateFormatter, dateFormatterFull, formatDuration, PROMETHEUS_URL } from '../../App'
+import { ObjectivesApi, QueryRange } from '../../client'
+import { IconExternal } from '../Icons'
+import { greens, reds } from '../colors'
+import { labelsString } from "../../labels";
 
 interface ErrorBudgetGraphProps {
     api: ObjectivesApi
     labels: { [key: string]: string }
+    grouping: { [key: string]: string }
     timeRange: number
 }
 
-const ErrorBudgetGraph = ({ api, labels, timeRange }: ErrorBudgetGraphProps): JSX.Element => {
+const ErrorBudgetGraph = ({ api, labels, grouping, timeRange }: ErrorBudgetGraphProps): JSX.Element => {
   const [samples, setSamples] = useState<any[]>([]);
   const [samplesOffset, setSamplesOffset] = useState<number>(0)
   const [samplesMin, setSamplesMin] = useState<number>(-10000)
@@ -29,7 +30,7 @@ const ErrorBudgetGraph = ({ api, labels, timeRange }: ErrorBudgetGraphProps): JS
     const start = Math.floor((now - timeRange) / 1000)
     const end = Math.floor(now / 1000)
 
-    api.getObjectiveErrorBudget({expr: labelsString(labels), start, end})
+    api.getObjectiveErrorBudget({ expr: labelsString(labels), grouping: labelsString(grouping), start, end })
       .then((r: QueryRange) => {
         let data: any[] = []
         r.values.forEach((v: number[], i: number) => {
@@ -74,7 +75,7 @@ const ErrorBudgetGraph = ({ api, labels, timeRange }: ErrorBudgetGraphProps): JS
         setQuery(r.query)
       })
       .finally(() => setLoading(false))
-  }, [api, labels, timeRange])
+  }, [api, labels, grouping, timeRange])
 
   if (!loading && samples.length === 0) {
     return <>

--- a/ui/src/components/graphs/ErrorsGraph.tsx
+++ b/ui/src/components/graphs/ErrorsGraph.tsx
@@ -6,15 +6,16 @@ import { ObjectivesApi, QueryRange } from '../../client'
 import { dateFormatter, dateFormatterFull, formatDuration, PROMETHEUS_URL } from '../../App'
 import { IconExternal } from '../Icons'
 import { reds } from '../colors'
-import {labelsString} from "../../labels";
+import { labelsString } from "../../labels";
 
 interface ErrorsGraphProps {
   api: ObjectivesApi
   labels: { [key: string]: string }
+  grouping: { [key: string]: string }
   timeRange: number
 }
 
-const ErrorsGraph = ({ api, labels, timeRange }: ErrorsGraphProps): JSX.Element => {
+const ErrorsGraph = ({ api, labels, grouping, timeRange }: ErrorsGraphProps): JSX.Element => {
   const [errors, setErrors] = useState<any[]>([])
   const [errorsQuery, setErrorsQuery] = useState<string>('')
   const [errorsLabels, setErrorsLabels] = useState<string[]>([])
@@ -26,7 +27,7 @@ const ErrorsGraph = ({ api, labels, timeRange }: ErrorsGraphProps): JSX.Element 
     const end = Math.floor(now / 1000)
 
     setErrorsLoading(true)
-    api.getREDErrors({ expr: labelsString(labels), start, end })
+    api.getREDErrors({ expr: labelsString(labels), grouping: labelsString(grouping), start, end })
       .then((r: QueryRange) => {
         let data: any[] = []
         r.values.forEach((v: number[], i: number) => {
@@ -43,7 +44,7 @@ const ErrorsGraph = ({ api, labels, timeRange }: ErrorsGraphProps): JSX.Element 
         setErrors(data)
       }).finally(() => setErrorsLoading(false))
 
-  }, [api, labels, timeRange])
+  }, [api, labels, grouping, timeRange])
 
   const ErrorsTooltip = ({ payload }: TooltipProps<number, number>): JSX.Element => {
     const style = {

--- a/ui/src/components/graphs/RequestsGraph.tsx
+++ b/ui/src/components/graphs/RequestsGraph.tsx
@@ -6,15 +6,16 @@ import { ObjectivesApi, QueryRange } from '../../client'
 import { dateFormatter, dateFormatterFull, formatDuration, PROMETHEUS_URL } from '../../App'
 import { IconExternal } from '../Icons'
 import { blues, greens, reds, yellows } from '../colors'
-import {labelsString} from "../../labels";
+import { labelsString } from "../../labels";
 
 interface RequestsGraphProps {
   api: ObjectivesApi
   labels: { [key: string]: string }
+  grouping: { [key: string]: string }
   timeRange: number
 }
 
-const RequestsGraph = ({ api, labels, timeRange }: RequestsGraphProps): JSX.Element => {
+const RequestsGraph = ({ api, labels, grouping, timeRange }: RequestsGraphProps): JSX.Element => {
   const [requests, setRequests] = useState<any[]>([])
   const [requestsQuery, setRequestsQuery] = useState<string>('')
   const [requestsLabels, setRequestsLabels] = useState<string[]>([])
@@ -26,7 +27,7 @@ const RequestsGraph = ({ api, labels, timeRange }: RequestsGraphProps): JSX.Elem
     const end = Math.floor(now / 1000)
 
     setRequestsLoading(true)
-    api.getREDRequests({ expr: labelsString(labels), start, end })
+    api.getREDRequests({ expr: labelsString(labels), grouping: labelsString(grouping), start, end })
       .then((r: QueryRange) => {
         let data: any[] = []
         r.values.forEach((v: number[], i: number) => {
@@ -42,7 +43,7 @@ const RequestsGraph = ({ api, labels, timeRange }: RequestsGraphProps): JSX.Elem
         setRequestsQuery(r.query)
         setRequests(data)
       }).finally(() => setRequestsLoading(false))
-  }, [api, labels, timeRange])
+  }, [api, labels, grouping, timeRange])
 
   const RequestTooltip = ({ payload }: TooltipProps<number, number>): JSX.Element => {
     const style = {

--- a/ui/src/labels.tsx
+++ b/ui/src/labels.tsx
@@ -13,7 +13,7 @@ export const labelsString = (lset: { [key: string]: string; } | undefined): stri
 }
 
 export const parseLabels = (expr: string | null): { [key: string]: string } => {
-  if (expr == null) {
+  if (expr == null || expr === '{}') {
     return {}
   }
   expr = expr.replace(/^{+|}+$/gm, '')

--- a/ui/src/labels.tsx
+++ b/ui/src/labels.tsx
@@ -4,11 +4,8 @@ export const labelsString = (lset: { [key: string]: string; } | undefined): stri
   }
 
   let s = '';
-
-
   s += '{'
   s += Object.entries(lset)
-    // .filter((l) => l[0] !== '__name__')
     .map((l) => `${l[0]}="${l[1]}"`)
     .join(', ')
   s += '}'

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -63,11 +63,11 @@ const Detail = () => {
       })
 
     api.getObjectiveStatus({expr: expr})
-      .then((s: ObjectiveStatus) => {
+      .then((s: ObjectiveStatus[]) => s.forEach((s: ObjectiveStatus) => {
         setAvailability(s.availability)
         setErrorBudget(s.budget)
         setStatusState(StatusState.Success)
-      })
+      }))
       .catch((resp) => {
         if (resp.status === 404) {
           setStatusState(StatusState.NoData)

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -26,10 +26,13 @@ const Detail = () => {
   }, [])
 
   const queryExpr = query.get('expr')
-  const groupingExpr = query.get('grouping')
   const expr = queryExpr == null ? '' : queryExpr
   const labels = parseLabels(expr)
-  const grouping = parseLabels(groupingExpr)
+
+  const groupingExpr = query.get('grouping')
+  const grouping = groupingExpr == null ? '' : groupingExpr
+  const groupingLabels = parseLabels(grouping)
+
   const name: string = labels['__name__']
 
   const timeRangeQuery = query.get('timerange')
@@ -64,12 +67,18 @@ const Detail = () => {
         }
       })
 
-    api.getObjectiveStatus({ expr: expr })
-      .then((s: ObjectiveStatus[]) => s.forEach((s: ObjectiveStatus) => {
-        setAvailability(s.availability)
-        setErrorBudget(s.budget)
-        setStatusState(StatusState.Success)
-      }))
+      api.getObjectiveStatus({ expr: expr, grouping: grouping })
+      .then((s: ObjectiveStatus[]) => {
+        if (s.length === 0) {
+          setStatusState(StatusState.NoData)
+        } else if (s.length === 1) {
+          setAvailability(s[0].availability)
+          setErrorBudget(s[0].budget)
+          setStatusState(StatusState.Success)
+        } else {
+          setStatusState(StatusState.Error)
+        }
+      })
       .catch((resp) => {
         if (resp.status === 404) {
           setStatusState(StatusState.NoData)
@@ -82,259 +91,259 @@ const Detail = () => {
     //     // cancel any pending requests.
     //     controller.abort()
     // }
-  }, [api, name, expr, groupingExpr, timeRange, StatusState.Error, StatusState.NoData, StatusState.Success])
+  }, [api, name, expr, grouping, timeRange, StatusState.Error, StatusState.NoData, StatusState.Success])
 
-  if (objectiveError !== '') {
+    if (objectiveError !== '') {
+      return (
+        <>
+          <Navbar/>
+          <Container>
+            <div style={{ margin: '50px 0' }}>
+              <h3>{objectiveError}</h3>
+              <br/>
+              <Link to="/" className="btn btn-light">
+                Go Back
+              </Link>
+            </div>
+          </Container>
+        </>
+      )
+    }
+
+    if (objective == null) {
+      return (
+        <div style={{ marginTop: '50px', textAlign: 'center' }}>
+          <Spinner animation="border" role="status">
+            <span className="sr-only">Loading...</span>
+          </Spinner>
+        </div>
+      )
+    }
+
+    if (objective.labels === undefined) {
+      return (
+        <></>
+      )
+    }
+
+    const timeRanges = [
+      28 * 24 * 3600 * 1000, // 4w
+      7 * 24 * 3600 * 1000, // 1w
+      24 * 3600 * 1000, // 1d
+      12 * 3600 * 1000, // 12h
+      3600 * 1000 // 1h
+    ]
+
+    const handleTimeRangeClick = (t: number) => () => {
+      history.push(`/objectives/?expr=${expr}&grouping=${groupingExpr}&timerange=${formatDuration(t)}`)
+    }
+
+    const renderAvailability = () => {
+      const headline = (<h6>Availability</h6>)
+      switch (statusState) {
+        case StatusState.Unknown:
+          return (
+            <div>
+              {headline}
+              <Spinner animation={'border'} style={{
+                width: 50,
+                height: 50,
+                padding: 0,
+                borderRadius: 50,
+                borderWidth: 2,
+                opacity: 0.25
+              }}/>
+            </div>
+          )
+        case StatusState.Error:
+          return (
+            <div>
+              {headline}
+              <h2 className="error">Error</h2>
+            </div>
+          )
+        case StatusState.NoData:
+          return (
+            <div>
+              {headline}
+              <h2>No data</h2>
+            </div>
+          )
+        case StatusState.Success:
+          if (availability === null) {
+            return <></>
+          }
+          return (
+            <div className={availability.percentage > objective.target ? 'good' : 'bad'}>
+              {headline}
+              <h2>{(100 * availability.percentage).toFixed(3)}%</h2>
+            </div>
+          )
+      }
+    }
+
+    const renderErrorBudget = () => {
+      const headline = (<h6>Error Budget</h6>)
+      switch (statusState) {
+        case StatusState.Unknown:
+          return (
+            <div>
+              {headline}
+              <Spinner animation={'border'} style={{
+                width: 50,
+                height: 50,
+                padding: 0,
+                borderRadius: 50,
+                borderWidth: 2,
+                opacity: 0.25
+              }}/>
+            </div>
+          )
+        case StatusState.Error:
+          return (
+            <div>
+              {headline}
+              <h2 className="error">Error</h2>
+            </div>
+          )
+        case StatusState.NoData:
+          return (
+            <div>
+              {headline}
+              <h2>No data</h2>
+            </div>
+          )
+        case StatusState.Success:
+          if (errorBudget === null) {
+            return <></>
+          }
+          return (
+            <div className={errorBudget.remaining > 0 ? 'good' : 'bad'}>
+              {headline}
+              <h2>{(100 * errorBudget.remaining).toFixed(3)}%</h2>
+            </div>
+          )
+      }
+    }
+
+    const labelBadges = Object.entries({ ...objective.labels, ...groupingLabels })
+      .filter((l: [string, string]) => l[0] !== '__name__')
+      .map((l: [string, string]) => (
+        <Badge variant={"light"}>{l[0]}={l[1]}</Badge>
+      ))
+
     return (
       <>
-        <Navbar/>
-        <Container>
-          <div style={{ margin: '50px 0' }}>
-            <h3>{objectiveError}</h3>
-            <br/>
-            <Link to="/" className="btn btn-light">
-              Go Back
-            </Link>
-          </div>
-        </Container>
-      </>
-    )
-  }
-
-  if (objective == null) {
-    return (
-      <div style={{ marginTop: '50px', textAlign: 'center' }}>
-        <Spinner animation="border" role="status">
-          <span className="sr-only">Loading...</span>
-        </Spinner>
-      </div>
-    )
-  }
-
-  if (objective.labels === undefined) {
-    return (
-      <></>
-    )
-  }
-
-  const timeRanges = [
-    28 * 24 * 3600 * 1000, // 4w
-    7 * 24 * 3600 * 1000, // 1w
-    24 * 3600 * 1000, // 1d
-    12 * 3600 * 1000, // 12h
-    3600 * 1000 // 1h
-  ]
-
-  const handleTimeRangeClick = (t: number) => () => {
-    history.push(`/objectives/?expr=${expr}&grouping=${groupingExpr}&timerange=${formatDuration(t)}`)
-  }
-
-  const renderAvailability = () => {
-    const headline = (<h6>Availability</h6>)
-    switch (statusState) {
-      case StatusState.Unknown:
-        return (
+        <Navbar>
           <div>
-            {headline}
-            <Spinner animation={'border'} style={{
-              width: 50,
-              height: 50,
-              padding: 0,
-              borderRadius: 50,
-              borderWidth: 2,
-              opacity: 0.25
-            }}/>
+            <Link to="/">Objectives</Link> &gt; <span>{name}</span>
           </div>
-        )
-      case StatusState.Error:
-        return (
-          <div>
-            {headline}
-            <h2 className="error">Error</h2>
-          </div>
-        )
-      case StatusState.NoData:
-        return (
-          <div>
-            {headline}
-            <h2>No data</h2>
-          </div>
-        )
-      case StatusState.Success:
-        if (availability === null) {
-          return <></>
-        }
-        return (
-          <div className={availability.percentage > objective.target ? 'good' : 'bad'}>
-            {headline}
-            <h2>{(100 * availability.percentage).toFixed(3)}%</h2>
-          </div>
-        )
-    }
-  }
+        </Navbar>
 
-  const renderErrorBudget = () => {
-    const headline = (<h6>Error Budget</h6>)
-    switch (statusState) {
-      case StatusState.Unknown:
-        return (
-          <div>
-            {headline}
-            <Spinner animation={'border'} style={{
-              width: 50,
-              height: 50,
-              padding: 0,
-              borderRadius: 50,
-              borderWidth: 2,
-              opacity: 0.25
-            }}/>
-          </div>
-        )
-      case StatusState.Error:
-        return (
-          <div>
-            {headline}
-            <h2 className="error">Error</h2>
-          </div>
-        )
-      case StatusState.NoData:
-        return (
-          <div>
-            {headline}
-            <h2>No data</h2>
-          </div>
-        )
-      case StatusState.Success:
-        if (errorBudget === null) {
-          return <></>
-        }
-        return (
-          <div className={errorBudget.remaining > 0 ? 'good' : 'bad'}>
-            {headline}
-            <h2>{(100 * errorBudget.remaining).toFixed(3)}%</h2>
-          </div>
-        )
-    }
-  }
+        <div className="content detail">
+          <Container>
+            <Row>
+              <Col xs={12}>
+                <h3>{name}</h3>
+                {labelBadges}
+              </Col>
+              {objective.description !== undefined && objective.description !== '' ? (
+                  <Col xs={12} md={6}>
+                    <p>{objective.description}</p>
+                  </Col>
+                )
+                : (<></>)}
+            </Row>
+            <Row>
+              <div className="metrics">
+                <div>
+                  <h6>Objective in <strong>{formatDuration(objective.window)}</strong></h6>
+                  <h2>{(100 * objective.target).toFixed(3)}%</h2>
+                </div>
 
-  const labelBadges = Object.entries({ ...objective.labels, ...grouping })
-    .filter((l: [string, string]) => l[0] !== '__name__')
-    .map((l: [string, string]) => (
-      <Badge variant={"light"}>{l[0]}={l[1]}</Badge>
-    ))
+                {renderAvailability()}
 
-  return (
-    <>
-      <Navbar>
-        <div>
-          <Link to="/">Objectives</Link> &gt; <span>{name}</span>
-        </div>
-      </Navbar>
+                {renderErrorBudget()}
 
-      <div className="content detail">
-        <Container>
-          <Row>
-            <Col xs={12}>
-              <h3>{name}</h3>
-              {labelBadges}
-            </Col>
-            {objective.description !== undefined && objective.description !== '' ? (
-                <Col xs={12} md={6}>
-                  <p>{objective.description}</p>
-                </Col>
-              )
-              : (<></>)}
-          </Row>
-          <Row>
-            <div className="metrics">
-              <div>
-                <h6>Objective in <strong>{formatDuration(objective.window)}</strong></h6>
-                <h2>{(100 * objective.target).toFixed(3)}%</h2>
               </div>
-
-              {renderAvailability()}
-
-              {renderErrorBudget()}
-
-            </div>
-          </Row>
-          <Row>
-            <Col className="text-center timerange">
-              <div className="inner">
-                <ButtonGroup aria-label="Time Range">
-                  {timeRanges.map((t: number, i: number) => (
-                    <Button
-                      key={i}
-                      variant="light"
-                      onClick={handleTimeRangeClick(t)}
-                      active={timeRange === t}
-                    >{formatDuration(t)}</Button>
-                  ))}
-                </ButtonGroup>
-              </div>
-            </Col>
-          </Row>
-          <Row style={{ marginBottom: 0 }}>
-            <Col>
-              <ErrorBudgetGraph
-                api={api}
-                labels={labels}
-                grouping={grouping}
-                timeRange={timeRange}
-              />
-            </Col>
-          </Row>
-          <Row>
-            <Col style={{ textAlign: 'right' }}>
-              {availability != null ? (
-                <>
-                  <small>Errors: {Math.floor(availability.errors).toLocaleString()}</small>&nbsp;
-                  <small>Total: {Math.floor(availability.total).toLocaleString()}</small>&nbsp;
-                </>
-              ) : (
-                <></>
-              )}
-            </Col>
-          </Row>
-          <Row>
-            <Col xs={12} sm={6}>
-              <RequestsGraph
-                api={api}
-                labels={labels}
-                grouping={grouping}
-                timeRange={timeRange}
-              />
-            </Col>
-            <Col xs={12} sm={6}>
-              <ErrorsGraph
-                api={api}
-                labels={labels}
-                grouping={grouping}
-                timeRange={timeRange}
-              />
-            </Col>
-          </Row>
-          <Row>
-            <Col>
-              <h4>Multi Burn Rate Alerts</h4>
-              <AlertsTable
-                objective={objective}
-                grouping={grouping}
-              />
-            </Col>
-          </Row>
-          <Row>
-            <Col>
-              <h4>Config</h4>
-              <pre style={{ padding: 20, borderRadius: 4 }}>
+            </Row>
+            <Row>
+              <Col className="text-center timerange">
+                <div className="inner">
+                  <ButtonGroup aria-label="Time Range">
+                    {timeRanges.map((t: number, i: number) => (
+                      <Button
+                        key={i}
+                        variant="light"
+                        onClick={handleTimeRangeClick(t)}
+                        active={timeRange === t}
+                      >{formatDuration(t)}</Button>
+                    ))}
+                  </ButtonGroup>
+                </div>
+              </Col>
+            </Row>
+            <Row style={{ marginBottom: 0 }}>
+              <Col>
+                <ErrorBudgetGraph
+                  api={api}
+                  labels={labels}
+                  grouping={groupingLabels}
+                  timeRange={timeRange}
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col style={{ textAlign: 'right' }}>
+                {availability != null ? (
+                  <>
+                    <small>Errors: {Math.floor(availability.errors).toLocaleString()}</small>&nbsp;
+                    <small>Total: {Math.floor(availability.total).toLocaleString()}</small>&nbsp;
+                  </>
+                ) : (
+                  <></>
+                )}
+              </Col>
+            </Row>
+            <Row>
+              <Col xs={12} sm={6}>
+                <RequestsGraph
+                  api={api}
+                  labels={labels}
+                  grouping={groupingLabels}
+                  timeRange={timeRange}
+                />
+              </Col>
+              <Col xs={12} sm={6}>
+                <ErrorsGraph
+                  api={api}
+                  labels={labels}
+                  grouping={groupingLabels}
+                  timeRange={timeRange}
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col>
+                <h4>Multi Burn Rate Alerts</h4>
+                <AlertsTable
+                  objective={objective}
+                  grouping={groupingLabels}
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col>
+                <h4>Config</h4>
+                <pre style={{ padding: 20, borderRadius: 4 }}>
                 <code>{objective.config}</code>
               </pre>
-            </Col>
-          </Row>
-        </Container>
-      </div>
-    </>
-  );
-};
+              </Col>
+            </Row>
+          </Container>
+        </div>
+      </>
+    );
+  };
 
-export default Detail
+  export default Detail

--- a/ui/src/pages/List.tsx
+++ b/ui/src/pages/List.tsx
@@ -1,11 +1,11 @@
-import React, {useEffect, useMemo, useReducer, useState} from 'react'
-import {Badge, Col, Container, OverlayTrigger, Row, Spinner, Table, Tooltip as OverlayTooltip} from 'react-bootstrap'
-import {Configuration, Objective, ObjectivesApi, ObjectiveStatus} from '../client'
-import {formatDuration, PUBLIC_API} from '../App'
-import {Link, useHistory} from 'react-router-dom'
+import React, { useEffect, useMemo, useReducer, useState } from 'react'
+import { Badge, Col, Container, OverlayTrigger, Row, Spinner, Table, Tooltip as OverlayTooltip } from 'react-bootstrap'
+import { Configuration, Objective, ObjectivesApi, ObjectiveStatus } from '../client'
+import { formatDuration, PUBLIC_API } from '../App'
+import { Link, useHistory } from 'react-router-dom'
 import Navbar from '../components/Navbar'
-import {IconArrowDown, IconArrowUp, IconArrowUpDown} from '../components/Icons'
-import {labelsString} from "../labels";
+import { IconArrowDown, IconArrowUp, IconArrowUpDown } from '../components/Icons'
+import { labelsString } from "../labels";
 
 enum TableObjectiveState {
   Unknown,
@@ -151,8 +151,10 @@ const List = () => {
         dispatchTable({type: TableActionType.SetObjective, objective: o})
 
         api.getObjectiveStatus({expr: labelsString(o.labels)})
-          .then((s: ObjectiveStatus) => {
-            dispatchTable({type: TableActionType.SetStatus, name: labelsString(o.labels), status: s})
+          .then((s: ObjectiveStatus[]) => {
+            s.forEach((s: ObjectiveStatus) => {
+              dispatchTable({ type: TableActionType.SetStatus, name: labelsString(o.labels), status: s })
+            })
           })
           .catch((err) => {
             if (err.status === 404) {


### PR DESCRIPTION
One definition of a SLO now gives us multiple individual SLOs by label grouping.

In this example it's the `prometheus_http_requests_total{handler=~"/api.*"}` by `handler`:
![list](https://user-images.githubusercontent.com/872251/139596775-e072a56e-ffbb-4248-addb-15df4b5c9074.png)
We can still look at an individual SLO detail page:
![detail](https://user-images.githubusercontent.com/872251/139596778-fa8d5be2-7b08-4da2-a7fd-b5b4df2bc522.png)

