### PR TITLE
Delete generated PrometheusRule by setting OwnerReferences

### DIFF
--- a/kubernetes/controllers/servicelevelobjective.go
+++ b/kubernetes/controllers/servicelevelobjective.go
@@ -96,6 +96,7 @@ func makePrometheusRule(kubeObjective pyrrav1alpha1.ServiceLevelObjective) (*mon
 		return nil, err
 	}
 
+	isController := true
 	return &monitoringv1.PrometheusRule{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       monitoringv1.PrometheusRuleKind,
@@ -105,6 +106,15 @@ func makePrometheusRule(kubeObjective pyrrav1alpha1.ServiceLevelObjective) (*mon
 			Name:      kubeObjective.GetName(),
 			Namespace: kubeObjective.GetNamespace(),
 			Labels:    kubeObjective.GetLabels(),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: kubeObjective.APIVersion,
+					Kind:       kubeObjective.Kind,
+					Name:       kubeObjective.Name,
+					UID:        kubeObjective.UID,
+					Controller: &isController,
+				},
+			},
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{group},

--- a/kubernetes/controllers/servicelevelobjective_test.go
+++ b/kubernetes/controllers/servicelevelobjective_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Test_makePrometheusRule(t *testing.T) {
+	trueBool := true
 	tests := []struct {
 		name      string
 		objective pyrrav1alpha1.ServiceLevelObjective
@@ -21,7 +22,14 @@ func Test_makePrometheusRule(t *testing.T) {
 	}{{
 		name: "http",
 		objective: pyrrav1alpha1.ServiceLevelObjective{
-			ObjectMeta: metav1.ObjectMeta{Name: "http"},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: pyrrav1alpha1.GroupVersion.Version,
+				Kind:       "ServiceLevelObjective",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "http",
+				UID:  "123",
+			},
 			Spec: pyrrav1alpha1.ServiceLevelObjectiveSpec{
 				Target: "99.5",
 				Window: model.Duration(28 * 24 * time.Hour),
@@ -44,6 +52,15 @@ func Test_makePrometheusRule(t *testing.T) {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "http",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: pyrrav1alpha1.GroupVersion.Version,
+						Kind:       "ServiceLevelObjective",
+						Name:       "http",
+						UID:        "123",
+						Controller: &trueBool,
+					},
+				},
 			},
 			Spec: monitoringv1.PrometheusRuleSpec{
 				Groups: []monitoringv1.RuleGroup{{


### PR DESCRIPTION
By setting owner references on the object we create, kubernetes will
handle deletion of the generated PrometheusRule when the corresponding
ServiceLevelObjective is deleted.

Example:

        k apply -f examples/pyrra-http-errors.yaml
        servicelevelobjective.pyrra.dev/pyrra-api-errors created

we see that the controller generates a prometheusrule object:

        k get prometheusrule,servicelevelobjective -n monitoring
        NAME                                                    AGE
        prometheusrule.monitoring.coreos.com/pyrra-api-errors   1s
        servicelevelobjective.pyrra.dev/pyrra-api-errors        1s

when we delete the SLO, the matching rule is deleted:

        k delete servicelevelobjective.pyrra.dev/pyrra-api-errors -n monitoring

        k get prometheusrule,servicelevelobjective -n monitoring
        No resources found in monitoring namespace.

Updates #39
