### PR TITLE
Add SLO as shortname for kubernetes

### DIFF
--- a/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
+++ b/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ServiceLevelObjective
     listKind: ServiceLevelObjectiveList
     plural: servicelevelobjectives
+    shortNames:
+    - slo
     singular: servicelevelobjective
   scope: Namespaced
   versions:

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -45,6 +45,7 @@ type ServiceLevelObjectiveList struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName=slo
 
 // ServiceLevelObjective is the Schema for the ServiceLevelObjectives API
 type ServiceLevelObjective struct {


### PR DESCRIPTION
Allow users to type "kubectl get slo" etc:

	$ kubectl apply -f examples/pyrra-http-errors.yaml
	servicelevelobjective.pyrra.dev/pyrra-api-errors created
	$ kubectl get slo -n monitoring
	NAME               AGE
	pyrra-api-errors   5s
