### PR TITLE
Add labels to internal SLO representation

### DIFF
--- a/main.go
+++ b/main.go
@@ -612,6 +612,9 @@ func (o *ObjectivesServer) GetMultiBurnrateAlerts(ctx context.Context, expr stri
 
 		alertstate := alertstateInactive
 
+		// TODO: It should be possible to reduce the amount of queries by querying ALERTS{slo="%s"}
+		// and then matching the resulting short and long values.
+
 		go func(name string, short, long int64) {
 			defer wg.Done()
 

--- a/openapi/internal.go
+++ b/openapi/internal.go
@@ -56,8 +56,13 @@ func InternalFromClient(o client.Objective) slo.Objective {
 		}
 	}
 
+	ls := make([]labels.Label, 0, len(o.GetLabels()))
+	for name, value := range o.GetLabels() {
+		ls = append(ls, labels.Label{Name: name, Value: value})
+	}
+
 	return slo.Objective{
-		//Name:        o.GetName(),
+		Labels:      ls,
 		Description: o.GetDescription(),
 		Target:      o.GetTarget(),
 		Window:      model.Duration(time.Duration(o.GetWindow()) * time.Millisecond),


### PR DESCRIPTION
This caused the Alerting Table to sometimes query the incorrect SLO alerts... 
While the query should be something like
```
ALERTS{slo="lastfm-api-errors",short="30m",long="6h"}
```
the SLO name wasn't properly populated and was instead
```
ALERTS{slo="",short="30m",long="6h"}
```

On my cluster it showed firing for another KubeAPIServer SLO although it was the wrong one...