### PR TITLE
ui: Make uplot graphs responsive with window resize listener

### DIFF
--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -314,7 +314,7 @@ const Detail = () => {
             </Col>
           </Row>
           <Row>
-            <Col xs={12} sm={6}>
+            <Col xs={12} md={6}>
               <RequestsGraph
                 api={api}
                 labels={labels}
@@ -323,7 +323,7 @@ const Detail = () => {
                 uPlotCursor={uPlotCursor}
               />
             </Col>
-            <Col xs={12} sm={6}>
+            <Col xs={12} md={6}>
               <ErrorsGraph
                 api={api}
                 labels={labels}


### PR DESCRIPTION
The uplot graphs had hardcoded width of 1000px and twice 500px. Thus adding a window resize listener to automatically set the uplot's canvas to the outer container's width.