### PR TITLE
ui: Show warning for SLOs that have too few requests

### DIFF
--- a/ui/src/components/Icons.tsx
+++ b/ui/src/components/Icons.tsx
@@ -5,6 +5,8 @@ interface IconExternalProps {
   width: number
 }
 
+// Font Awesome Pro 6.0.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc.
+
 export const IconExternal = ({ height, width }: IconExternalProps): JSX.Element => (
   <svg width={width} height={height} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
@@ -35,5 +37,11 @@ export const IconArrowUpDown = (): JSX.Element => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M19 14L12 21L5 14" stroke="black" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
     <path d="M19 10L12 3L5 10" stroke="black" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+)
+
+export const TriangleExclamation = ({ height, width }: IconExternalProps): JSX.Element => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" height={height} width={width}>
+    <path d="M506.3 417l-213.3-364c-16.33-28-57.54-28-73.98 0l-213.2 364C-10.59 444.9 9.849 480 42.74 480h426.6C502.1 480 522.6 445 506.3 417zM232 168c0-13.25 10.75-24 24-24S280 154.8 280 168v128c0 13.25-10.75 24-23.1 24S232 309.3 232 296V168zM256 416c-17.36 0-31.44-14.08-31.44-31.44c0-17.36 14.07-31.44 31.44-31.44s31.44 14.08 31.44 31.44C287.4 401.9 273.4 416 256 416z"/>
   </svg>
 )

--- a/ui/src/pages/List.tsx
+++ b/ui/src/pages/List.tsx
@@ -324,19 +324,39 @@ const List = () => {
         if (o.availability === null || o.availability === undefined) {
           return <></>
         }
+
+        const volumeWarning = ((1 - o.target) * o.availability.total)
+
+
+        let ls = labelsString(Object.assign({}, o.labels, o.groupingLabels))
+        console.log(ls)
         return (
-          <OverlayTrigger
-            key={labelsString(o.labels)}
-            overlay={
-              <OverlayTooltip id={`tooltip-${labelsString(o.labels)}`}>
-                Errors: {Math.floor(o.availability.errors).toLocaleString()}<br/>
-                Total: {Math.floor(o.availability.total).toLocaleString()}
-              </OverlayTooltip>
-            }>
-          <span className={o.availability.percentage > o.target ? 'good' : 'bad'}>
-            {(100 * o.availability.percentage).toFixed(2)}%
-          </span>
-          </OverlayTrigger>
+          <>
+            <OverlayTrigger
+              key={ls}
+              overlay={
+                <OverlayTooltip id={`tooltip-${ls}`}>
+                  Errors: {Math.floor(o.availability.errors).toLocaleString()}<br/>
+                  Total: {Math.floor(o.availability.total).toLocaleString()}
+                </OverlayTooltip>
+              }>
+              <span className={o.availability.percentage > o.target ? 'good' : 'bad'}>
+                {(100 * o.availability.percentage).toFixed(2)}%
+              </span>
+            </OverlayTrigger>
+            {volumeWarning < 1 ? <>
+              <OverlayTrigger
+                key={`${ls}-warning`}
+                overlay={
+                  <OverlayTooltip id={`tooltip-${ls}-warning`}>
+                    Just one request error will exhaust the entire error budget.<br/>
+                    Either increase the amount of requests or decrease your objective's target.
+                  </OverlayTooltip>
+                }>
+                <TriangleExclamation width={24} height={24}/>
+              </OverlayTrigger>
+            </> : <></>}
+          </>
         )
     }
   }


### PR DESCRIPTION
If there are too few requests for a SLO which would mean that just one bad request could exhaust the entire error budget, we want to show a warning to the user.

The UI is far from finished and needs some tweaks and proper design.
![localhost_3000_](https://user-images.githubusercontent.com/872251/153585336-6f0b7f75-a256-497c-a4ec-402a033ec755.png)

Should we also show a warning on the detail page somewhere? Probably next to the availability box at the top too?