### PR TITLE
Separate increase rules into separate rule group with higher interval

### DIFF
--- a/kubernetes/controllers/servicelevelobjective.go
+++ b/kubernetes/controllers/servicelevelobjective.go
@@ -22,12 +22,13 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	pyrrav1alpha1 "github.com/pyrra-dev/pyrra/kubernetes/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	pyrrav1alpha1 "github.com/pyrra-dev/pyrra/kubernetes/api/v1alpha1"
 )
 
 // ServiceLevelObjectiveReconciler reconciles a ServiceLevelObjective object
@@ -91,7 +92,11 @@ func makePrometheusRule(kubeObjective pyrrav1alpha1.ServiceLevelObjective) (*mon
 		return nil, err
 	}
 
-	group, err := objective.Burnrates()
+	increases, err := objective.IncreaseRules()
+	if err != nil {
+		return nil, err
+	}
+	burnrates, err := objective.Burnrates()
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +122,7 @@ func makePrometheusRule(kubeObjective pyrrav1alpha1.ServiceLevelObjective) (*mon
 			},
 		},
 		Spec: monitoringv1.PrometheusRuleSpec{
-			Groups: []monitoringv1.RuleGroup{group},
+			Groups: []monitoringv1.RuleGroup{increases, burnrates},
 		},
 	}, nil
 }

--- a/kubernetes/controllers/servicelevelobjective_test.go
+++ b/kubernetes/controllers/servicelevelobjective_test.go
@@ -66,7 +66,7 @@ func Test_makePrometheusRule(t *testing.T) {
 			Spec: monitoringv1.PrometheusRuleSpec{
 				Groups: []monitoringv1.RuleGroup{{
 					Name:     "http-increase",
-					Interval: "30s",
+					Interval: "2m30s",
 					Rules: []monitoringv1.Rule{{
 						Record: "http_requests:increase4w",
 						Expr:   intstr.FromString(`sum by(status) (increase(http_requests_total{job="app"}[4w]))`),

--- a/kubernetes/controllers/servicelevelobjective_test.go
+++ b/kubernetes/controllers/servicelevelobjective_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus/common/model"
-	pyrrav1alpha1 "github.com/pyrra-dev/pyrra/kubernetes/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	pyrrav1alpha1 "github.com/pyrra-dev/pyrra/kubernetes/api/v1alpha1"
 )
 
 func Test_makePrometheusRule(t *testing.T) {
@@ -64,13 +65,17 @@ func Test_makePrometheusRule(t *testing.T) {
 			},
 			Spec: monitoringv1.PrometheusRuleSpec{
 				Groups: []monitoringv1.RuleGroup{{
-					Name:     "http",
+					Name:     "http-increase",
 					Interval: "30s",
 					Rules: []monitoringv1.Rule{{
 						Record: "http_requests:increase4w",
 						Expr:   intstr.FromString(`sum by(status) (increase(http_requests_total{job="app"}[4w]))`),
 						Labels: map[string]string{"job": "app", "slo": "http"},
-					}, {
+					}},
+				}, {
+					Name:     "http",
+					Interval: "30s",
+					Rules: []monitoringv1.Rule{{
 						Record: "http_requests:burnrate5m",
 						Expr:   intstr.FromString(`sum(rate(http_requests_total{job="app",status=~"5.."}[5m])) / sum(rate(http_requests_total{job="app"}[5m]))`),
 						Labels: map[string]string{"job": "app", "slo": "http"},

--- a/slo/rules.go
+++ b/slo/rules.go
@@ -502,9 +502,33 @@ func (o Objective) IncreaseRules() (monitoringv1.RuleGroup, error) {
 		})
 	}
 
+	day := 24 * time.Hour
+
+	var interval model.Duration
+	window := time.Duration(o.Window)
+
+	// TODO: Make this a function with an equation
+	if window < 7*day {
+		interval = model.Duration(30 * time.Second)
+	} else if window < 14*day {
+		interval = model.Duration(60 * time.Second)
+	} else if window < 21*day {
+		interval = model.Duration(90 * time.Second)
+	} else if window < 28*day {
+		interval = model.Duration(120 * time.Second)
+	} else if window < 35*day {
+		interval = model.Duration(150 * time.Second)
+	} else if window < 42*day {
+		interval = model.Duration(180 * time.Second)
+	} else if window < 49*day {
+		interval = model.Duration(210 * time.Second)
+	} else { // 8w
+		interval = model.Duration(240 * time.Second)
+	}
+
 	return monitoringv1.RuleGroup{
 		Name:     sloName + "-increase",
-		Interval: "30s",
+		Interval: interval.String(),
 		Rules:    rules,
 	}, nil
 }

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -15,16 +15,12 @@ func TestObjective_Burnrates(t *testing.T) {
 		slo   Objective
 		rules monitoringv1.RuleGroup
 	}{{
-		name: "http-ratio", // super similar to gRPC and therefore only HTTP
+		name: "http-ratio",
 		slo:  objectiveHTTPRatio(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-errors",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "http_requests:increase4w",
-				Expr:   intstr.FromString(`sum by(code) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`),
-				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
-			}, {
 				Record: "http_requests:burnrate5m",
 				Expr:   intstr.FromString(`sum(rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[5m])) / sum(rate(http_requests_total{job="thanos-receive-default"}[5m]))`),
 				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
@@ -81,10 +77,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-http-errors",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "http_requests:increase4w",
-				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`),
-				Labels: map[string]string{"slo": "monitoring-http-errors"},
-			}, {
 				Record: "http_requests:burnrate5m",
 				Expr:   intstr.FromString(`sum by(handler, job) (rate(http_requests_total{code=~"5..",job="thanos-receive-default"}[5m])) / sum by(handler, job) (rate(http_requests_total{job="thanos-receive-default"}[5m]))`),
 				Labels: map[string]string{"slo": "monitoring-http-errors"},
@@ -141,10 +133,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-http-errors",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "http_requests:increase4w",
-				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_requests_total{handler=~"/api.*",job="thanos-receive-default"}[4w]))`),
-				Labels: map[string]string{"slo": "monitoring-http-errors"},
-			}, {
 				Record: "http_requests:burnrate5m",
 				Expr:   intstr.FromString(`sum by(handler, job) (rate(http_requests_total{code=~"5..",handler=~"/api.*",job="thanos-receive-default"}[5m])) / sum by(handler, job) (rate(http_requests_total{handler=~"/api.*",job="thanos-receive-default"}[5m]))`),
 				Labels: map[string]string{"slo": "monitoring-http-errors"},
@@ -201,10 +189,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-grpc-errors",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "grpc_server_handled:increase4w",
-				Expr:   intstr.FromString(`sum by(grpc_code) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`),
-				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
-			}, {
 				Record: "grpc_server_handled:burnrate5m",
 				Expr:   intstr.FromString(`sum(rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[5m])) / sum(rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[5m]))`),
 				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
@@ -261,10 +245,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-grpc-errors",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "grpc_server_handled:increase4w",
-				Expr:   intstr.FromString(`sum by(grpc_code, handler, job) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`),
-				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "slo": "monitoring-grpc-errors"},
-			}, {
 				Record: "grpc_server_handled:burnrate5m",
 				Expr:   intstr.FromString(`sum by(handler, job) (rate(grpc_server_handled_total{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[5m])) / sum by(handler, job) (rate(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[5m]))`),
 				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "slo": "monitoring-grpc-errors"},
@@ -315,20 +295,12 @@ func TestObjective_Burnrates(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "http-latency", // super similar to gRPC and therefore only HTTP
+		name: "http-latency",
 		slo:  objectiveHTTPLatency(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-latency",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "http_request_duration_seconds:increase4w",
-				Expr:   intstr.FromString(`sum by(code) (increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w]))`),
-				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
-			}, {
-				Record: "http_request_duration_seconds:increase4w",
-				Expr:   intstr.FromString(`sum by(code) (increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]))`),
-				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "le": "1"},
-			}, {
 				Record: "http_request_duration_seconds:burnrate5m",
 				Expr:   intstr.FromString(`(sum by(code) (rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[5m])) - sum by(code) (rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[5m]))) / sum by(code) (rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[5m]))`),
 				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
@@ -385,14 +357,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-http-latency",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "http_request_duration_seconds:increase4w",
-				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w]))`),
-				Labels: map[string]string{"slo": "monitoring-http-latency"},
-			}, {
-				Record: "http_request_duration_seconds:increase4w",
-				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]))`),
-				Labels: map[string]string{"slo": "monitoring-http-latency", "le": "1"},
-			}, {
 				Record: "http_request_duration_seconds:burnrate5m",
 				Expr:   intstr.FromString(`(sum by(code, handler, job) (rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[5m])) - sum by(code, handler, job) (rate(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[5m]))) / sum by(code, handler, job) (rate(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[5m]))`),
 				Labels: map[string]string{"slo": "monitoring-http-latency"},
@@ -449,14 +413,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-http-latency",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "http_request_duration_seconds:increase4w",
-				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_count{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default"}[4w]))`),
-				Labels: map[string]string{"slo": "monitoring-http-latency"},
-			}, {
-				Record: "http_request_duration_seconds:increase4w",
-				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_bucket{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default",le="1"}[4w]))`),
-				Labels: map[string]string{"slo": "monitoring-http-latency", "le": "1"},
-			}, {
 				Record: "http_request_duration_seconds:burnrate5m",
 				Expr:   intstr.FromString(`(sum by(code, handler, job) (rate(http_request_duration_seconds_count{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default"}[5m])) - sum by(code, handler, job) (rate(http_request_duration_seconds_bucket{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default",le="1"}[5m]))) / sum by(code, handler, job) (rate(http_request_duration_seconds_count{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default"}[5m]))`),
 				Labels: map[string]string{"slo": "monitoring-http-latency"},
@@ -513,14 +469,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-grpc-latency",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "grpc_server_handling_seconds:increase1w",
-				Expr:   intstr.FromString(`sum(increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w]))`),
-				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
-			}, {
-				Record: "grpc_server_handling_seconds:increase1w",
-				Expr:   intstr.FromString(`sum(increase(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1w]))`),
-				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "le": "0.6"},
-			}, {
 				Record: "grpc_server_handling_seconds:burnrate1m",
 				Expr:   intstr.FromString(`(sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1m])) - sum(rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1m]))) / sum(rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1m]))`),
 				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
@@ -577,14 +525,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-grpc-latency",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "grpc_server_handling_seconds:increase1w",
-				Expr:   intstr.FromString(`sum by(handler, job) (increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w]))`),
-				Labels: map[string]string{"slo": "monitoring-grpc-latency", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
-			}, {
-				Record: "grpc_server_handling_seconds:increase1w",
-				Expr:   intstr.FromString(`sum by(handler, job) (increase(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1w]))`),
-				Labels: map[string]string{"slo": "monitoring-grpc-latency", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "le": "0.6"},
-			}, {
 				Record: "grpc_server_handling_seconds:burnrate1m",
 				Expr:   intstr.FromString(`(sum by(handler, job) (rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1m])) - sum by(handler, job) (rate(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1m]))) / sum by(handler, job) (rate(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1m]))`),
 				Labels: map[string]string{"slo": "monitoring-grpc-latency", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
@@ -641,14 +581,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-prometheus-operator-errors",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "prometheus_operator_reconcile_operations:increase2w",
-				Expr:   intstr.FromString(`sum(increase(prometheus_operator_reconcile_operations_total[2w]))`),
-				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
-			}, {
-				Record: "prometheus_operator_reconcile_errors:increase2w",
-				Expr:   intstr.FromString(`sum(increase(prometheus_operator_reconcile_errors_total[2w]))`),
-				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
-			}, {
 				Record: "prometheus_operator_reconcile_operations:burnrate3m",
 				Expr:   intstr.FromString(`sum(rate(prometheus_operator_reconcile_errors_total[3m])) / sum(rate(prometheus_operator_reconcile_operations_total[3m]))`),
 				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
@@ -705,14 +637,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "monitoring-prometheus-operator-errors",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "prometheus_operator_reconcile_operations:increase2w",
-				Expr:   intstr.FromString(`sum by(namespace) (increase(prometheus_operator_reconcile_operations_total[2w]))`),
-				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
-			}, {
-				Record: "prometheus_operator_reconcile_errors:increase2w",
-				Expr:   intstr.FromString(`sum by(namespace) (increase(prometheus_operator_reconcile_errors_total[2w]))`),
-				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
-			}, {
 				Record: "prometheus_operator_reconcile_operations:burnrate3m",
 				Expr:   intstr.FromString(`sum by(namespace) (rate(prometheus_operator_reconcile_errors_total[3m])) / sum by(namespace) (rate(prometheus_operator_reconcile_operations_total[3m]))`),
 				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
@@ -769,10 +693,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "apiserver-write-response-errors",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "apiserver_request:increase2w",
-				Expr:   intstr.FromString(`sum by(code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2w]))`),
-				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-write-response-errors"},
-			}, {
 				Record: "apiserver_request:burnrate3m",
 				Expr:   intstr.FromString(`sum by(verb) (rate(apiserver_request_total{code=~"5..",job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3m])) / sum by(verb) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3m]))`),
 				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-write-response-errors"},
@@ -829,14 +749,14 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "apiserver-read-resource-latency",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				Record: "apiserver_request_duration_seconds:increase2w",
-				Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),
-				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency"},
-			}, {
-				Record: "apiserver_request_duration_seconds:increase2w",
-				Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_bucket{job="apiserver",le="0.1",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),
-				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency", "le": "0.1"},
-			}, {
+				//	Record: "apiserver_request_duration_seconds:increase2w",
+				//	Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),
+				//	Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency"},
+				//}, {
+				//	Record: "apiserver_request_duration_seconds:increase2w",
+				//	Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_bucket{job="apiserver",le="0.1",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),
+				//	Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency", "le": "0.1"},
+				//}, {
 				Record: "apiserver_request_duration_seconds:burnrate3m",
 				Expr:   intstr.FromString(`(sum by(resource, verb) (rate(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}[3m])) - sum by(resource, verb) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",le="0.1",resource=~"resource|",verb=~"LIST|GET"}[3m]))) / sum by(resource, verb) (rate(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}[3m]))`),
 				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency"},
@@ -888,9 +808,229 @@ func TestObjective_Burnrates(t *testing.T) {
 		},
 	}}
 
+	require.Len(t, testcases, 14)
+
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			group, err := tc.slo.Burnrates()
+			require.NoError(t, err)
+			require.Equal(t, tc.rules, group)
+		})
+	}
+}
+
+func TestObjective_IncreaseRules(t *testing.T) {
+	testcases := []struct {
+		name  string
+		slo   Objective
+		rules monitoringv1.RuleGroup
+	}{{
+		name: "http-ratio",
+		slo:  objectiveHTTPRatio(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-errors-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "http_requests:increase4w",
+				Expr:   intstr.FromString(`sum by(code) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}},
+		},
+	}, {
+		name: "http-ratio-grouping",
+		slo:  objectiveHTTPRatioGrouping(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-errors-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "http_requests:increase4w",
+				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`),
+				Labels: map[string]string{"slo": "monitoring-http-errors"},
+			}},
+		},
+	}, {
+		name: "http-ratio-grouping-regex",
+		slo:  objectiveHTTPRatioGroupingRegex(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-errors-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "http_requests:increase4w",
+				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_requests_total{handler=~"/api.*",job="thanos-receive-default"}[4w]))`),
+				Labels: map[string]string{"slo": "monitoring-http-errors"},
+			}},
+		},
+	}, {
+		name: "grpc-errors",
+		slo:  objectiveGRPCRatio(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-grpc-errors-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "grpc_server_handled:increase4w",
+				Expr:   intstr.FromString(`sum by(grpc_code) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`),
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
+			}},
+		},
+	}, {
+		name: "grpc-errors-grouping",
+		slo:  objectiveGRPCRatioGrouping(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-grpc-errors-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "grpc_server_handled:increase4w",
+				Expr:   intstr.FromString(`sum by(grpc_code, handler, job) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`),
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "slo": "monitoring-grpc-errors"},
+			}},
+		},
+	}, {
+		name: "http-latency",
+		slo:  objectiveHTTPLatency(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-latency-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "http_request_duration_seconds:increase4w",
+				Expr:   intstr.FromString(`sum by(code) (increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w]))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:increase4w",
+				Expr:   intstr.FromString(`sum by(code) (increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]))`),
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "le": "1"},
+			}},
+		},
+	}, {
+		name: "http-latency-grouping",
+		slo:  objectiveHTTPLatencyGrouping(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-latency-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "http_request_duration_seconds:increase4w",
+				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w]))`),
+				Labels: map[string]string{"slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:increase4w",
+				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]))`),
+				Labels: map[string]string{"slo": "monitoring-http-latency", "le": "1"},
+			}},
+		},
+	}, {
+		name: "http-latency-grouping-regex",
+		slo:  objectiveHTTPLatencyGroupingRegex(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-latency-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "http_request_duration_seconds:increase4w",
+				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_count{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default"}[4w]))`),
+				Labels: map[string]string{"slo": "monitoring-http-latency"},
+			}, {
+				Record: "http_request_duration_seconds:increase4w",
+				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_bucket{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default",le="1"}[4w]))`),
+				Labels: map[string]string{"slo": "monitoring-http-latency", "le": "1"},
+			}},
+		},
+	}, {
+		name: "grpc-latency",
+		slo:  objectiveGRPCLatency(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-grpc-latency-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "grpc_server_handling_seconds:increase1w",
+				Expr:   intstr.FromString(`sum(increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w]))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
+			}, {
+				Record: "grpc_server_handling_seconds:increase1w",
+				Expr:   intstr.FromString(`sum(increase(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1w]))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "le": "0.6"},
+			}},
+		},
+	}, {
+		name: "grpc-latency-grouping",
+		slo:  objectiveGRPCLatencyGrouping(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-grpc-latency-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "grpc_server_handling_seconds:increase1w",
+				Expr:   intstr.FromString(`sum by(handler, job) (increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w]))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore"},
+			}, {
+				Record: "grpc_server_handling_seconds:increase1w",
+				Expr:   intstr.FromString(`sum by(handler, job) (increase(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1w]))`),
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "le": "0.6"},
+			}},
+		},
+	}, {
+		name: "operator-ratio",
+		slo:  objectiveOperator(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-prometheus-operator-errors-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "prometheus_operator_reconcile_operations:increase2w",
+				Expr:   intstr.FromString(`sum(increase(prometheus_operator_reconcile_operations_total[2w]))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Record: "prometheus_operator_reconcile_errors:increase2w",
+				Expr:   intstr.FromString(`sum(increase(prometheus_operator_reconcile_errors_total[2w]))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}},
+		},
+	}, {
+		name: "operator-ratio-grouping",
+		slo:  objectiveOperatorGrouping(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-prometheus-operator-errors-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "prometheus_operator_reconcile_operations:increase2w",
+				Expr:   intstr.FromString(`sum by(namespace) (increase(prometheus_operator_reconcile_operations_total[2w]))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Record: "prometheus_operator_reconcile_errors:increase2w",
+				Expr:   intstr.FromString(`sum by(namespace) (increase(prometheus_operator_reconcile_errors_total[2w]))`),
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}},
+		},
+	}, {
+		name: "apiserver-write-response-errors",
+		slo:  objectiveAPIServerRatio(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "apiserver-write-response-errors-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "apiserver_request:increase2w",
+				Expr:   intstr.FromString(`sum by(code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2w]))`),
+				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-write-response-errors"},
+			}},
+		},
+	}, {
+		name: "apiserver-read-resource-latency",
+		slo:  objectiveAPIServerLatency(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "apiserver-read-resource-latency-increase",
+			Interval: "30s",
+			Rules: []monitoringv1.Rule{{
+				Record: "apiserver_request_duration_seconds:increase2w",
+				Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),
+				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency"},
+			}, {
+				Record: "apiserver_request_duration_seconds:increase2w",
+				Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_bucket{job="apiserver",le="0.1",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),
+				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency", "le": "0.1"},
+			}},
+		},
+	}}
+
+	require.Len(t, testcases, 14)
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			group, err := tc.slo.IncreaseRules()
 			require.NoError(t, err)
 			require.Equal(t, tc.rules, group)
 		})

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -749,14 +749,6 @@ func TestObjective_Burnrates(t *testing.T) {
 			Name:     "apiserver-read-resource-latency",
 			Interval: "30s",
 			Rules: []monitoringv1.Rule{{
-				//	Record: "apiserver_request_duration_seconds:increase2w",
-				//	Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),
-				//	Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency"},
-				//}, {
-				//	Record: "apiserver_request_duration_seconds:increase2w",
-				//	Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_bucket{job="apiserver",le="0.1",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),
-				//	Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency", "le": "0.1"},
-				//}, {
 				Record: "apiserver_request_duration_seconds:burnrate3m",
 				Expr:   intstr.FromString(`(sum by(resource, verb) (rate(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}[3m])) - sum by(resource, verb) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",le="0.1",resource=~"resource|",verb=~"LIST|GET"}[3m]))) / sum by(resource, verb) (rate(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}[3m]))`),
 				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency"},
@@ -829,7 +821,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveHTTPRatio(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-errors-increase",
-			Interval: "30s",
+			Interval: "2m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "http_requests:increase4w",
 				Expr:   intstr.FromString(`sum by(code) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`),
@@ -841,7 +833,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveHTTPRatioGrouping(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-errors-increase",
-			Interval: "30s",
+			Interval: "2m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "http_requests:increase4w",
 				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`),
@@ -853,7 +845,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveHTTPRatioGroupingRegex(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-errors-increase",
-			Interval: "30s",
+			Interval: "2m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "http_requests:increase4w",
 				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_requests_total{handler=~"/api.*",job="thanos-receive-default"}[4w]))`),
@@ -865,7 +857,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveGRPCRatio(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-grpc-errors-increase",
-			Interval: "30s",
+			Interval: "2m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "grpc_server_handled:increase4w",
 				Expr:   intstr.FromString(`sum by(grpc_code) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`),
@@ -877,7 +869,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveGRPCRatioGrouping(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-grpc-errors-increase",
-			Interval: "30s",
+			Interval: "2m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "grpc_server_handled:increase4w",
 				Expr:   intstr.FromString(`sum by(grpc_code, handler, job) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`),
@@ -889,7 +881,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveHTTPLatency(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-latency-increase",
-			Interval: "30s",
+			Interval: "2m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "http_request_duration_seconds:increase4w",
 				Expr:   intstr.FromString(`sum by(code) (increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w]))`),
@@ -905,7 +897,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveHTTPLatencyGrouping(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-latency-increase",
-			Interval: "30s",
+			Interval: "2m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "http_request_duration_seconds:increase4w",
 				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}[4w]))`),
@@ -921,7 +913,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveHTTPLatencyGroupingRegex(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-http-latency-increase",
-			Interval: "30s",
+			Interval: "2m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "http_request_duration_seconds:increase4w",
 				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_count{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default"}[4w]))`),
@@ -937,7 +929,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveGRPCLatency(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-grpc-latency-increase",
-			Interval: "30s",
+			Interval: "1m",
 			Rules: []monitoringv1.Rule{{
 				Record: "grpc_server_handling_seconds:increase1w",
 				Expr:   intstr.FromString(`sum(increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w]))`),
@@ -953,7 +945,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveGRPCLatencyGrouping(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-grpc-latency-increase",
-			Interval: "30s",
+			Interval: "1m",
 			Rules: []monitoringv1.Rule{{
 				Record: "grpc_server_handling_seconds:increase1w",
 				Expr:   intstr.FromString(`sum by(handler, job) (increase(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[1w]))`),
@@ -969,7 +961,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveOperator(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-prometheus-operator-errors-increase",
-			Interval: "30s",
+			Interval: "1m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "prometheus_operator_reconcile_operations:increase2w",
 				Expr:   intstr.FromString(`sum(increase(prometheus_operator_reconcile_operations_total[2w]))`),
@@ -985,7 +977,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveOperatorGrouping(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "monitoring-prometheus-operator-errors-increase",
-			Interval: "30s",
+			Interval: "1m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "prometheus_operator_reconcile_operations:increase2w",
 				Expr:   intstr.FromString(`sum by(namespace) (increase(prometheus_operator_reconcile_operations_total[2w]))`),
@@ -1001,7 +993,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveAPIServerRatio(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "apiserver-write-response-errors-increase",
-			Interval: "30s",
+			Interval: "1m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "apiserver_request:increase2w",
 				Expr:   intstr.FromString(`sum by(code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2w]))`),
@@ -1013,7 +1005,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		slo:  objectiveAPIServerLatency(),
 		rules: monitoringv1.RuleGroup{
 			Name:     "apiserver-read-resource-latency-increase",
-			Interval: "30s",
+			Interval: "1m30s",
 			Rules: []monitoringv1.Rule{{
 				Record: "apiserver_request_duration_seconds:increase2w",
 				Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),


### PR DESCRIPTION
This should especially make a difference on Prometheus CPU load.
Rather than evaluating these `increase(...[4w])` every 30s we relax this interval depending on how long the SLO's time window is, such that within e.g. 2m over the 4w not toooo much will change.