### PR TITLE
config/crd/bases: Generate YAML and JSON CRD files

### DIFF
--- a/config/crd/bases/pyrra.dev_servicelevelobjectives.json
+++ b/config/crd/bases/pyrra.dev_servicelevelobjectives.json
@@ -1,0 +1,173 @@
+{
+  "apiVersion": "apiextensions.k8s.io/v1",
+  "kind": "CustomResourceDefinition",
+  "metadata": {
+    "annotations": {
+      "controller-gen.kubebuilder.io/version": "v0.8.0"
+    },
+    "creationTimestamp": null,
+    "name": "servicelevelobjectives.pyrra.dev"
+  },
+  "spec": {
+    "group": "pyrra.dev",
+    "names": {
+      "kind": "ServiceLevelObjective",
+      "listKind": "ServiceLevelObjectiveList",
+      "plural": "servicelevelobjectives",
+      "shortNames": [
+        "slo"
+      ],
+      "singular": "servicelevelobjective"
+    },
+    "scope": "Namespaced",
+    "versions": [
+      {
+        "name": "v1alpha1",
+        "schema": {
+          "openAPIV3Schema": {
+            "description": "ServiceLevelObjective is the Schema for the ServiceLevelObjectives API.",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "metadata": {
+                "type": "object"
+              },
+              "spec": {
+                "description": "ServiceLevelObjectiveSpec defines the desired state of ServiceLevelObjective.",
+                "properties": {
+                  "description": {
+                    "description": "Description describes the ServiceLevelObjective in more detail and gives extra context for engineers that might not directly work on the service.",
+                    "type": "string"
+                  },
+                  "indicator": {
+                    "description": "ServiceLevelIndicator is the underlying data source that indicates how the service is doing. This will be a Prometheus metric with specific selectors for your service.",
+                    "properties": {
+                      "latency": {
+                        "description": "Latency is the indicator that measures a certain percentage to be fast than.",
+                        "properties": {
+                          "grouping": {
+                            "description": "Grouping allows an SLO to be defined for many SLI at once, like HTTP handlers for example.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "success": {
+                            "description": "Success is the metric that returns how many errors there are.",
+                            "properties": {
+                              "metric": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "metric"
+                            ],
+                            "type": "object"
+                          },
+                          "total": {
+                            "description": "Total is the metric that returns how many requests there are in total.",
+                            "properties": {
+                              "metric": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "metric"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "success",
+                          "total"
+                        ],
+                        "type": "object"
+                      },
+                      "ratio": {
+                        "description": "Ratio is the indicator that measures against errors / total events.",
+                        "properties": {
+                          "errors": {
+                            "description": "Errors is the metric that returns how many errors there are.",
+                            "properties": {
+                              "metric": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "metric"
+                            ],
+                            "type": "object"
+                          },
+                          "grouping": {
+                            "description": "Grouping allows an SLO to be defined for many SLI at once, like HTTP handlers for example.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "total": {
+                            "description": "Total is the metric that returns how many requests there are in total.",
+                            "properties": {
+                              "metric": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "metric"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "errors",
+                          "total"
+                        ],
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "target": {
+                    "description": "Target is a string that's casted to a float64 between 0 - 100. It represents the desired availability of the service in the given window. float64 are not supported: https://github.com/kubernetes-sigs/controller-tools/issues/245",
+                    "type": "string"
+                  },
+                  "window": {
+                    "description": "Window within which the Target is supposed to be kept. Usually something like 1d, 7d or 28d.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "indicator",
+                  "target",
+                  "window"
+                ],
+                "type": "object"
+              },
+              "status": {
+                "description": "ServiceLevelObjectiveStatus defines the observed state of ServiceLevelObjective.",
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "served": true,
+        "storage": true
+      }
+    ]
+  },
+  "status": {
+    "acceptedNames": {
+      "kind": "",
+      "plural": ""
+    },
+    "conditions": [],
+    "storedVersions": []
+  }
+}

--- a/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
+++ b/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
@@ -21,7 +21,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: ServiceLevelObjective is the Schema for the ServiceLevelObjectives
-          API
+          API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -36,7 +36,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServiceLevelObjectiveSpec defines the desired state of ServiceLevelObjective
+            description: ServiceLevelObjectiveSpec defines the desired state of ServiceLevelObjective.
             properties:
               description:
                 description: Description describes the ServiceLevelObjective in more
@@ -129,7 +129,7 @@ spec:
             type: object
           status:
             description: ServiceLevelObjectiveStatus defines the observed state of
-              ServiceLevelObjective
+              ServiceLevelObjective.
             type: object
         type: object
     served: true

--- a/kubernetes/controllers/servicelevelobjective_test.go
+++ b/kubernetes/controllers/servicelevelobjective_test.go
@@ -3,11 +3,9 @@ package controllers
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +27,7 @@ var (
 		},
 		Spec: pyrrav1alpha1.ServiceLevelObjectiveSpec{
 			Target: "99.5",
-			Window: model.Duration(28 * 24 * time.Hour),
+			Window: "28d",
 			ServiceLevelIndicator: pyrrav1alpha1.ServiceLevelIndicator{
 				Ratio: &pyrrav1alpha1.RatioIndicator{
 					Errors: pyrrav1alpha1.Query{

--- a/kubernetes_test.go
+++ b/kubernetes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,7 @@ var (
 			Name:      "objective-one",
 			Namespace: "default",
 		},
-		Spec: pyrrav1alpha1.ServiceLevelObjectiveSpec{Target: "99"},
+		Spec: pyrrav1alpha1.ServiceLevelObjectiveSpec{Target: "99", Window: "1w"},
 	}
 	c1, _ = yaml.Marshal(o1)
 	i1    = openapiserver.Objective{
@@ -30,6 +31,7 @@ var (
 			"namespace":       "default",
 		},
 		Target: 0.99,
+		Window: (1 * 7 * 24 * time.Hour).Milliseconds(),
 		Config: string(c1),
 	}
 	o2 = pyrrav1alpha1.ServiceLevelObjective{
@@ -37,7 +39,7 @@ var (
 			Name:      "objective-two",
 			Namespace: "monitoring",
 		},
-		Spec: pyrrav1alpha1.ServiceLevelObjectiveSpec{Target: "98"},
+		Spec: pyrrav1alpha1.ServiceLevelObjectiveSpec{Target: "98", Window: "2w"},
 	}
 	c2, _ = yaml.Marshal(o2)
 	i2    = openapiserver.Objective{
@@ -46,6 +48,7 @@ var (
 			"namespace":       "monitoring",
 		},
 		Target: 0.98,
+		Window: (2 * 7 * 24 * time.Hour).Milliseconds(),
 		Config: string(c2),
 	}
 	o3 = pyrrav1alpha1.ServiceLevelObjective{
@@ -53,7 +56,7 @@ var (
 			Name:      "objective-three",
 			Namespace: "default",
 		},
-		Spec: pyrrav1alpha1.ServiceLevelObjectiveSpec{Target: "42.123"},
+		Spec: pyrrav1alpha1.ServiceLevelObjectiveSpec{Target: "42.123", Window: "3w"},
 	}
 	c3, _ = yaml.Marshal(o3)
 	i3    = openapiserver.Objective{
@@ -62,6 +65,7 @@ var (
 			"namespace":       "default",
 		},
 		Target: 0.42123,
+		Window: (3 * 7 * 24 * time.Hour).Milliseconds(),
 		Config: string(c3),
 	}
 )


### PR DESCRIPTION
Add a gojsontoyaml converted for converting the YAML CRD to JSON and thus it's easier to be consumed in jsonnet.

The type change in the CRD from `model.Duration` to `string` was logical, as I've always overwritten the changes after generation... No CRD needs updating because of this.