### PR TITLE
ui: Fix paddings of components after bootstrap update

### DIFF
--- a/ui/src/components/graphs/ErrorsGraph.tsx
+++ b/ui/src/components/graphs/ErrorsGraph.tsx
@@ -102,6 +102,7 @@ const ErrorsGraph = ({ api, labels, grouping, timeRange, uPlotCursor }: ErrorsGr
           <UplotReact options={{
             width: width,
             height: 150,
+            padding: [15, 0, 0, 0],
             cursor: uPlotCursor,
             series: [{}, ...errorsLabels.map((label: string, i: number): uPlot.Series => {
               return {
@@ -128,6 +129,7 @@ const ErrorsGraph = ({ api, labels, grouping, timeRange, uPlotCursor }: ErrorsGr
           <UplotReact options={{
             width: width,
             height: 150,
+            padding: [15, 0, 0, 0],
             series: [{}, {}],
             scales: {
               x: { min: start, max: end },

--- a/ui/src/components/graphs/RequestsGraph.tsx
+++ b/ui/src/components/graphs/RequestsGraph.tsx
@@ -105,6 +105,7 @@ const RequestsGraph = ({ api, labels, grouping, timeRange, uPlotCursor }: Reques
           <UplotReact options={{
             width: width,
             height: 150,
+            padding: [15, 0, 0, 0],
             cursor: uPlotCursor,
             series: [{}, ...requestsLabels.map((label: string): uPlot.Series => {
               return {
@@ -127,6 +128,7 @@ const RequestsGraph = ({ api, labels, grouping, timeRange, uPlotCursor }: Reques
           <UplotReact options={{
             width: width,
             height: 150,
+            padding: [15, 0, 0, 0],
             series: [{}, {}],
             scales: {
               x: { min: start, max: end },

--- a/ui/src/pages/Detail.scss
+++ b/ui/src/pages/Detail.scss
@@ -6,7 +6,7 @@
   .metrics {
     width: 100%;
     display: grid;
-    margin: 0 15px;
+    padding: 0 15px;
     grid-template-columns: repeat(1, 1fr);
     column-gap: 25px;
     row-gap: 25px;
@@ -23,7 +23,7 @@
       row-gap: 75px;
     }
     @media (min-width: 1200px) {
-      margin: 0 75px;
+      padding: 0 75px;
     }
 
     div {


### PR DESCRIPTION
Some components were slightly offset and not centered anymore. This fixes that.