### PR TITLE
CI: Push docker image only if same repository

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -38,6 +38,6 @@ jobs:
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
-          push: true
+          push: ${{ github.repository == 'pyrra-dev/pyrra'}}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
In the hopes that if we have a branch in this repository we'll still get docker images that can be tried. However, exclude PRs that are coming from outside forks as they might be potentially harmful and we don't want to push them to our registry just like that.