### PR TITLE
Expose the Window struct

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44
+          version: v1.45

--- a/slo/rules.go
+++ b/slo/rules.go
@@ -27,7 +27,7 @@ type MultiBurnRateAlert struct {
 
 func (o Objective) Alerts() ([]MultiBurnRateAlert, error) {
 	sloName := o.Labels.Get(labels.MetricName)
-	ws := windows(time.Duration(o.Window))
+	ws := Windows(time.Duration(o.Window))
 
 	var (
 		metric         string
@@ -85,7 +85,7 @@ func (o Objective) Alerts() ([]MultiBurnRateAlert, error) {
 func (o Objective) Burnrates() (monitoringv1.RuleGroup, error) {
 	sloName := o.Labels.Get(labels.MetricName)
 
-	ws := windows(time.Duration(o.Window))
+	ws := Windows(time.Duration(o.Window))
 	burnrates := burnratesFromWindows(ws)
 	rules := make([]monitoringv1.Rule, 0, len(burnrates))
 
@@ -540,7 +540,7 @@ const (
 	warning  severity = "warning"
 )
 
-type window struct {
+type Window struct {
 	Severity severity
 	For      time.Duration
 	Long     time.Duration
@@ -548,13 +548,13 @@ type window struct {
 	Factor   float64
 }
 
-func windows(sloWindow time.Duration) []window {
+func Windows(sloWindow time.Duration) []Window {
 	// TODO: I'm still not sure if For, Long, Short should really be based on the 28 days ratio...
 
 	round := time.Minute // TODO: Change based on sloWindow
 
 	// long and short rates are calculated based on the ratio for 28 days.
-	return []window{{
+	return []Window{{
 		Severity: critical,
 		For:      (sloWindow / (28 * 24 * (60 / 2))).Round(round), // 2m for 28d - half short
 		Long:     (sloWindow / (28 * 24)).Round(round),            // 1h for 28d
@@ -581,7 +581,7 @@ func windows(sloWindow time.Duration) []window {
 	}}
 }
 
-func burnratesFromWindows(ws []window) []time.Duration {
+func burnratesFromWindows(ws []Window) []time.Duration {
 	dedup := map[time.Duration]bool{}
 	for _, w := range ws {
 		dedup[w.Long] = true

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -1030,9 +1030,9 @@ func TestObjective_IncreaseRules(t *testing.T) {
 }
 
 func Test_windows(t *testing.T) {
-	ws := windows(28 * 24 * time.Hour)
+	ws := Windows(28 * 24 * time.Hour)
 
-	require.Equal(t, window{
+	require.Equal(t, Window{
 		Severity: critical,
 		For:      2 * time.Minute,
 		Long:     1 * time.Hour,
@@ -1040,7 +1040,7 @@ func Test_windows(t *testing.T) {
 		Factor:   14,
 	}, ws[0])
 
-	require.Equal(t, window{
+	require.Equal(t, Window{
 		Severity: critical,
 		For:      15 * time.Minute,
 		Long:     6 * time.Hour,
@@ -1048,7 +1048,7 @@ func Test_windows(t *testing.T) {
 		Factor:   7,
 	}, ws[1])
 
-	require.Equal(t, window{
+	require.Equal(t, Window{
 		Severity: warning,
 		For:      time.Hour,
 		Long:     24 * time.Hour,
@@ -1056,7 +1056,7 @@ func Test_windows(t *testing.T) {
 		Factor:   2,
 	}, ws[2])
 
-	require.Equal(t, window{
+	require.Equal(t, Window{
 		Severity: warning,
 		For:      3 * time.Hour,
 		Long:     4 * 24 * time.Hour,

--- a/slo/slo.go
+++ b/slo/slo.go
@@ -27,18 +27,18 @@ func (o Objective) Name() string {
 	return ""
 }
 
-func (o Objective) Windows() []window {
-	return windows(time.Duration(o.Window))
+func (o Objective) Windows() []Window {
+	return Windows(time.Duration(o.Window))
 }
 
-func (o Objective) HasWindows(short, long model.Duration) (window, bool) {
-	for _, w := range windows(time.Duration(o.Window)) {
+func (o Objective) HasWindows(short, long model.Duration) (Window, bool) {
+	for _, w := range Windows(time.Duration(o.Window)) {
 		if w.Short == time.Duration(short) && w.Long == time.Duration(long) {
 			return w, true
 		}
 	}
 
-	return window{}, false
+	return Window{}, false
 }
 
 type Indicator struct {


### PR DESCRIPTION
This should fix golangci-lint again so that we can rebase all dependabot PRs and merge them in.