### PR TITLE
feat(examples): add OpenShift examples and readme

### DIFF
--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -1,0 +1,104 @@
+# Pyrra OpenShift Example
+
+This example walks you through the setup of Pyrra on OpenShift. Please keep 
+in mind that doing anything in OpenShift's core namespaces voids support. If 
+you want to deploy Pyrra in a production environment, you need to move the 
+deployment to a different namespace.
+
+## OpenShift vs Kubernetes
+While OpenShift has Kubernetes at its core, there are some significant 
+differences. Those get especially obvious when trying to work with 
+prometheus-operator: OpenShift comes with its own built-in monitoring stack 
+out of the box. Said stack is based on kube-prometheus but has some 
+modifications and additions.
+
+### Certificates
+The most important changes to a regular installation of Pyrra on Kubernetes are 
+that all OpenShift built-in services are tls secured. However, if you didn't 
+change anything, those are secured with self-signed certificates.
+
+### Authentication
+The Second key difference is the requirement for authentication: Every 
+built-in component that's in any way exposed, is secured via an Oauth-proxy 
+that is making use of OpenShift's authentication methods. This is generally 
+great because you don't have to worry about hardening the exposed part but 
+in this case, where we want to hook Pyrra to the built-in monitoring stack, 
+that means we need to make sure that Pyrra authenticates accordingly.
+
+## Prerequisites
+
+You need an OpenShift cluster. It generally doesn't matter where it loves 
+but for the ease of use we will use a 
+[Code Ready Containers](https://crc.dev/crc/) cluster.\
+Follow the 
+[documentation](https://crc.dev/crc/#installing-codeready-containers_gsg) to 
+install CrC on your platform. After tha is done you can run the following 
+command to get the command to log in as `kubeadmin`:
+
+```shell
+crc console --credentials
+```
+
+You can verify that you are logged in, and it's working as expected by 
+running the following command which you return `kubeadmin`:
+
+```shell
+$ oc whoami
+kubeadmin
+```
+
+## Deploying Pyrra
+
+Check out this repository and enter the directory like so:
+
+```shell
+https://github.com/pyrra-dev/pyrra.git
+cd pyrra 
+```
+
+As mention in the [Authentication](#authentication) section, Pyrra needs to 
+be able to authenticate against OpenShift. In order to do that, you need to 
+create a ServiceAccount and get its bearer token. Instead of manually 
+getting a serviceAccountToken, we just use
+[projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes/#serviceaccounttoken)
+to automount the token into the pod and be able to use it. This holds the 
+big advantage of automatically rotated tokens and also the token never has 
+to leave the cluster. In order to deploy Pyrra including the serviceAccount, 
+you can run the following commands:
+
+```shell
+oc apply -f examples/openshift/deploy/openshift.yaml
+oc apply -f examples/openshift/deploy/role.yaml
+oc apply -f examples/openshift/deploy/api.yaml
+```
+
+If you want to access Pyrra, you can leverage OpenShift's router and create 
+a route with the following command:
+
+```shell
+oc expose service pyrra-api -n openshift-monitoring
+```
+
+This command will return the URL to for you to access Pyrra. In case you 
+missed it, you can always find it out later with the following command:
+
+```shell
+oc get route pyrra-api -n openshift-monitoring
+```
+
+## Deploying SLO Examples
+
+The following command will deploy an example set of SLOs targeting the 
+availability of the API-Server using errors as Service Level Indicator:
+
+```shell
+oc apply -f examples/openshift/slos/apiserver-request-errors.yaml
+```
+
+## Using Pyrra
+
+Maneuver to URL that you get from the following command:
+
+```shell
+oc get route pyrra-api -n openshift-monitoring
+```

--- a/examples/openshift/deploy/api.yaml
+++ b/examples/openshift/deploy/api.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/name: pyrra-api
+  name: pyrra-api
+  namespace: openshift-monitoring
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyrra-api
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pyrra-api
+    spec:
+      containers:
+        - args:
+            - api
+            - --prometheus-url=https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091
+            - --api-url=http://pyrra-kubernetes.openshift-monitoring.svc.cluster.local:9444
+            - --prometheus-bearer-token-path=/var/run/secrets/tokens/pyrra-kubernetes
+          image: ghcr.io/pyrra-dev/pyrra:v0.3.4
+          imagePullPolicy: IfNotPresent
+          name: pyrra-api
+          ports:
+            - containerPort: 9099
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 30Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/run/secrets/tokens
+              name: pyrra-sa-token
+              readOnly: true
+            - mountPath: /etc/ssl/certs
+              name: trusted-ca
+              readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      serviceAccountName: pyrra-kubernetes
+      volumes:
+        - name: pyrra-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: pyrra-kubernetes
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: service-ca.crt
+                path: service-ca.crt
+            name: openshift-service-ca.crt
+          name: trusted-ca

--- a/examples/openshift/deploy/openshift.yaml
+++ b/examples/openshift/deploy/openshift.yaml
@@ -1,0 +1,80 @@
+metadata:
+  name: pyrra-kubernetes
+  namespace: openshift-monitoring
+  labels:
+    app.kubernetes.io/name: pyrra-kubernetes
+spec:
+  ports:
+  - name: internal
+    port: 9443
+  - name: api
+    port: 9444
+  selector:
+    app.kubernetes.io/name: pyrra-kubernetes
+kind: Service
+apiVersion: v1
+---
+metadata:
+  name: pyrra-kubernetes
+  namespace: openshift-monitoring
+  labels:
+    app.kubernetes.io/name: pyrra-kubernetes
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyrra-kubernetes
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pyrra-kubernetes
+    spec:
+      serviceAccountName: pyrra-kubernetes
+      containers:
+      - args:
+        - kubernetes
+        image: ghcr.io/pyrra-dev/pyrra:v0.3.4
+        name: pyrra-kubernetes
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+kind: Deployment
+apiVersion: apps/v1
+---
+metadata:
+  name: pyrra-kubernetes
+  namespace: openshift-monitoring
+kind: ServiceAccount
+apiVersion: v1
+---
+metadata:
+  name: pyrra-kubernetes
+  namespace: openshift-monitoring
+subjects:
+- kind: ServiceAccount
+  name: pyrra-kubernetes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pyrra-kubernetes
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: pyrra-kubernetes
+    namespace: openshift-monitoring
+

--- a/examples/openshift/deploy/pyrra.dev_servicelevelobjectives.yaml
+++ b/examples/openshift/deploy/pyrra.dev_servicelevelobjectives.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  name: servicelevelobjectives.pyrra.dev
+spec:
+  group: pyrra.dev
+  names:
+    kind: ServiceLevelObjective
+    listKind: ServiceLevelObjectiveList
+    plural: servicelevelobjectives
+    shortNames:
+    - slo
+    singular: servicelevelobjective
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceLevelObjective is the Schema for the ServiceLevelObjectives
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceLevelObjectiveSpec defines the desired state of ServiceLevelObjective.
+            properties:
+              description:
+                description: Description describes the ServiceLevelObjective in more
+                  detail and gives extra context for engineers that might not directly
+                  work on the service.
+                type: string
+              indicator:
+                description: ServiceLevelIndicator is the underlying data source that
+                  indicates how the service is doing. This will be a Prometheus metric
+                  with specific selectors for your service.
+                properties:
+                  latency:
+                    description: Latency is the indicator that measures a certain
+                      percentage to be fast than.
+                    properties:
+                      grouping:
+                        description: Grouping allows an SLO to be defined for many
+                          SLI at once, like HTTP handlers for example.
+                        items:
+                          type: string
+                        type: array
+                      success:
+                        description: Success is the metric that returns how many errors
+                          there are.
+                        properties:
+                          metric:
+                            type: string
+                        required:
+                        - metric
+                        type: object
+                      total:
+                        description: Total is the metric that returns how many requests
+                          there are in total.
+                        properties:
+                          metric:
+                            type: string
+                        required:
+                        - metric
+                        type: object
+                    required:
+                    - success
+                    - total
+                    type: object
+                  ratio:
+                    description: Ratio is the indicator that measures against errors
+                      / total events.
+                    properties:
+                      errors:
+                        description: Errors is the metric that returns how many errors
+                          there are.
+                        properties:
+                          metric:
+                            type: string
+                        required:
+                        - metric
+                        type: object
+                      grouping:
+                        description: Grouping allows an SLO to be defined for many
+                          SLI at once, like HTTP handlers for example.
+                        items:
+                          type: string
+                        type: array
+                      total:
+                        description: Total is the metric that returns how many requests
+                          there are in total.
+                        properties:
+                          metric:
+                            type: string
+                        required:
+                        - metric
+                        type: object
+                    required:
+                    - errors
+                    - total
+                    type: object
+                type: object
+              target:
+                description: 'Target is a string that''s casted to a float64 between
+                  0 - 100. It represents the desired availability of the service in
+                  the given window. float64 are not supported: https://github.com/kubernetes-sigs/controller-tools/issues/245'
+                type: string
+              window:
+                description: Window within which the Target is supposed to be kept.
+                  Usually something like 1d, 7d or 28d.
+                type: string
+            required:
+            - indicator
+            - target
+            - window
+            type: object
+          status:
+            description: ServiceLevelObjectiveStatus defines the observed state of
+              ServiceLevelObjective.
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/examples/openshift/deploy/role.yaml
+++ b/examples/openshift/deploy/role.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pyrra-kubernetes
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules/status
+  verbs:
+  - get
+- apiGroups:
+  - pyrra.dev
+  resources:
+  - servicelevelobjectives
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - pyrra.dev
+  resources:
+  - servicelevelobjectives/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+  - patch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list

--- a/examples/openshift/slos/apiserver-request-errors.yaml
+++ b/examples/openshift/slos/apiserver-request-errors.yaml
@@ -1,0 +1,37 @@
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: apiserver-read-response-errors
+  namespace: openshift-monitoring
+spec:
+  description: ""
+  indicator:
+    ratio:
+      errors:
+        metric: apiserver_request_total{job="apiserver",verb=~"LIST|GET",code=~"5.."}
+      total:
+        metric: apiserver_request_total{job="apiserver",verb=~"LIST|GET"}
+  target: "99.99"
+  window: 2w
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: apiserver-write-response-errors
+  namespace: openshift-monitoring
+spec:
+  description: ""
+  indicator:
+    ratio:
+      errors:
+        metric: apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}
+      total:
+        metric: apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}
+  target: "99"
+  window: 1w


### PR DESCRIPTION
Signed-off-by: Rick Rackow <rick.rackow@gmail.com>

Since OpenShift has some different behavior especially around connecting to built-in services, it makes sense to have a separate Readme for it with examples adjusted to work on OpenShift. This PR adds exactly that: A readme and all files to deploy a running Pyrra on Openshift

cc @vrutkovs 