### PR TITLE
.github: build container images for arm64

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -38,6 +38,7 @@ jobs:
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.repository == 'pyrra-dev/pyrra'}}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
As in title.

Spawned from https://github.com/prometheus-operator/kube-prometheus/pull/1720#pullrequestreview-937273045

I am not 100% sure this will work as I am not familiar with the toolchain used in the repository. However, according to https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md this should do something :) 