### PR TITLE
Propagate k8s labels prefixed with pyrra.dev/ to RuleGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
+    pyrra.dev/team: operations  # Any labels prefixed with 'pyrra.dev/' will be propagated as Prometheus labels, while stripping the prefix.
 spec:
   target: '99'
   window: 2w

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -228,13 +229,18 @@ func (in ServiceLevelObjective) Internal() (slo.Objective, error) {
 		return slo.Objective{}, fmt.Errorf("failed to marshal resource as config")
 	}
 
-	ls := labels.Labels{{
-		Name: labels.MetricName, Value: in.GetName(),
-	}}
+	ls := labels.Labels{{Name: labels.MetricName, Value: in.GetName()}}
+
 	if in.GetNamespace() != "" {
 		ls = append(ls, labels.Label{
 			Name: "namespace", Value: in.GetNamespace(),
 		})
+	}
+
+	for name, value := range in.GetLabels() {
+		if strings.HasPrefix(name, slo.PropagationLabelsPrefix) {
+			ls = append(ls, labels.Label{Name: name, Value: value})
+		}
 	}
 
 	return slo.Objective{

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
@@ -17,7 +17,8 @@ var examples = []struct {
 	config    string
 	objective slo.Objective
 }{
-	{config: `
+	{
+		config: `
 apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective
 metadata:
@@ -26,6 +27,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
+    pyrra.dev/team: foo
 spec:
   target: 99
   window: 1w
@@ -35,34 +37,38 @@ spec:
         metric: http_requests_total{job="metrics-service-thanos-receive-default",code=~"5.."}
       total:
         metric: http_requests_total{job="metrics-service-thanos-receive-default"}
-`, objective: slo.Objective{
-		Labels: labels.FromStrings(
-			labels.MetricName, "http-errors",
-			"namespace", "monitoring",
-		),
-		Description: "",
-		Target:      0.99,
-		Window:      model.Duration(7 * 24 * time.Hour),
-		Indicator: slo.Indicator{
-			Ratio: &slo.RatioIndicator{
-				Errors: slo.Metric{
-					Name: "http_requests_total",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
-						{Type: labels.MatchRegexp, Name: "code", Value: "5.."},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
+`,
+		objective: slo.Objective{
+			Labels: labels.FromStrings(
+				labels.MetricName, "http-errors",
+				"namespace", "monitoring",
+				"pyrra.dev/team", "foo",
+			),
+			Description: "",
+			Target:      0.99,
+			Window:      model.Duration(7 * 24 * time.Hour),
+			Indicator: slo.Indicator{
+				Ratio: &slo.RatioIndicator{
+					Errors: slo.Metric{
+						Name: "http_requests_total",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
+							{Type: labels.MatchRegexp, Name: "code", Value: "5.."},
+							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
+						},
 					},
-				},
-				Total: slo.Metric{
-					Name: "http_requests_total",
-					LabelMatchers: []*labels.Matcher{
-						{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
-						{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
+					Total: slo.Metric{
+						Name: "http_requests_total",
+						LabelMatchers: []*labels.Matcher{
+							{Type: labels.MatchEqual, Name: "job", Value: "metrics-service-thanos-receive-default"},
+							{Type: labels.MatchEqual, Name: labels.MetricName, Value: "http_requests_total"},
+						},
 					},
 				},
 			},
 		},
-	}}, {
+	},
+	{
 		config: `
 apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective
@@ -114,7 +120,8 @@ spec:
 				},
 			},
 		},
-	}, {
+	},
+	{
 		config: `
 apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective
@@ -163,7 +170,8 @@ spec:
 				},
 			},
 		},
-	}, {
+	},
+	{
 		config: `
 apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective
@@ -214,7 +222,8 @@ spec:
 				},
 			},
 		},
-	}, {
+	},
+	{
 		config: `
 apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective
@@ -264,7 +273,8 @@ spec:
 				},
 			},
 		},
-	}, {
+	},
+	{
 		config: `
 apiVersion: pyrra.dev/v1alpha1
 kind: ServiceLevelObjective

--- a/slo/rules.go
+++ b/slo/rules.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const PublicLabelsPrefix = "pyrra.dev/"
-
 type MultiBurnRateAlert struct {
 	Severity string
 	Short    time.Duration

--- a/slo/slo.go
+++ b/slo/slo.go
@@ -8,6 +8,10 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
+// PropagationLabelsPrefix provides a way to propagate labels from the
+// ObjectMeta to the PrometheusRule.
+const PropagationLabelsPrefix = "pyrra.dev/"
+
 type Objective struct {
 	Labels      labels.Labels
 	Description string


### PR DESCRIPTION
This MR propagates all lables prefixed with 'pyrra.dev/' to  the generated
rule groups, while stripping said prefix in the final label. This is so we can
still yaml.Marshal the RuleGroup and receive a label that complies with the
Prometheus data model.

It also adds some whitespace changes in the test files to make it easier for IDEs
to collapse individual tests.

Closes #157 