### PR TITLE
Fix label and grouping matching both in backend and UI

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -67,7 +67,17 @@ Objectives:
 				v = o.Labels.Get(slo.PropagationLabelsPrefix + m.Name)
 			}
 			if !m.Matches(v) {
-				continue Objectives
+				// If no label matches then maybe the objective is grouped by this label
+				var grouping bool
+				for _, g := range o.Grouping() {
+					if m.Name == g {
+						grouping = true
+					}
+				}
+				// If the label is not a grouping either then skip this objective
+				if !grouping {
+					continue Objectives
+				}
 			}
 		}
 		objectives = append(objectives, o)

--- a/filesystem.go
+++ b/filesystem.go
@@ -61,6 +61,11 @@ Objectives:
 	for _, o := range os.objectives {
 		for _, m := range ms {
 			v := o.Labels.Get(m.Name)
+			// If there's no label with this exact name,
+			// check if there are labels with the label prefix.
+			if v == "" {
+				v = o.Labels.Get(slo.PropagationLabelsPrefix + m.Name)
+			}
 			if !m.Matches(v) {
 				continue Objectives
 			}

--- a/slo/slo.go
+++ b/slo/slo.go
@@ -45,6 +45,16 @@ func (o Objective) HasWindows(short, long model.Duration) (Window, bool) {
 	return Window{}, false
 }
 
+func (o Objective) Grouping() []string {
+	if o.Indicator.Ratio != nil {
+		return o.Indicator.Ratio.Grouping
+	}
+	if o.Indicator.Latency != nil {
+		return o.Indicator.Latency.Grouping
+	}
+	return nil
+}
+
 type Indicator struct {
 	Ratio   *RatioIndicator
 	Latency *LatencyIndicator

--- a/ui/src/pages/Detail.scss
+++ b/ui/src/pages/Detail.scss
@@ -3,6 +3,12 @@
     margin-bottom: 100px;
   }
 
+  .header {
+    span.badge {
+      margin-right: 5px;
+    }
+  }
+
   .metrics {
     width: 100%;
     display: grid;

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -122,7 +122,7 @@ const Detail = () => {
       <>
         <Navbar/>
         <Container>
-          <div style={{ margin: '50px 0' }}>
+          <div className='header'>
             <h3>{objectiveError}</h3>
             <br/>
             <Link to="/" className="btn btn-light">
@@ -274,7 +274,7 @@ const Detail = () => {
       <div className="content detail">
         <Container>
           <Row>
-            <Col xs={12}>
+            <Col xs={12} className='header'>
               <h3>{name}</h3>
               {labelBadges}
             </Col>

--- a/ui/src/pages/List.scss
+++ b/ui/src/pages/List.scss
@@ -1,4 +1,20 @@
 .content.list {
+
+  button.filter-close {
+    margin-top: 20px;
+    margin-bottom: 20px;
+    margin-right: 10px;
+
+    span.btn-close {
+      display: inline-block;
+      width: 0.3em;
+      height: 0.3em;
+      margin-top: 0.3em;
+      margin-left: 0.3em;
+    }
+  }
+
+
   .table > :not(:first-child) {
     border-top-color: inherit;
   }

--- a/ui/src/pages/List.tsx
+++ b/ui/src/pages/List.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   Badge,
   Button,
-  CloseButton,
   Col,
   Container,
   OverlayTrigger,
@@ -556,10 +555,9 @@ const List = () => {
         <Row>
           <Col>
             {Object.keys(filterLabels).map((k: string) => (
-              <Button variant="light" size="sm" onClick={() => removeFilterLabel(k)}
-                      style={{ marginTop: 20, marginBottom: 20, marginRight: 10 }}>
+              <Button variant="light" size="sm" className='filter-close' onClick={() => removeFilterLabel(k)}>
                 {`${k}=${filterLabels[k]}`}
-                <CloseButton style={{ width: '0.5em', height: '0.5em', padding: '0.25em 0.5em' }}/>
+                <span className='btn-close'></span>
               </Button>
             ))}
             <Alert show={filterError} variant="danger">Your SLO filter is broken. Please reset the filter.</Alert>


### PR DESCRIPTION
First of all we strip `pyrra.dev/` from the labels now before they get send to the UI via the API.
This gets rid of the issue in #289. 

Second, we then need  to fix the matching of objectives to match for both `team=thanos` and `pyrra.dev/team=thanos`. If both don't exist we exclude the objective from the returned list.

Third, the UI and backend needed to support grouping labels, like `handler=/api/v1/query` that's not in the label set of the objective but actually comes from Prometheus. Pyrra now checks if a grouping label, like `handler` for example, is part of the objective's groupings.

Fixes #289 