### PR TITLE
Use burnrate recording rules to query for alerts table

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -419,7 +419,7 @@ func TestAlertsMatchingObjectives(t *testing.T) {
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.alerts, alertsMatchingObjectives(tc.metrics, tc.objectives, tc.inactive))
+			require.Equal(t, tc.alerts, alertsMatchingObjectives(tc.metrics, tc.objectives, nil, tc.inactive))
 		})
 	}
 }

--- a/slo/promql_test.go
+++ b/slo/promql_test.go
@@ -463,6 +463,99 @@ func TestObjective_QueryErrorBudget(t *testing.T) {
 	}
 }
 
+func TestObjective_QueryBurnrate(t *testing.T) {
+	testcases := []struct {
+		name      string
+		objective Objective
+		grouping  []*labels.Matcher
+		expected  string
+	}{{
+		name:      "http-ratio",
+		objective: objectiveHTTPRatio(),
+		expected:  `http_requests:burnrate5m{job="thanos-receive-default",slo="monitoring-http-errors"}`,
+	}, {
+		name:      "http-ratio-grouping",
+		objective: objectiveHTTPRatioGrouping(),
+		grouping: []*labels.Matcher{
+			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
+		},
+		expected: `http_requests:burnrate5m{handler="/api/v1/query",job="thanos-receive-default",slo="monitoring-http-errors"}`,
+	}, {
+		name:      "http-ratio-grouping-regex",
+		objective: objectiveHTTPRatioGroupingRegex(),
+		grouping: []*labels.Matcher{
+			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
+		},
+		expected: `http_requests:burnrate5m{handler="/api/v1/query",job="thanos-receive-default",slo="monitoring-http-errors"}`,
+	}, {
+		name:      "grpc-ratio",
+		objective: objectiveGRPCRatio(),
+		expected:  `grpc_server_handled:burnrate5m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"}`,
+	}, {
+		name:      "grpc-ratio-grouping",
+		objective: objectiveGRPCRatioGrouping(),
+		grouping: []*labels.Matcher{
+			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
+		},
+		expected: `grpc_server_handled:burnrate5m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",handler="/api/v1/query",job="api",slo="monitoring-grpc-errors"}`,
+	}, {
+		name:      "http-latency",
+		objective: objectiveHTTPLatency(),
+		expected:  `http_request_duration_seconds:burnrate5m{code=~"2..",job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"}`,
+	}, {
+		name:      "http-latency-grouping",
+		objective: objectiveHTTPLatencyGrouping(),
+		grouping: []*labels.Matcher{
+			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
+		},
+		expected: `http_request_duration_seconds:burnrate5m{code=~"2..",handler="/api/v1/query",job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"}`,
+	}, {
+		name:      "http-latency-grouping-regex",
+		objective: objectiveHTTPLatencyGroupingRegex(),
+		grouping: []*labels.Matcher{
+			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
+		},
+		expected: `http_request_duration_seconds:burnrate5m{code=~"2..",handler="/api/v1/query",job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"}`,
+	}, {
+		name:      "grpc-latency",
+		objective: objectiveGRPCLatency(),
+		expected:  `grpc_server_handling_seconds:burnrate5m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-latency"}`,
+	}, {
+		name:      "grpc-latency-regex",
+		objective: objectiveGRPCLatencyGrouping(),
+		grouping: []*labels.Matcher{
+			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
+		},
+		expected: `grpc_server_handling_seconds:burnrate5m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",handler="/api/v1/query",job="api",slo="monitoring-grpc-latency"}`,
+	}, {
+		name:      "operator-ratio",
+		objective: objectiveOperator(),
+		expected:  `prometheus_operator_reconcile_operations:burnrate5m{slo="monitoring-prometheus-operator-errors"}`,
+	}, {
+		name:      "operator-ratio-grouping",
+		objective: objectiveOperatorGrouping(),
+		grouping: []*labels.Matcher{
+			{Type: labels.MatchEqual, Name: "namespace", Value: "monitoring"},
+		},
+		expected: `prometheus_operator_reconcile_operations:burnrate5m{namespace="monitoring",slo="monitoring-prometheus-operator-errors"}`,
+	}, {
+		name:      "apiserver-write-response-errors",
+		objective: objectiveAPIServerRatio(),
+		expected:  `apiserver_request:burnrate5m{job="apiserver",slo="apiserver-write-response-errors",verb=~"POST|PUT|PATCH|DELETE"}`,
+	}, {
+		name:      "apiserver-read-resource-latency",
+		objective: objectiveAPIServerRatio(),
+		expected:  `apiserver_request:burnrate5m{job="apiserver",slo="apiserver-write-response-errors",verb=~"POST|PUT|PATCH|DELETE"}`,
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			query, err := tc.objective.QueryBurnrate(5*time.Minute, tc.grouping)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, query)
+		})
+	}
+}
+
 func TestObjective_RequestRange(t *testing.T) {
 	testcases := []struct {
 		name      string

--- a/slo/rules.go
+++ b/slo/rules.go
@@ -30,11 +30,11 @@ func (o Objective) Alerts() ([]MultiBurnRateAlert, error) {
 
 	mbras := make([]MultiBurnRateAlert, len(ws))
 	for i, w := range ws {
-		queryShort, err := o.QueryBurnrate(w.Short)
+		queryShort, err := o.QueryBurnrate(w.Short, nil)
 		if err != nil {
 			return nil, err
 		}
-		queryLong, err := o.QueryBurnrate(w.Long)
+		queryLong, err := o.QueryBurnrate(w.Long, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -811,6 +811,75 @@ func TestObjective_Burnrates(t *testing.T) {
 	}
 }
 
+func TestObjective_BurnrateNames(t *testing.T) {
+	testcases := []struct {
+		name     string
+		slo      Objective
+		burnrate string
+	}{{
+		name:     "http-ratio",
+		slo:      objectiveHTTPRatio(),
+		burnrate: "http_requests:burnrate5m",
+	}, {
+		name:     "http-ratio-grouping",
+		slo:      objectiveHTTPRatioGrouping(),
+		burnrate: "http_requests:burnrate5m",
+	}, {
+		name:     "http-ratio-grouping-regex",
+		slo:      objectiveHTTPRatioGroupingRegex(),
+		burnrate: "http_requests:burnrate5m",
+	}, {
+		name:     "grpc-errors",
+		slo:      objectiveGRPCRatio(),
+		burnrate: "grpc_server_handled:burnrate5m",
+	}, {
+		name:     "grpc-errors-grouping",
+		slo:      objectiveGRPCRatioGrouping(),
+		burnrate: "grpc_server_handled:burnrate5m",
+	}, {
+		name:     "http-latency",
+		slo:      objectiveHTTPLatency(),
+		burnrate: "http_request_duration_seconds:burnrate5m",
+	}, {
+		name:     "http-latency-grouping",
+		slo:      objectiveHTTPLatencyGrouping(),
+		burnrate: "http_request_duration_seconds:burnrate5m",
+	}, {
+		name:     "http-latency-grouping-regex",
+		slo:      objectiveHTTPLatencyGroupingRegex(),
+		burnrate: "http_request_duration_seconds:burnrate5m",
+	}, {
+		name:     "grpc-latency",
+		slo:      objectiveGRPCLatency(),
+		burnrate: "grpc_server_handling_seconds:burnrate5m",
+	}, {
+		name:     "grpc-latency-grouping",
+		slo:      objectiveGRPCLatencyGrouping(),
+		burnrate: "grpc_server_handling_seconds:burnrate5m",
+	}, {
+		name:     "operator-ratio",
+		slo:      objectiveOperator(),
+		burnrate: "prometheus_operator_reconcile_operations:burnrate5m",
+	}, {
+		name:     "operator-ratio-grouping",
+		slo:      objectiveOperatorGrouping(),
+		burnrate: "prometheus_operator_reconcile_operations:burnrate5m",
+	}, {
+		name:     "apiserver-write-response-errors",
+		slo:      objectiveAPIServerRatio(),
+		burnrate: "apiserver_request:burnrate5m",
+	}, {
+		name:     "apiserver-read-resource-latency",
+		slo:      objectiveAPIServerLatency(),
+		burnrate: "apiserver_request_duration_seconds:burnrate5m",
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.burnrate, tc.slo.BurnrateName(5*time.Minute))
+		})
+	}
+}
+
 func TestObjective_IncreaseRules(t *testing.T) {
 	testcases := []struct {
 		name  string

--- a/ui/src/pages/List.tsx
+++ b/ui/src/pages/List.tsx
@@ -305,7 +305,7 @@ const List = () => {
     // TODO: This is prone to a concurrency race with updates of status that have additional groupings...
     // One solution would be to store this in a separate array and reconcile against that array after every status update.
     if (objectives.length > 0) {
-      api.getMultiBurnrateAlerts({expr: '', inactive: false})
+      api.getMultiBurnrateAlerts({expr: '', inactive: false, current: false})
         .then((alerts: MultiBurnrateAlert[]) => {
           alerts.forEach((alert: MultiBurnrateAlert) => {
             if (alert.state === MultiBurnrateAlertStateEnum.Firing) {


### PR DESCRIPTION
Currently the fix for release-0.4 was to use a raw query.
However, we already use those queries in the recording rules that are used by the alerting itself. 
This PR improves the implementation to query the exact same recording rules for the UI too.