### PR TITLE
slo: Copy labels for burnrate queries to avoid possible race

### DIFF
--- a/slo/promql.go
+++ b/slo/promql.go
@@ -264,14 +264,22 @@ func (o Objective) QueryBurnrate(timerange time.Duration, groupingMatchers []*la
 	if o.Indicator.Ratio != nil && o.Indicator.Ratio.Total.Name != "" {
 		metric = o.BurnrateName(timerange)
 		for _, m := range o.Indicator.Ratio.Total.LabelMatchers {
-			matchers[m.Name] = m
+			matchers[m.Name] = &labels.Matcher{ // Copy labels by value to avoid race
+				Type:  m.Type,
+				Name:  m.Name,
+				Value: m.Value,
+			}
 		}
 	}
 
 	if o.Indicator.Latency != nil && o.Indicator.Latency.Total.Name != "" {
 		metric = o.BurnrateName(timerange)
 		for _, m := range o.Indicator.Latency.Total.LabelMatchers {
-			matchers[m.Name] = m
+			matchers[m.Name] = &labels.Matcher{ // Copy labels by value to avoid race
+				Type:  m.Type,
+				Name:  m.Name,
+				Value: m.Value,
+			}
 		}
 	}
 


### PR DESCRIPTION
Since it's a map to pointers it's possible that the underlying matcher gets concurrently accessed and rewritten. Copying the labels avoids this problem.

The symptom of how this showed up was that sometimes the metric and the label `__name__` were different and Prometheus returned an error.