### PR TITLE
Don't round objective status query time

### DIFF
--- a/main.go
+++ b/main.go
@@ -305,14 +305,6 @@ type prometheusAPI interface {
 	QueryRange(ctx context.Context, query string, r prometheusv1.Range) (model.Value, prometheusv1.Warnings, error)
 }
 
-func RoundUp(t time.Time, d time.Duration) time.Time {
-	n := t.Round(d)
-	if n.Before(t) {
-		return n.Add(d)
-	}
-	return n
-}
-
 type promCache struct {
 	api   prometheusAPI
 	cache *ristretto.Cache
@@ -460,7 +452,7 @@ func (o *ObjectivesServer) GetObjectiveStatus(ctx context.Context, expr, groupin
 		}
 	}
 
-	ts := RoundUp(time.Now().UTC(), 5*time.Minute)
+	ts := time.Now().UTC()
 
 	queryTotal := objective.QueryTotal(objective.Window)
 	level.Debug(o.logger).Log("msg", "sending query total", "query", queryTotal)


### PR DESCRIPTION
This one I was chasing for weeks now. It turns out that Pyrra often show's "No Data" because the timestamp send to Prometheus is actually too far in the future (at 15:01 it rounds to 15:05) and Prometheus doesn't yet have data.
This was an optimization for when the availability & error budget weren't recording rules yet.
Turns out 5min was way too much anyway...

Hopefully the "no data" is mostly a thing of the past now.