### PR TITLE
Feature cli component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ bin
 *.swp
 *.swo
 *~
+.vscode
 
 /pyrra

--- a/generate.go
+++ b/generate.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+func cmdGenerate(logger log.Logger, configFiles, prometheusFolder string) int {
+	filenames, err := filepath.Glob(configFiles)
+	if err != nil {
+		level.Error(logger).Log("getting files names: %w", err)
+	}
+	for _, f := range filenames {
+		// Omit setting Objectives because UI is not used for the generate command
+		_, err := processFileSLO(f, prometheusFolder)
+		if err != nil {
+			level.Error(logger).Log("failed to convert files names: %s: %w", f, err)
+			return 2
+		}
+	}
+	return 0
+}

--- a/main.go
+++ b/main.go
@@ -64,6 +64,10 @@ var CLI struct {
 		MetricsAddr   string `default:":8080" help:"The address the metric endpoint binds to."`
 		ConfigMapMode bool   `default:"false" help:"If the generated recording rules should instead be saved to config maps in the default Prometheus format."`
 	} `cmd:"" help:"Runs Pyrra's Kubernetes operator and backend for the API."`
+	Generate struct {
+		ConfigFiles      string `default:"/etc/pyrra/*.yaml" help:"The folder where Pyrra finds the config files to use."`
+		PrometheusFolder string `default:"/etc/prometheus/pyrra" help:"The folder where Pyrra writes the generates Prometheus rules and alerts."`
+	} `cmd:"" help:"Generate Prometheus rules and alerts for the specified config files."`
 }
 
 func main() {
@@ -126,6 +130,8 @@ func main() {
 		code = cmdFilesystem(logger, reg, client, CLI.Filesystem.ConfigFiles, CLI.Filesystem.PrometheusFolder)
 	case "kubernetes":
 		code = cmdKubernetes(logger, CLI.Kubernetes.MetricsAddr, CLI.Kubernetes.ConfigMapMode)
+	case "generate":
+		code = cmdGenerate(logger, CLI.Generate.ConfigFiles, CLI.Generate.PrometheusFolder)
 	}
 	os.Exit(code)
 }


### PR DESCRIPTION
Hello!

This PR is intended for adding CLI functionality to Pyrra. It works relatively straightforward with minimal refactoring:
Taking SLO Config files -> Converting them to Prometheus Rules/Alerts Files

It doesn't update objectives intended for displaying with UI because this wouldn't fit the purpose of the tool. In this scenario it would usage in CI/CD systems or there where custom UI is not needed.

How to use:
```
go build
./pyrra generate --config-files="examples/docker-compose/pyrra/*.yaml" --prometheus-folder=.
```

Closes #314 