### PR TITLE
Remove `spec.latency` from nginx.yaml example

### DIFF
--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -24,7 +24,6 @@ metadata:
   namespace: monitoring
 spec:
   target: '90' # 90% of requests should be faster than 1s
-  latency: '1' # le="1" needs to be available on _bucket metric
   window: 4w
   indicator:
     latency:

--- a/examples/nginx.yaml
+++ b/examples/nginx.yaml
@@ -28,6 +28,6 @@ spec:
   indicator:
     latency:
       success:
-        metric: nginx_ingress_controller_request_duration_seconds_bucket{namespace="lastfm",ingress="lastfm",service="lastfm",status=~"5.."}
+        metric: nginx_ingress_controller_request_duration_seconds_bucket{namespace="lastfm",ingress="lastfm",service="lastfm",status=~"5..",le="1"}
       total:
         metric: nginx_ingress_controller_request_duration_seconds_count{namespace="lastfm",ingress="lastfm",service="lastfm"}


### PR DESCRIPTION
It's not part of the ServiceLevelObjective spec.