### PR TITLE
Propagate annotations from SLO to alerts

### DIFF
--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -268,6 +268,7 @@ func (in ServiceLevelObjective) Internal() (slo.Objective, error) {
 
 	return slo.Objective{
 		Labels:      ls,
+		Annotations: in.Annotations,
 		Description: in.Spec.Description,
 		Target:      target / 100,
 		Window:      window,

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
@@ -28,6 +28,8 @@ metadata:
     prometheus: k8s
     role: alert-rules
     pyrra.dev/team: foo
+  annotations:
+    pyrra.dev/description: "foo"
 spec:
   target: 99
   window: 1w
@@ -44,6 +46,7 @@ spec:
 				"namespace", "monitoring",
 				"pyrra.dev/team", "foo",
 			),
+			Annotations: map[string]string{"pyrra.dev/description": "foo"},
 			Description: "",
 			Target:      0.99,
 			Window:      model.Duration(7 * 24 * time.Hour),

--- a/kubernetes/controllers/servicelevelobjective_test.go
+++ b/kubernetes/controllers/servicelevelobjective_test.go
@@ -29,6 +29,10 @@ var (
 				slo.PropagationLabelsPrefix + "team": "foo",
 				"team":                               "bar",
 			},
+			Annotations: map[string]string{
+				slo.PropagationLabelsPrefix + "description": "foo",
+				"description": "bar",
+			},
 		},
 		Spec: pyrrav1alpha1.ServiceLevelObjectiveSpec{
 			Target: "99.5",
@@ -134,28 +138,32 @@ func Test_makePrometheusRule(t *testing.T) {
 									Labels: map[string]string{"job": "app", "slo": "http", "team": "foo"},
 								},
 								{
-									Alert:  "ErrorBudgetBurn",
-									Expr:   intstr.FromString(`http_requests:burnrate5m{job="app",slo="http"} > (14 * (1-0.995)) and http_requests:burnrate1h{job="app",slo="http"} > (14 * (1-0.995))`),
-									For:    "2m",
-									Labels: map[string]string{"severity": "critical", "job": "app", "long": "1h", "slo": "http", "short": "5m", "team": "foo"},
+									Alert:       "ErrorBudgetBurn",
+									Expr:        intstr.FromString(`http_requests:burnrate5m{job="app",slo="http"} > (14 * (1-0.995)) and http_requests:burnrate1h{job="app",slo="http"} > (14 * (1-0.995))`),
+									For:         "2m",
+									Labels:      map[string]string{"severity": "critical", "job": "app", "long": "1h", "slo": "http", "short": "5m", "team": "foo"},
+									Annotations: map[string]string{"description": "foo"},
 								},
 								{
-									Alert:  "ErrorBudgetBurn",
-									Expr:   intstr.FromString(`http_requests:burnrate30m{job="app",slo="http"} > (7 * (1-0.995)) and http_requests:burnrate6h{job="app",slo="http"} > (7 * (1-0.995))`),
-									For:    "15m",
-									Labels: map[string]string{"severity": "critical", "job": "app", "long": "6h", "slo": "http", "short": "30m", "team": "foo"},
+									Alert:       "ErrorBudgetBurn",
+									Expr:        intstr.FromString(`http_requests:burnrate30m{job="app",slo="http"} > (7 * (1-0.995)) and http_requests:burnrate6h{job="app",slo="http"} > (7 * (1-0.995))`),
+									For:         "15m",
+									Labels:      map[string]string{"severity": "critical", "job": "app", "long": "6h", "slo": "http", "short": "30m", "team": "foo"},
+									Annotations: map[string]string{"description": "foo"},
 								},
 								{
-									Alert:  "ErrorBudgetBurn",
-									Expr:   intstr.FromString(`http_requests:burnrate2h{job="app",slo="http"} > (2 * (1-0.995)) and http_requests:burnrate1d{job="app",slo="http"} > (2 * (1-0.995))`),
-									For:    "1h",
-									Labels: map[string]string{"severity": "warning", "job": "app", "long": "1d", "slo": "http", "short": "2h", "team": "foo"},
+									Alert:       "ErrorBudgetBurn",
+									Expr:        intstr.FromString(`http_requests:burnrate2h{job="app",slo="http"} > (2 * (1-0.995)) and http_requests:burnrate1d{job="app",slo="http"} > (2 * (1-0.995))`),
+									For:         "1h",
+									Labels:      map[string]string{"severity": "warning", "job": "app", "long": "1d", "slo": "http", "short": "2h", "team": "foo"},
+									Annotations: map[string]string{"description": "foo"},
 								},
 								{
-									Alert:  "ErrorBudgetBurn",
-									Expr:   intstr.FromString(`http_requests:burnrate6h{job="app",slo="http"} > (1 * (1-0.995)) and http_requests:burnrate4d{job="app",slo="http"} > (1 * (1-0.995))`),
-									For:    "3h",
-									Labels: map[string]string{"severity": "warning", "job": "app", "long": "4d", "slo": "http", "short": "6h", "team": "foo"},
+									Alert:       "ErrorBudgetBurn",
+									Expr:        intstr.FromString(`http_requests:burnrate6h{job="app",slo="http"} > (1 * (1-0.995)) and http_requests:burnrate4d{job="app",slo="http"} > (1 * (1-0.995))`),
+									For:         "3h",
+									Labels:      map[string]string{"severity": "warning", "job": "app", "long": "4d", "slo": "http", "short": "6h", "team": "foo"},
+									Annotations: map[string]string{"description": "foo"},
 								},
 							},
 						},
@@ -230,6 +238,8 @@ func Test_makeConfigMap(t *testing.T) {
       team: foo
     record: http_requests:burnrate4d
   - alert: ErrorBudgetBurn
+    annotations:
+      description: foo
     expr: http_requests:burnrate5m{job="app",slo="http"} > (14 * (1-0.995)) and http_requests:burnrate1h{job="app",slo="http"}
       > (14 * (1-0.995))
     for: 2m
@@ -241,6 +251,8 @@ func Test_makeConfigMap(t *testing.T) {
       slo: http
       team: foo
   - alert: ErrorBudgetBurn
+    annotations:
+      description: foo
     expr: http_requests:burnrate30m{job="app",slo="http"} > (7 * (1-0.995)) and http_requests:burnrate6h{job="app",slo="http"}
       > (7 * (1-0.995))
     for: 15m
@@ -252,6 +264,8 @@ func Test_makeConfigMap(t *testing.T) {
       slo: http
       team: foo
   - alert: ErrorBudgetBurn
+    annotations:
+      description: foo
     expr: http_requests:burnrate2h{job="app",slo="http"} > (2 * (1-0.995)) and http_requests:burnrate1d{job="app",slo="http"}
       > (2 * (1-0.995))
     for: 1h
@@ -263,6 +277,8 @@ func Test_makeConfigMap(t *testing.T) {
       slo: http
       team: foo
   - alert: ErrorBudgetBurn
+    annotations:
+      description: foo
     expr: http_requests:burnrate6h{job="app",slo="http"} > (1 * (1-0.995)) and http_requests:burnrate4d{job="app",slo="http"}
       > (1 * (1-0.995))
     for: 3h

--- a/slo/rules.go
+++ b/slo/rules.go
@@ -108,6 +108,7 @@ func (o Objective) Burnrates() (monitoringv1.RuleGroup, error) {
 
 		for _, w := range ws {
 			alertLabels := o.commonRuleLabels(sloName)
+			alertAnnotations := o.commonRuleAnnotations()
 			for _, m := range matchers {
 				if m.Type == labels.MatchEqual && m.Name != labels.MetricName {
 					if _, ok := groupingMap[m.Name]; !ok { // only add labels that aren't grouped by
@@ -132,8 +133,9 @@ func (o Objective) Burnrates() (monitoringv1.RuleGroup, error) {
 					w.Factor,
 					strconv.FormatFloat(o.Target, 'f', -1, 64),
 				)),
-				For:    model.Duration(w.For).String(),
-				Labels: alertLabels,
+				For:         model.Duration(w.For).String(),
+				Labels:      alertLabels,
+				Annotations: alertAnnotations,
 			}
 			rules = append(rules, r)
 		}
@@ -193,6 +195,7 @@ func (o Objective) Burnrates() (monitoringv1.RuleGroup, error) {
 
 		for _, w := range ws {
 			alertLabels := o.commonRuleLabels(sloName)
+			alertAnnotations := o.commonRuleAnnotations()
 			for _, m := range matchers {
 				if m.Type == labels.MatchEqual && m.Name != labels.MetricName {
 					if _, ok := groupingMap[m.Name]; !ok { // only add labels that aren't grouped by
@@ -217,8 +220,9 @@ func (o Objective) Burnrates() (monitoringv1.RuleGroup, error) {
 					w.Factor,
 					strconv.FormatFloat(o.Target, 'f', -1, 64),
 				)),
-				For:    model.Duration(w.For).String(),
-				Labels: alertLabels,
+				For:         model.Duration(w.For).String(),
+				Labels:      alertLabels,
+				Annotations: alertAnnotations,
 			}
 			rules = append(rules, r)
 		}
@@ -339,6 +343,20 @@ func (o Objective) commonRuleLabels(sloName string) map[string]string {
 	}
 
 	return ruleLabels
+}
+
+func (o Objective) commonRuleAnnotations() map[string]string {
+	var annotations map[string]string
+	if len(o.Annotations) > 0 {
+		annotations = make(map[string]string)
+		for key, value := range o.Annotations {
+			if strings.HasPrefix(key, PropagationLabelsPrefix) {
+				annotations[strings.TrimPrefix(key, PropagationLabelsPrefix)] = value
+			}
+		}
+	}
+
+	return annotations
 }
 
 func (o Objective) IncreaseRules() (monitoringv1.RuleGroup, error) {

--- a/slo/slo.go
+++ b/slo/slo.go
@@ -17,6 +17,7 @@ const (
 
 type Objective struct {
 	Labels      labels.Labels
+	Annotations map[string]string
 	Description string
 	Target      float64
 	Window      model.Duration


### PR DESCRIPTION
Re-using the same strategy used to propagate labels from SLO definitions to alerts, this propagates annotations from SLO to alerts. If any annotation is prefixed with `pyrra.dev/`, then this annotation will be present in the alert while the prefix itself is removed.

PS: Differently from the labels propagation, annotations are only propagated to alerting rules and not to recording rules.

---

Should fix https://github.com/pyrra-dev/pyrra/issues/112