### PR TITLE
Set USER to 65533

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ RUN chmod +x pyrra
 FROM --platform="${TARGETPLATFORM:-linux/amd64}"  docker.io/alpine:3.16.2 AS runner
 WORKDIR /
 COPY --chown=0:0 --from=builder /app/pyrra /usr/bin/pyrra
-USER nobody
+USER 65533
 
 ENTRYPOINT ["/usr/bin/pyrra"]


### PR DESCRIPTION
AppArmor on GKE clusters will block simply running as nobody and wants a specific user number. https://kubernetes.io/docs/tutorials/security/apparmor/