### PR TITLE
ui: Improve styles for metric tiles and add large breakpoints

### DIFF
--- a/ui/src/components/Navbar.scss
+++ b/ui/src/components/Navbar.scss
@@ -13,7 +13,6 @@
 
   .breadcrumb {
     font-size: 18px;
-    margin-left: 16px;
 
     a {
       color: $gray-700;

--- a/ui/src/components/Navbar.tsx
+++ b/ui/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import {ReactNode} from 'react'
-import {Container, Navbar as BootstrapNavbar} from 'react-bootstrap'
+import {Col, Container, Navbar as BootstrapNavbar} from 'react-bootstrap'
 import {Link} from 'react-router-dom'
 import logo from '../logo.svg'
 
@@ -12,7 +12,9 @@ const Navbar = ({children}: NavbarProps): JSX.Element => {
     <BootstrapNavbar className={children !== undefined ? 'navbar-tall' : ''}>
       {children !== undefined ? (
         <Container>
-          <div className="breadcrumb">{children}</div>
+          <Col className="col-xxxl-10 offset-xxxl-1">
+            <div className="breadcrumb">{children}</div>
+          </Col>
         </Container>
       ) : (
         <></>

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -31,6 +31,7 @@ $headings-margin-bottom: 1rem * 0.75;
 $table-th-font-weight: 600;
 
 @import "@fontsource/inter/400.css";
+@import "@fontsource/inter/500.css";
 @import "@fontsource/inter/600.css";
 @import "@fontsource/inter/700.css";
 @import "@fontsource/lato/400.css";
@@ -47,12 +48,10 @@ $table-th-font-weight: 600;
 
 $grid-breakpoints: map-merge($grid-breakpoints, (
   xxxl: 1700px,
-  xxxxl: 2000px,
 ));
 
 $container-max-widths:map-merge($container-max-widths, (
   xxxl: 1600px,
-  xxxxl: 1880px,
 ));
 
 // Layout & components

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -30,6 +30,12 @@ $headings-margin-bottom: 1rem * 0.75;
 
 $table-th-font-weight: 600;
 
+@import "@fontsource/inter/400.css";
+@import "@fontsource/inter/600.css";
+@import "@fontsource/inter/700.css";
+@import "@fontsource/lato/400.css";
+@import "@fontsource/lato/700.css";
+
 // Import all bootstrap modules manually and comment out the ones we don't need.
 // The diff should make it easier to upgrade in the future too.
 
@@ -38,6 +44,16 @@ $table-th-font-weight: 600;
 @import '~bootstrap/scss/variables';
 @import '~bootstrap/scss/mixins';
 @import '~bootstrap/scss/utilities';
+
+$grid-breakpoints: map-merge($grid-breakpoints, (
+  xxxl: 1700px,
+  xxxxl: 2000px,
+));
+
+$container-max-widths:map-merge($container-max-widths, (
+  xxxl: 1600px,
+  xxxxl: 1880px,
+));
 
 // Layout & components
 @import '~bootstrap/scss/root';

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.scss'
-import '@fontsource/lato'
-import '@fontsource/inter'
 
 ReactDOM.createRoot(document.getElementById('root') as Element).render(
   <React.StrictMode>

--- a/ui/src/pages/Detail.scss
+++ b/ui/src/pages/Detail.scss
@@ -12,7 +12,6 @@
   .metrics {
     width: 100%;
     display: grid;
-    padding: 0 15px;
     grid-template-columns: repeat(1, 1fr);
     column-gap: 25px;
     row-gap: 25px;
@@ -57,6 +56,10 @@
       .metric {
         display: inline-block;
         margin-right: 0.5rem;
+      }
+
+      .details {
+        font-weight: 500;
       }
 
       &.good {

--- a/ui/src/pages/Detail.scss
+++ b/ui/src/pages/Detail.scss
@@ -50,7 +50,7 @@
         font-size: 20px;
       }
 
-      .headline {
+      .headline, .details {
         opacity: 0.5;
       }
 

--- a/ui/src/pages/Detail.scss
+++ b/ui/src/pages/Detail.scss
@@ -35,19 +35,28 @@
       color: $gray-900;
       border-radius: 8px;
 
-      h2,
-      h6 {
-        font-weight: normal;
+      h2, h6 {
         font-family: $font-family-sans-serif;
       }
 
       h2 {
+        font-weight: 400;
         font-size: 40px;
         margin-bottom: 0;
       }
 
       h6 {
+        font-weight: 600;
         font-size: 20px;
+      }
+
+      .headline {
+        opacity: 0.5;
+      }
+
+      .metric {
+        display: inline-block;
+        margin-right: 0.5rem;
       }
 
       &.good {

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -245,7 +245,7 @@ const Detail = () => {
             <h2 className="metric">{(100 * objective.target).toFixed(3)}%</h2>
             <>in {formatDuration(Number(objective.window?.seconds) * 1000)}</>
             <br />
-            <p>faster than {renderLatencyTarget(objective)}</p>
+            <p className="details">faster than {renderLatencyTarget(objective)}</p>
           </div>
         )
       default:
@@ -295,7 +295,7 @@ const Detail = () => {
           <div className={availability.percentage > objective.target ? 'good' : 'bad'}>
             {headline}
             <h2 className="metric">{(100 * availability.percentage).toFixed(3)}%</h2>
-            <table>
+            <table className="details">
               <tr>
                 <td>{objectiveType === ObjectiveType.Latency ? 'Slow:' : 'Errors:'}</td>
                 <td>{Math.floor(availability.errors).toLocaleString()}</td>

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -383,12 +383,12 @@ const Detail = () => {
       <div className="content detail">
         <Container>
           <Row>
-            <Col xs={12} className="header">
+            <Col xs={12} className="col-xxxl-10 offset-xxxl-1 header">
               <h3>{name}</h3>
               {labelBadges}
             </Col>
             {objective.description !== undefined && objective.description !== '' ? (
-              <Col xs={12} md={6} style={{marginTop: 12}}>
+              <Col xs={12} md={6} style={{marginTop: 12}} className="col-xxxl-10 offset-xxxl-1">
                 <p>{objective.description}</p>
               </Col>
             ) : (
@@ -396,11 +396,13 @@ const Detail = () => {
             )}
           </Row>
           <Row>
-            <div className="metrics">
-              {renderObjective()}
-              {renderAvailability()}
-              {renderErrorBudget()}
-            </div>
+            <Col className="col-xxxl-10 offset-xxxl-1">
+              <div className="metrics">
+                {renderObjective()}
+                {renderAvailability()}
+                {renderErrorBudget()}
+              </div>
+            </Col>
           </Row>
           <Row>
             <Col className="text-center timerange">
@@ -491,13 +493,13 @@ const Detail = () => {
             )}
           </Row>
           <Row>
-            <Col>
+            <Col className="col-xxxl-10 offset-xxxl-1">
               <h4>Multi Burn Rate Alerts</h4>
               <AlertsTable client={client} objective={objective} grouping={groupingLabels} />
             </Col>
           </Row>
           <Row>
-            <Col>
+            <Col className="col-xxxl-10 offset-xxxl-1">
               <h4>Config</h4>
               <pre style={{padding: 20, borderRadius: 4}}>
                 <code>{objective.config}</code>

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -233,23 +233,19 @@ const Detail = () => {
       case ObjectiveType.Ratio:
         return (
           <div>
-            <h6>
-              Objective in{' '}
-              <strong>{formatDuration(Number(objective.window?.seconds) * 1000)}</strong>
-            </h6>
-            <h2>{(100 * objective.target).toFixed(3)}%</h2>
+            <h6 className="headline">Objective</h6>
+            <h2 className="metric">{(100 * objective.target).toFixed(3)}%</h2>
+            <>in {formatDuration(Number(objective.window?.seconds) * 1000)}</>
           </div>
         )
       case ObjectiveType.Latency:
         return (
           <div>
-            <h6>
-              Objective in{' '}
-              <strong>{formatDuration(Number(objective.window?.seconds) * 1000)}</strong>
-            </h6>
-            <h2>
-              {(100 * objective.target).toFixed(3)}% &lt; {renderLatencyTarget(objective)}
-            </h2>
+            <h6 className="headline">Objective</h6>
+            <h2 className="metric">{(100 * objective.target).toFixed(3)}%</h2>
+            <>in {formatDuration(Number(objective.window?.seconds) * 1000)}</>
+            <br />
+            <p>faster than {renderLatencyTarget(objective)}</p>
           </div>
         )
       default:
@@ -258,7 +254,7 @@ const Detail = () => {
   }
 
   const renderAvailability = () => {
-    const headline = <h6>Availability</h6>
+    const headline = <h6 className="headline">Availability</h6>
     switch (statusState) {
       case StatusState.Unknown:
         return (
@@ -298,14 +294,24 @@ const Detail = () => {
         return (
           <div className={availability.percentage > objective.target ? 'good' : 'bad'}>
             {headline}
-            <h2>{(100 * availability.percentage).toFixed(3)}%</h2>
+            <h2 className="metric">{(100 * availability.percentage).toFixed(3)}%</h2>
+            <table>
+              <tr>
+                <td>{objectiveType === ObjectiveType.Latency ? 'Slow:' : 'Errors:'}</td>
+                <td>{Math.floor(availability.errors).toLocaleString()}</td>
+              </tr>
+              <tr>
+                <td>Total:</td>
+                <td>{Math.floor(availability.total).toLocaleString()}</td>
+              </tr>
+            </table>
           </div>
         )
     }
   }
 
   const renderErrorBudget = () => {
-    const headline = <h6>Error Budget</h6>
+    const headline = <h6 className="headline">Error Budget</h6>
     switch (statusState) {
       case StatusState.Unknown:
         return (
@@ -345,7 +351,7 @@ const Detail = () => {
         return (
           <div className={errorBudget.remaining > 0 ? 'good' : 'bad'}>
             {headline}
-            <h2>{(100 * errorBudget.remaining).toFixed(3)}%</h2>
+            <h2 className="metric">{(100 * errorBudget.remaining).toFixed(3)}%</h2>
           </div>
         )
     }
@@ -427,7 +433,7 @@ const Detail = () => {
               </div>
             </Col>
           </Row>
-          <Row style={{marginBottom: 0}}>
+          <Row>
             <Col>
               <ErrorBudgetGraph
                 client={client}
@@ -440,19 +446,10 @@ const Detail = () => {
             </Col>
           </Row>
           <Row>
-            <Col style={{textAlign: 'right'}}>
-              {availability != null ? (
-                <>
-                  <small>Errors: {Math.floor(availability.errors).toLocaleString()}</small>&nbsp;
-                  <small>Total: {Math.floor(availability.total).toLocaleString()}</small>&nbsp;
-                </>
-              ) : (
-                <></>
-              )}
-            </Col>
-          </Row>
-          <Row>
-            <Col xs={12} md={objectiveType === ObjectiveType.Ratio ? 6 : 12}>
+            <Col
+              xs={12}
+              md={objectiveType === ObjectiveType.Latency ? 12 : 6}
+              className={objectiveType === ObjectiveType.Latency ? 'col-xxxl-4' : ''}>
               <RequestsGraph
                 client={client}
                 labels={labels}
@@ -462,7 +459,10 @@ const Detail = () => {
                 uPlotCursor={uPlotCursor}
               />
             </Col>
-            <Col xs={12} md={objectiveType === ObjectiveType.Ratio ? 6 : 12}>
+            <Col
+              xs={12}
+              md={objectiveType === ObjectiveType.Latency ? 12 : 6}
+              className={objectiveType === ObjectiveType.Latency ? 'col-xxxl-4' : ''}>
               <ErrorsGraph
                 client={client}
                 type={objectiveType}
@@ -474,16 +474,18 @@ const Detail = () => {
               />
             </Col>
             {objectiveType === ObjectiveType.Latency ? (
-              <DurationGraph
-                client={client}
-                labels={labels}
-                grouping={groupingLabels}
-                from={from}
-                to={to}
-                uPlotCursor={uPlotCursor}
-                target={objective.target}
-                latency={latencyTarget(objective)}
-              />
+              <Col xs={12} className="col-xxxl-4">
+                <DurationGraph
+                  client={client}
+                  labels={labels}
+                  grouping={groupingLabels}
+                  from={from}
+                  to={to}
+                  uPlotCursor={uPlotCursor}
+                  target={objective.target}
+                  latency={latencyTarget(objective)}
+                />
+              </Col>
             ) : (
               <></>
             )}


### PR DESCRIPTION
Next to improving the style for the metric tiles, like font and text, we add new xxxl and xxxxl breakpoints to improve the width of Pyrra on big screens. This allows to show the metric graphs for Requests, Errors and Duration next to each other on big screens.

Old:
![metrics-old](https://user-images.githubusercontent.com/872251/194828063-780ba5ab-6767-4aae-8ccc-bfc9cff17f4e.png)
New:
![metrics-new](https://user-images.githubusercontent.com/872251/194828071-4e02f54f-c0b5-46f0-85e1-1a52563cb5bc.png)

Additionally, I've created new larger containers so that Pyrra get get wider on bigger screens, allowing the list to be better readable if it has many labels, as well as, having enough screen width to actually put the RED graphs next to each other on big enough screens:

List old:
![list-old](https://user-images.githubusercontent.com/872251/194828669-c7cd4e64-5081-402b-a8fb-28ddff2ff091.png)
List new
![list-new](https://user-images.githubusercontent.com/872251/194828632-a4ebc23c-41e8-4b09-95b2-6a97c6ca569d.png)

RED old:
![red-old](https://user-images.githubusercontent.com/872251/194828739-c23c016c-bfb7-4b6d-8606-d36653cbd60f.png)

RED new:
![red-new](https://user-images.githubusercontent.com/872251/194828727-ad13e7b4-dfdd-4464-ac63-ec8680732f2b.png)

It's probably best to look at this on the deployed version on https://demo.pyrra.dev
