### PR TITLE
UI: Add latency target as own series

### DIFF
--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -42,6 +42,7 @@ import AlertsTable from '../components/AlertsTable'
 import Toggle from '../components/Toggle'
 import {Timestamp} from '@bufbuild/protobuf'
 import DurationGraph from '../components/graphs/DurationGraph'
+import uPlot from 'uplot'
 
 const Detail = () => {
   const client = useMemo(() => {
@@ -365,7 +366,8 @@ const Detail = () => {
       </Badge>
     ))
 
-  const uPlotCursor = {
+  const uPlotCursor: uPlot.Cursor = {
+    y: false,
     lock: true,
     sync: {
       key: 'detail',


### PR DESCRIPTION
As discussed in https://github.com/pyrra-dev/pyrra/pull/450#issuecomment-1272354942 we would have much preferred the latency target to be shown as separate series too. Including a legend. 

Well, here it is. You can also disable it being shown by clicking on the legend.

![latency-target](https://user-images.githubusercontent.com/872251/195952580-ecffe524-d01d-48a3-b767-197e2146be99.png)
