### PR TITLE
slo: Create absent rules for SLI metrics

### DIFF
--- a/kubernetes/controllers/servicelevelobjective_test.go
+++ b/kubernetes/controllers/servicelevelobjective_test.go
@@ -96,6 +96,20 @@ func Test_makePrometheusRule(t *testing.T) {
 										"team": "foo",
 									},
 								},
+								{
+									Alert: "SLOMetricAbsent",
+									Expr:  intstr.FromString(`absent(http_requests_total{job="app"}) == 1`),
+									For:   "2m",
+									Annotations: map[string]string{
+										"description": "foo",
+									},
+									Labels: map[string]string{
+										"severity": "critical",
+										"job":      "app",
+										"slo":      "http",
+										"team":     "foo",
+									},
+								},
 							},
 						},
 						{
@@ -192,6 +206,16 @@ func Test_makeConfigMap(t *testing.T) {
       slo: http
       team: foo
     record: http_requests:increase4w
+  - alert: SLOMetricAbsent
+    annotations:
+      description: foo
+    expr: absent(http_requests_total{job="app"}) == 1
+    for: 2m
+    labels:
+      job: app
+      severity: critical
+      slo: http
+      team: foo
 - interval: 30s
   name: http
   rules:

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -1023,6 +1023,11 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "http_requests:increase4w",
 				Expr:   intstr.FromString(`sum by(code) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`),
 				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_requests_total{job="thanos-receive-default"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1035,6 +1040,11 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "http_requests:increase4w",
 				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`),
 				Labels: map[string]string{"slo": "monitoring-http-errors"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_requests_total{job="thanos-receive-default"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"slo": "monitoring-http-errors", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1047,6 +1057,11 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "http_requests:increase4w",
 				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_requests_total{handler=~"/api.*",job="thanos-receive-default"}[4w]))`),
 				Labels: map[string]string{"slo": "monitoring-http-errors"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_requests_total{handler=~"/api.*",job="thanos-receive-default"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"slo": "monitoring-http-errors", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1059,6 +1074,11 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "grpc_server_handled:increase4w",
 				Expr:   intstr.FromString(`sum by(grpc_code) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`),
 				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "job": "api", "slo": "monitoring-grpc-errors", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1071,6 +1091,11 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "grpc_server_handled:increase4w",
 				Expr:   intstr.FromString(`sum by(grpc_code, handler, job) (increase(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}[4w]))`),
 				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "slo": "monitoring-grpc-errors"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(grpc_server_handled_total{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "slo": "monitoring-grpc-errors", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1087,6 +1112,16 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "http_request_duration_seconds:increase4w",
 				Expr:   intstr.FromString(`sum by(code) (increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]))`),
 				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "le": "1"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "severity": "critical"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"job": "metrics-service-thanos-receive-default", "slo": "monitoring-http-latency", "le": "1", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1103,6 +1138,16 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "http_request_duration_seconds:increase4w",
 				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}[4w]))`),
 				Labels: map[string]string{"slo": "monitoring-http-latency", "le": "1"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_request_duration_seconds_count{code=~"2..",job="metrics-service-thanos-receive-default"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"slo": "monitoring-http-latency", "severity": "critical"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_request_duration_seconds_bucket{code=~"2..",job="metrics-service-thanos-receive-default",le="1"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"slo": "monitoring-http-latency", "le": "1", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1119,6 +1164,16 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "http_request_duration_seconds:increase4w",
 				Expr:   intstr.FromString(`sum by(code, handler, job) (increase(http_request_duration_seconds_bucket{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default",le="1"}[4w]))`),
 				Labels: map[string]string{"slo": "monitoring-http-latency", "le": "1"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_request_duration_seconds_count{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"slo": "monitoring-http-latency", "severity": "critical"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_request_duration_seconds_bucket{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default",le="1"}) == 1`),
+				For:    "2m",
+				Labels: map[string]string{"slo": "monitoring-http-latency", "le": "1", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1135,6 +1190,16 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "grpc_server_handling_seconds:increase1w",
 				Expr:   intstr.FromString(`sum(increase(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1w]))`),
 				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "le": "0.6"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "severity": "critical"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "job": "api", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "le": "0.6", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1151,6 +1216,16 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "grpc_server_handling_seconds:increase1w",
 				Expr:   intstr.FromString(`sum by(handler, job) (increase(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}[1w]))`),
 				Labels: map[string]string{"slo": "monitoring-grpc-latency", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "le": "0.6"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(grpc_server_handling_seconds_count{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"}) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "severity": "critical"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(grpc_server_handling_seconds_bucket{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",le="0.6"}) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"slo": "monitoring-grpc-latency", "grpc_method": "Write", "grpc_service": "conprof.WritableProfileStore", "le": "0.6", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1164,9 +1239,19 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Expr:   intstr.FromString(`sum(increase(prometheus_operator_reconcile_operations_total[2w]))`),
 				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
 			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(prometheus_operator_reconcile_operations_total) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors", "severity": "critical"},
+			}, {
 				Record: "prometheus_operator_reconcile_errors:increase2w",
 				Expr:   intstr.FromString(`sum(increase(prometheus_operator_reconcile_errors_total[2w]))`),
 				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(prometheus_operator_reconcile_errors_total) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1180,9 +1265,19 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Expr:   intstr.FromString(`sum by(namespace) (increase(prometheus_operator_reconcile_operations_total[2w]))`),
 				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
 			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(prometheus_operator_reconcile_operations_total) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors", "severity": "critical"},
+			}, {
 				Record: "prometheus_operator_reconcile_errors:increase2w",
 				Expr:   intstr.FromString(`sum by(namespace) (increase(prometheus_operator_reconcile_errors_total[2w]))`),
 				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(prometheus_operator_reconcile_errors_total) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1195,6 +1290,11 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "apiserver_request:increase2w",
 				Expr:   intstr.FromString(`sum by(code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2w]))`),
 				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-write-response-errors"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-write-response-errors", "severity": "critical"},
 			}},
 		},
 	}, {
@@ -1211,6 +1311,16 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Record: "apiserver_request_duration_seconds:increase2w",
 				Expr:   intstr.FromString(`sum by(resource, verb) (increase(apiserver_request_duration_seconds_bucket{job="apiserver",le="0.1",resource=~"resource|",verb=~"LIST|GET"}[2w]))`),
 				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency", "le": "0.1"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(apiserver_request_duration_seconds_count{job="apiserver",resource=~"resource|",verb=~"LIST|GET"}) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency", "severity": "critical"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(apiserver_request_duration_seconds_bucket{job="apiserver",le="0.1",resource=~"resource|",verb=~"LIST|GET"}) == 1`),
+				For:    "1m",
+				Labels: map[string]string{"job": "apiserver", "slo": "apiserver-read-resource-latency", "le": "0.1", "severity": "critical"},
 			}},
 		},
 	}}


### PR DESCRIPTION
If a metric for a SLO and SLI isn't available, called absent, we will fire an alert pretty quickly. It also should be of severity critical as we aren't able to tell if the error budget is burning too quickly. Hence, we'll treat it like the worst outage for the service possible.

related to #448 

cc @ArthurSens 
Maybe interesting for you too @brancz @paulfantom 