### PR TITLE
ui: Support microseconds and nanoseconds

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -109,21 +109,24 @@ export default App
 
 // From prometheus/prometheus
 
-export const formatDuration = (d: number): string => {
+export const formatDuration = (d: number, precision: number = 2): string => {
   let ms = d
   let r = ''
   if (ms === 0) {
     return '0s'
   }
 
+  let precisionCount = 0
+
   const f = (unit: string, mult: number, exact: boolean) => {
-    if (exact && ms % mult !== 0) {
+    if ((exact && ms % mult !== 0) || precisionCount === precision) {
       return
     }
     const v = Math.floor(ms / mult)
     if (v > 0) {
       r += `${v}${unit}`
       ms -= v * mult
+      precisionCount++
     }
   }
 
@@ -137,6 +140,8 @@ export const formatDuration = (d: number): string => {
   f('m', 1000 * 60, false)
   f('s', 1000, false)
   f('ms', 1, false)
+  f('μs', 0.001, false)
+  f('ns', 0.001 * 0.001, false)
 
   return r
 }

--- a/ui/src/components/graphs/DurationGraph.tsx
+++ b/ui/src/components/graphs/DurationGraph.tsx
@@ -169,7 +169,7 @@ const DurationGraph = ({
                     dash: i === 0 ? [25, 10] : undefined,
                     label: parseLabelValue(label),
                     gaps: seriesGaps(from / 1000, to / 1000),
-                    value: (u, v) => (v == null ? '-' : formatDuration(v * 1000)),
+                    value: (u, v) => (v == null ? '-' : formatDuration(v * 1000, 1)),
                   }
                 }),
               ],


### PR DESCRIPTION
Additionally, support setting the precision in formatDuration to not return 3 time durations.

Fixes #478 

<img width="553" alt="Screenshot 2022-10-16 at 22 15 36" src="https://user-images.githubusercontent.com/872251/196056166-cf3bb8cc-f062-45bb-8f9c-222e96171eb2.png">
