### PR TITLE
fix permission bug for docker compose demo

### DIFF
--- a/examples/docker-compose/docker-compose.yaml
+++ b/examples/docker-compose/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
 
   pyrra-filesystem:
     image: ghcr.io/pyrra-dev/pyrra:v0.5.0
+    user: root
     restart: always
     command:
       - filesystem


### PR DESCRIPTION
When using docker compose demo, I met this error, and pyrra file-system keeps restarting

```
level=error ts=2022-11-28T11:22:42.911072351Z caller=filesystem.go:306 msg="failed to run" err="failed to write file \"/etc/prometheus/pyrra/prometheus-http.yaml\": open /etc/prometheus/pyrra/prometheus-http.yaml: permission denied"
```

It seems that pyrra does not have enough permission, as this is a demo, I change the user to root to solve it, happy to see if you have more suitable method to solve this. :)

Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>