### PR TITLE
ui/src/components: Use toFixed in RequestsGraph

### DIFF
--- a/ui/src/components/graphs/RequestsGraph.tsx
+++ b/ui/src/components/graphs/RequestsGraph.tsx
@@ -139,7 +139,7 @@ const RequestsGraph = ({
                     label: parseLabelValue(label),
                     stroke: `#${labelColor(pickedColors, label)}`,
                     gaps: seriesGaps(from / 1000, to / 1000),
-                    value: (u, v) => (v == null ? '-' : `${v.toPrecision(2)}req/s`),
+                    value: (u, v) => (v == null ? '-' : `${v.toFixed(2)}req/s`),
                   }
                 }),
               ],


### PR DESCRIPTION
Seems like this was indeed a bug. All other graphs already use `toFixed`. 

Closes #534