### PR TITLE
Replacer: Add support for replacing duration in seconds

### DIFF
--- a/slo/promql.go
+++ b/slo/promql.go
@@ -389,6 +389,9 @@ func (r objectiveReplacer) replace(node parser.Node) {
 		if n.Val == 0.420 {
 			n.Val = r.percentile
 		}
+		if n.Val == 86400 {
+			n.Val = r.window.Seconds()
+		}
 	default:
 		panic(fmt.Sprintf("no support for type %T", n))
 	}


### PR DESCRIPTION
This pull request enhances the functionality of the replacer by introducing support for replacing the scalar value of 86400 with the duration of the window. The scalar value of 86400 represents the number of seconds in one day, making it an easily recognizable constant.

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>