### PR TITLE
ui/aligneddata: support for no label and multiple labels

### DIFF
--- a/ui/src/components/graphs/aligneddata.tsx
+++ b/ui/src/components/graphs/aligneddata.tsx
@@ -22,7 +22,15 @@ export const convertAlignedData = (response: QueryRangeResponse | null): Aligned
 
     response.options.value.samples.forEach((ss: SampleStream, i: number) => {
       // Add this series' labels to the array of label values
-      Object.values(ss.metric).forEach((l: string) => labels.push(l))
+      const kvs: string[] = []
+      Object.values(ss.metric).forEach((l: string) => kvs.push(l))
+      if (kvs.length === 1) {
+        labels.push(kvs[0])
+      } else if (kvs.length === 0) {
+        labels.push("value")
+      } else {
+        labels.push("["+kvs.join(" ")+"]")
+      }
 
       // Create an empty nested array for this time series
       values.push([])


### PR DESCRIPTION
Support for graph data that not only has multiple or no labels.

Previously, the graph would not display any data that had no labels, and in cases where the data had multiple labels, there was a potential for the labels to be incorrectly attached to wrong time series in the graph. However, it is unclear if the multi-labels scenario actually occurs in practice.

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>