### PR TITLE
Use text for relative timestamps and numbers for absolute

### DIFF
--- a/ui/src/components/graphs/DurationGraph.tsx
+++ b/ui/src/components/graphs/DurationGraph.tsx
@@ -15,6 +15,7 @@ import {
   Series,
   Timeseries,
 } from '../../proto/objectives/v1alpha1/objectives_pb'
+import {selectTimeRange} from './selectTimeRange'
 
 interface DurationGraphProps {
   client: PromiseClient<typeof ObjectiveService>
@@ -23,6 +24,7 @@ interface DurationGraphProps {
   from: number
   to: number
   uPlotCursor: uPlot.Cursor
+  updateTimeRange: (min: number, max: number, absolute: boolean) => void
   target: number
   latency: number | undefined
 }
@@ -34,6 +36,7 @@ const DurationGraph = ({
   from,
   to,
   uPlotCursor,
+  updateTimeRange,
   target,
   latency,
 }: DurationGraphProps): JSX.Element => {
@@ -189,6 +192,9 @@ const DurationGraph = ({
                     v.map((v: number) => formatDuration(v * 1000)),
                 },
               ],
+              hooks: {
+                setSelect: [selectTimeRange(updateTimeRange)],
+              },
             }}
             data={durations}
           />

--- a/ui/src/components/graphs/ErrorBudgetGraph.tsx
+++ b/ui/src/components/graphs/ErrorBudgetGraph.tsx
@@ -12,6 +12,7 @@ import {PromiseClient} from '@bufbuild/connect-web'
 import {ObjectiveService} from '../../proto/objectives/v1alpha1/objectives_connectweb'
 import {GraphErrorBudgetResponse} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {Timestamp} from '@bufbuild/protobuf'
+import {selectTimeRange} from './selectTimeRange'
 
 interface ErrorBudgetGraphProps {
   client: PromiseClient<typeof ObjectiveService>
@@ -20,6 +21,7 @@ interface ErrorBudgetGraphProps {
   from: number
   to: number
   uPlotCursor: uPlot.Cursor
+  updateTimeRange: (min: number, max: number, absolute: boolean) => void
 }
 
 const ErrorBudgetGraph = ({
@@ -29,6 +31,7 @@ const ErrorBudgetGraph = ({
   from,
   to,
   uPlotCursor,
+  updateTimeRange,
 }: ErrorBudgetGraphProps): JSX.Element => {
   const targetRef = useRef() as React.MutableRefObject<HTMLDivElement>
 
@@ -200,6 +203,9 @@ const ErrorBudgetGraph = ({
                   values: (uplot: uPlot, v: number[]) => v.map((v: number) => `${v.toFixed(2)}%`),
                 },
               ],
+              hooks: {
+                setSelect: [selectTimeRange(updateTimeRange)],
+              },
             }}
             data={samples}
           />

--- a/ui/src/components/graphs/ErrorsGraph.tsx
+++ b/ui/src/components/graphs/ErrorsGraph.tsx
@@ -11,6 +11,7 @@ import {PromiseClient} from '@bufbuild/connect-web'
 import {ObjectiveService} from '../../proto/objectives/v1alpha1/objectives_connectweb'
 import {Timestamp} from '@bufbuild/protobuf'
 import {GraphErrorsResponse, Series} from '../../proto/objectives/v1alpha1/objectives_pb'
+import {selectTimeRange} from './selectTimeRange'
 
 interface ErrorsGraphProps {
   client: PromiseClient<typeof ObjectiveService>
@@ -20,6 +21,7 @@ interface ErrorsGraphProps {
   from: number
   to: number
   uPlotCursor: uPlot.Cursor
+  updateTimeRange: (min: number, max: number, absolute: boolean) => void
 }
 
 const ErrorsGraph = ({
@@ -30,6 +32,7 @@ const ErrorsGraph = ({
   from,
   to,
   uPlotCursor,
+  updateTimeRange,
 }: ErrorsGraphProps): JSX.Element => {
   const targetRef = useRef() as React.MutableRefObject<HTMLDivElement>
 
@@ -157,6 +160,9 @@ const ErrorsGraph = ({
                   values: (uplot: uPlot, v: number[]) => v.map((v: number) => `${v}%`),
                 },
               ],
+              hooks: {
+                setSelect: [selectTimeRange(updateTimeRange)],
+              },
             }}
             data={errors}
           />

--- a/ui/src/components/graphs/RequestsGraph.tsx
+++ b/ui/src/components/graphs/RequestsGraph.tsx
@@ -11,6 +11,7 @@ import {PromiseClient} from '@bufbuild/connect-web'
 import {ObjectiveService} from '../../proto/objectives/v1alpha1/objectives_connectweb'
 import {GraphRateResponse, Series} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {Timestamp} from '@bufbuild/protobuf'
+import {selectTimeRange} from './selectTimeRange'
 
 interface RequestsGraphProps {
   client: PromiseClient<typeof ObjectiveService>
@@ -19,6 +20,7 @@ interface RequestsGraphProps {
   from: number
   to: number
   uPlotCursor: uPlot.Cursor
+  updateTimeRange: (min: number, max: number, absolute: boolean) => void
 }
 
 const RequestsGraph = ({
@@ -28,6 +30,7 @@ const RequestsGraph = ({
   from,
   to,
   uPlotCursor,
+  updateTimeRange,
 }: RequestsGraphProps): JSX.Element => {
   const targetRef = useRef() as React.MutableRefObject<HTMLDivElement>
 
@@ -151,6 +154,9 @@ const RequestsGraph = ({
                     max: {},
                   },
                 },
+              },
+              hooks: {
+                setSelect: [selectTimeRange(updateTimeRange)],
               },
             }}
             data={requests}

--- a/ui/src/components/graphs/selectTimeRange.tsx
+++ b/ui/src/components/graphs/selectTimeRange.tsx
@@ -1,0 +1,10 @@
+import uPlot from 'uplot'
+
+export const selectTimeRange =
+  (updateTimeRange: (min: number, max: number, absolute: boolean) => void) => (u: uPlot) => {
+    if (u.select.width > 0) {
+      const min = u.posToVal(u.select.left, 'x')
+      const max = u.posToVal(u.select.left + u.select.width, 'x')
+      updateTimeRange(Math.floor(min * 1000), Math.floor(max * 1000), true)
+    }
+  }


### PR DESCRIPTION
Using text like `now` and `now-12h` will not spam the browser's history like reported in #590.

However, selecting a specific time range with the cursor in the graphs will now still select the very specific timestamps and store them in the URL.