### PR TITLE
ui: Replace interval in queries - refactor duration

### DIFF
--- a/main.go
+++ b/main.go
@@ -564,8 +564,8 @@ func (s *objectiveServer) List(ctx context.Context, req *connect.Request[objecti
 			CountTotal:       oi.QueryTotal(oi.Window),
 			CountErrors:      oi.QueryErrors(oi.Window),
 			GraphErrorBudget: oi.QueryErrorBudget(),
-			GraphRequests:    oi.RequestRange(5 * time.Minute),
-			GraphErrors:      oi.ErrorsRange(5 * time.Minute),
+			GraphRequests:    oi.RequestRange(time.Second),
+			GraphErrors:      oi.ErrorsRange(time.Second),
 		}
 	}
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,6 +4,7 @@ import List from './pages/List'
 import Detail from './pages/Detail'
 import {LabelMatcher, Latency, Objective} from './proto/objectives/v1alpha1/objectives_pb'
 import {QueryClient, QueryClientProvider} from 'react-query'
+import {formatDuration} from './duration'
 
 // @ts-expect-error - this is passed from the HTML template.
 export const PATH_PREFIX: string = window.PATH_PREFIX
@@ -122,81 +123,3 @@ export const dateFormatterFull = (t: number): string => {
 }
 
 export default App
-
-// From prometheus/prometheus
-
-export const formatDuration = (d: number, precision: number = 2): string => {
-  let ms = d
-  let r = ''
-  if (ms === 0) {
-    return '0s'
-  }
-
-  let precisionCount = 0
-
-  const f = (unit: string, mult: number, exact: boolean) => {
-    if ((exact && ms % mult !== 0) || precisionCount === precision) {
-      return
-    }
-    const v = Math.floor(ms / mult)
-    if (v > 0) {
-      r += `${v}${unit}`
-      ms -= v * mult
-      precisionCount++
-    }
-  }
-
-  // Only format years and weeks if the remainder is zero, as it is often
-  // easier to read 90d than 12w6d.
-  f('y', 1000 * 60 * 60 * 24 * 365, true)
-  f('w', 1000 * 60 * 60 * 24 * 7, true)
-
-  f('d', 1000 * 60 * 60 * 24, false)
-  f('h', 1000 * 60 * 60, false)
-  f('m', 1000 * 60, false)
-  f('s', 1000, false)
-  f('ms', 1, false)
-  f('μs', 0.001, false)
-  f('ns', 0.001 * 0.001, false)
-
-  return r
-}
-
-export const parseDuration = (durationStr: string): number | null => {
-  if (durationStr === '') {
-    return null
-  }
-  if (durationStr === '0') {
-    // Allow 0 without a unit.
-    return 0
-  }
-
-  const durationRE =
-    /^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$/
-  const matches = durationStr.match(durationRE)
-  if (matches === null) {
-    return null
-  }
-
-  let dur = 0
-
-  // Parse the match at pos `pos` in the regex and use `mult` to turn that
-  // into ms, then add that value to the total parsed duration.
-  const m = (pos: number, mult: number) => {
-    if (matches[pos] === undefined) {
-      return
-    }
-    const n = parseInt(matches[pos])
-    dur += n * mult
-  }
-
-  m(2, 1000 * 60 * 60 * 24 * 365) // y
-  m(4, 1000 * 60 * 60 * 24 * 7) // w
-  m(6, 1000 * 60 * 60 * 24) // d
-  m(8, 1000 * 60 * 60) // h
-  m(10, 1000 * 60) // m
-  m(12, 1000) // s
-  m(14, 1) // ms
-
-  return dur
-}

--- a/ui/src/components/AlertsTable.tsx
+++ b/ui/src/components/AlertsTable.tsx
@@ -1,11 +1,12 @@
 import {OverlayTrigger, Table, Tooltip as OverlayTooltip} from 'react-bootstrap'
 import React, {useEffect, useState} from 'react'
-import {formatDuration, PROMETHEUS_URL} from '../App'
+import {PROMETHEUS_URL} from '../App'
 import {IconExternal} from './Icons'
 import {Labels, labelsString} from '../labels'
 import {Alert, GetAlertsResponse, Objective} from '../proto/objectives/v1alpha1/objectives_pb'
 import {PromiseClient} from '@bufbuild/connect-web'
 import {ObjectiveService} from '../proto/objectives/v1alpha1/objectives_connectweb'
+import {formatDuration} from '../duration'
 
 interface AlertsTableProps {
   client: PromiseClient<typeof ObjectiveService>

--- a/ui/src/components/graphs/DurationGraph.tsx
+++ b/ui/src/components/graphs/DurationGraph.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useLayoutEffect, useRef, useState} from 'react'
 import {Spinner} from 'react-bootstrap'
 import UplotReact from 'uplot-react'
 import uPlot, {AlignedData} from 'uplot'
-import {formatDuration, PROMETHEUS_URL} from '../../App'
+import {PROMETHEUS_URL} from '../../App'
 import {IconExternal} from '../Icons'
 import {Labels, labelsString, parseLabelValue} from '../../labels'
 import {colorful, reds} from './colors'
@@ -16,6 +16,7 @@ import {
   Timeseries,
 } from '../../proto/objectives/v1alpha1/objectives_pb'
 import {selectTimeRange} from './selectTimeRange'
+import {formatDuration} from '../../duration'
 
 interface DurationGraphProps {
   client: PromiseClient<typeof ObjectiveService>

--- a/ui/src/components/graphs/ErrorBudgetGraph.tsx
+++ b/ui/src/components/graphs/ErrorBudgetGraph.tsx
@@ -3,7 +3,7 @@ import {Spinner} from 'react-bootstrap'
 import UplotReact from 'uplot-react'
 import uPlot, {AlignedData} from 'uplot'
 
-import {formatDuration, PROMETHEUS_URL} from '../../App'
+import {PROMETHEUS_URL} from '../../App'
 import {IconExternal} from '../Icons'
 import {greens, reds} from './colors'
 import {seriesGaps} from './gaps'
@@ -12,6 +12,7 @@ import {PrometheusService} from '../../proto/prometheus/v1/prometheus_connectweb
 import {usePrometheusQueryRange} from '../../prometheus'
 import {SamplePair, SampleStream} from '../../proto/prometheus/v1/prometheus_pb'
 import {selectTimeRange} from './selectTimeRange'
+import {formatDuration} from '../../duration'
 
 interface ErrorBudgetGraphProps {
   client: PromiseClient<typeof PrometheusService>

--- a/ui/src/components/graphs/ErrorsGraph.tsx
+++ b/ui/src/components/graphs/ErrorsGraph.tsx
@@ -2,7 +2,7 @@ import React, {useLayoutEffect, useRef, useState} from 'react'
 import {Spinner} from 'react-bootstrap'
 import UplotReact from 'uplot-react'
 import uPlot from 'uplot'
-import {formatDuration, ObjectiveType, PROMETHEUS_URL} from '../../App'
+import {ObjectiveType, PROMETHEUS_URL} from '../../App'
 import {IconExternal} from '../Icons'
 import {reds} from './colors'
 import {seriesGaps} from './gaps'
@@ -12,6 +12,7 @@ import {PrometheusService} from '../../proto/prometheus/v1/prometheus_connectweb
 import {step} from './step'
 import {convertAlignedData} from './aligneddata'
 import {selectTimeRange} from './selectTimeRange'
+import {formatDuration} from '../../duration'
 
 interface ErrorsGraphProps {
   client: PromiseClient<typeof PrometheusService>
@@ -95,9 +96,24 @@ const ErrorsGraph = ({
 
   const {labels, data} = convertAlignedData(response)
 
+  let headline = 'Errors'
+  let description: string
+  switch (type) {
+    case ObjectiveType.Ratio:
+      description = 'What percentage of requests were errors?'
+      break
+    case ObjectiveType.Latency:
+      headline = 'Too Slow'
+      description = 'What percentage of requests were too slow?'
+      break
+    case ObjectiveType.BoolGauge:
+      description = 'What percentage of probes were errors?'
+  }
+
   return (
     <>
       <div style={{display: 'flex', alignItems: 'baseline', justifyContent: 'space-between'}}>
+        <h4 className="graphs-headline">{headline}</h4>
         <a
           className="external-prometheus"
           target="_blank"
@@ -110,11 +126,7 @@ const ErrorsGraph = ({
         </a>
       </div>
       <div>
-        {type === ObjectiveType.Latency ? (
-          <p>What percentage of requests were too slow?</p>
-        ) : (
-          <p>What percentage of {type === ObjectiveType.Ratio ? "requests" : "probes"} were errors?</p>
-        )}
+        <p>{description}</p>
       </div>
 
       <div ref={targetRef}>
@@ -151,9 +163,10 @@ const ErrorsGraph = ({
                 values: (uplot: uPlot, v: number[]) => v.map((v: number) => `${v}%`),
               },
             ],
-          hooks: {
-                setSelect: [selectTimeRange(updateTimeRange)],
-              },}}
+            hooks: {
+              setSelect: [selectTimeRange(updateTimeRange)],
+            },
+          }}
           data={data}
         />
       </div>

--- a/ui/src/components/graphs/RequestsGraph.tsx
+++ b/ui/src/components/graphs/RequestsGraph.tsx
@@ -2,7 +2,7 @@ import React, {useLayoutEffect, useRef, useState} from 'react'
 import {Spinner} from 'react-bootstrap'
 import UplotReact from 'uplot-react'
 import uPlot from 'uplot'
-import {formatDuration, ObjectiveType, PROMETHEUS_URL} from '../../App'
+import {ObjectiveType, PROMETHEUS_URL} from '../../App'
 import {IconExternal} from '../Icons'
 import {blues, greens, reds, yellows} from './colors'
 import {seriesGaps} from './gaps'
@@ -12,6 +12,7 @@ import {PrometheusService} from '../../proto/prometheus/v1/prometheus_connectweb
 import {step} from './step'
 import {convertAlignedData} from './aligneddata'
 import {selectTimeRange} from './selectTimeRange'
+import {formatDuration} from '../../duration'
 
 interface RequestsGraphProps {
   client: PromiseClient<typeof PrometheusService>
@@ -94,10 +95,17 @@ const RequestsGraph = ({
     reds: 0,
   }
 
+  let headline = 'Requests'
+  let description = 'How many requests per second have there been?'
+  if (type === ObjectiveType.BoolGauge) {
+    headline = 'Probes'
+    description = 'How many probes per second have there been?'
+  }
+
   return (
     <div>
       <div style={{display: 'flex', alignItems: 'baseline', justifyContent: 'space-between'}}>
-        <h4 className="graphs-headline">{type === ObjectiveType.Ratio ? 'Requests' : 'Probes'}</h4>
+        <h4 className="graphs-headline">{headline}</h4>
         <a
           className="external-prometheus"
           target="_blank"
@@ -110,11 +118,7 @@ const RequestsGraph = ({
         </a>
       </div>
       <div>
-        {type === ObjectiveType.Ratio ? (
-          <p>How many requests per second have there been?</p>
-        ) : (
-          <p>How many probes per second have there been?</p>
-        )}
+        <p>{description}</p>
       </div>
 
       <div ref={targetRef}>
@@ -174,7 +178,7 @@ const RequestsGraph = ({
 const labelColor = (picked: {[color: string]: number}, label: string): string => {
   label = label.toLowerCase()
   let color = ''
-  if (label === '{}') {
+  if (label === '{}' || label === '' || label === 'value') {
     color = greens[picked.greens % greens.length]
     picked.greens++
   }

--- a/ui/src/duration.tsx
+++ b/ui/src/duration.tsx
@@ -1,0 +1,77 @@
+// From prometheus/prometheus
+
+export const formatDuration = (d: number, precision: number = 2): string => {
+  let ms = d
+  let r = ''
+  if (ms === 0) {
+    return '0s'
+  }
+
+  let precisionCount = 0
+
+  const f = (unit: string, mult: number, exact: boolean) => {
+    if ((exact && ms % mult !== 0) || precisionCount === precision) {
+      return
+    }
+    const v = Math.floor(ms / mult)
+    if (v > 0) {
+      r += `${v}${unit}`
+      ms -= v * mult
+      precisionCount++
+    }
+  }
+
+  // Only format years and weeks if the remainder is zero, as it is often
+  // easier to read 90d than 12w6d.
+  f('y', 1000 * 60 * 60 * 24 * 365, true)
+  f('w', 1000 * 60 * 60 * 24 * 7, true)
+
+  f('d', 1000 * 60 * 60 * 24, false)
+  f('h', 1000 * 60 * 60, false)
+  f('m', 1000 * 60, false)
+  f('s', 1000, false)
+  f('ms', 1, false)
+  f('μs', 0.001, false)
+  f('ns', 0.001 * 0.001, false)
+
+  return r
+}
+
+export const parseDuration = (durationStr: string): number | null => {
+  if (durationStr === '') {
+    return null
+  }
+  if (durationStr === '0') {
+    // Allow 0 without a unit.
+    return 0
+  }
+
+  const durationRE =
+    /^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$/
+  const matches = durationStr.match(durationRE)
+  if (matches === null) {
+    return null
+  }
+
+  let dur = 0
+
+  // Parse the match at pos `pos` in the regex and use `mult` to turn that
+  // into ms, then add that value to the total parsed duration.
+  const m = (pos: number, mult: number) => {
+    if (matches[pos] === undefined) {
+      return
+    }
+    const n = parseInt(matches[pos])
+    dur += n * mult
+  }
+
+  m(2, 1000 * 60 * 60 * 24 * 365) // y
+  m(4, 1000 * 60 * 60 * 24 * 7) // w
+  m(6, 1000 * 60 * 60 * 24) // d
+  m(8, 1000 * 60 * 60) // h
+  m(10, 1000 * 60) // m
+  m(12, 1000) // s
+  m(14, 1) // ms
+
+  return dur
+}

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -13,11 +13,9 @@ import {
 } from 'react-bootstrap'
 import {
   API_BASEPATH,
-  formatDuration,
   hasObjectiveType,
   latencyTarget,
   ObjectiveType,
-  parseDuration,
   renderLatencyTarget,
 } from '../App'
 import Navbar from '../components/Navbar'
@@ -32,9 +30,10 @@ import Toggle from '../components/Toggle'
 import DurationGraph from '../components/graphs/DurationGraph'
 import uPlot from 'uplot'
 import {PrometheusService} from '../proto/prometheus/v1/prometheus_connectweb'
-import {usePrometheusQuery} from '../prometheus'
+import {replaceInterval, usePrometheusQuery} from '../prometheus'
 import {useObjectivesList} from '../objectives'
 import {Objective} from '../proto/objectives/v1alpha1/objectives_pb'
+import {formatDuration, parseDuration} from '../duration'
 
 const Detail = () => {
   const client = useMemo(() => {
@@ -490,7 +489,7 @@ const Detail = () => {
               {objective.queries?.graphRequests !== undefined ? (
                 <RequestsGraph
                   client={promClient}
-                  query={objective.queries.graphRequests}
+                  query={replaceInterval(objective.queries.graphRequests, from, to)}
                   from={from}
                   to={to}
                   uPlotCursor={uPlotCursor}
@@ -509,7 +508,7 @@ const Detail = () => {
                 <ErrorsGraph
                   client={promClient}
                   type={objectiveType}
-                  query={objective.queries.graphErrors}
+                  query={replaceInterval(objective.queries.graphErrors, from, to)}
                   from={from}
                   to={to}
                   uPlotCursor={uPlotCursor}

--- a/ui/src/pages/List.tsx
+++ b/ui/src/pages/List.tsx
@@ -13,7 +13,6 @@ import {
 } from 'react-bootstrap'
 import {
   API_BASEPATH,
-  formatDuration,
   hasObjectiveType,
   latencyTarget,
   ObjectiveType,
@@ -34,6 +33,7 @@ import {
   Objective,
   ObjectiveStatus,
 } from '../proto/objectives/v1alpha1/objectives_pb'
+import {formatDuration} from '../duration'
 
 enum TableObjectiveState {
   Unknown,

--- a/ui/src/prometheus.spec.tsx
+++ b/ui/src/prometheus.spec.tsx
@@ -1,0 +1,26 @@
+import {replaceInterval} from './prometheus'
+
+describe('replaceInterval', () => {
+  it('should parse a request graph query', () => {
+    expect(
+      replaceInterval(
+        'sum(rate(grpc_server_handling_seconds_count{grpc_method="ProfileTypes",grpc_service="parca.query.v1alpha1.QueryService"}[1s]))',
+        0,
+        60 * 60 * 1000,
+      ),
+    ).toEqual(
+      'sum(rate(grpc_server_handling_seconds_count{grpc_method="ProfileTypes",grpc_service="parca.query.v1alpha1.QueryService"}[5m]))',
+    )
+  })
+  it('should parse a errors graph query', () => {
+    expect(
+      replaceInterval(
+        '(sum(rate(caddy_http_response_duration_seconds_count{code!~"5..",handler="subroute",job="caddy"}[1s])) - sum(rate(caddy_http_response_duration_seconds_bucket{code!~"5..",handler="subroute",job="caddy",le="0.05"}[1s]))) / sum(rate(caddy_http_response_duration_seconds_count{code!~"5..",handler="subroute",job="caddy"}[1s]))',
+        0,
+        14 * 24 * 60 * 60 * 1000,
+      ),
+    ).toEqual(
+      '(sum(rate(caddy_http_response_duration_seconds_count{code!~"5..",handler="subroute",job="caddy"}[1h])) - sum(rate(caddy_http_response_duration_seconds_bucket{code!~"5..",handler="subroute",job="caddy",le="0.05"}[1h]))) / sum(rate(caddy_http_response_duration_seconds_count{code!~"5..",handler="subroute",job="caddy"}[1h]))',
+    )
+  })
+})

--- a/ui/src/prometheus.tsx
+++ b/ui/src/prometheus.tsx
@@ -3,6 +3,7 @@ import {PrometheusService} from './proto/prometheus/v1/prometheus_connectweb'
 import {ConnectError, PromiseClient} from '@bufbuild/connect-web'
 import {QueryStatus} from 'react-query/types/core/types'
 import {QueryOptions, useConnectQuery} from './query'
+import {formatDuration} from './duration'
 
 export interface PrometheusQueryResponse {
   response: QueryResponse | null
@@ -59,4 +60,29 @@ export const usePrometheusQueryRange = (
   })
 
   return {response: data ?? null, error: error as ConnectError, status}
+}
+
+export const replaceInterval = (query: string, from: number, to: number): string => {
+  const duration: number = (to - from) / 1000
+
+  const minute = 60
+  const hour = 60 * minute
+  const day = 24 * hour
+  const week = 7 * day
+  const month = 4 * week
+
+  let rateInterval: number = 5 * 60
+  if (duration >= month) {
+    rateInterval = 3 * hour
+  } else if (duration >= week) {
+    rateInterval = hour
+  } else if (duration >= day) {
+    rateInterval = 30 * minute
+  } else if (duration >= day / 2) {
+    rateInterval = 15 * minute
+  }
+
+  const rateIntervalStr = formatDuration(rateInterval * 1000, 1)
+
+  return query.replaceAll(/\[(1s)\]/g, `[${rateIntervalStr}]`)
 }


### PR DESCRIPTION
The new approach of sending the queries along with the objective has the drawback of hardcoding the interval. This will now use `1s` window intervals and replace them in the string with the actually wanted interval windows - what previously had been done on the backend. 