### PR TITLE
Add burnrate graphs to multi burn rate alerts table

### DIFF
--- a/ui/src/components/AlertsTable.scss
+++ b/ui/src/components/AlertsTable.scss
@@ -18,4 +18,22 @@
     border-left: 5px solid $red;
     color: darken($red, 40%);
   }
+
+  tr button.accordion {
+    border: none;
+    background: none;
+
+    svg {
+      transform: rotateZ(0deg);
+      transition: transform 0.5s;
+    }
+
+    &.down svg {
+      transform: rotateZ(90deg);
+    }
+  }
+
+  tr.burnrate {
+    background-color: $gray-100;
+  }
 }

--- a/ui/src/components/AlertsTable.tsx
+++ b/ui/src/components/AlertsTable.tsx
@@ -1,23 +1,53 @@
 import {OverlayTrigger, Table, Tooltip as OverlayTooltip} from 'react-bootstrap'
 import React, {useEffect, useState} from 'react'
 import {PROMETHEUS_URL} from '../App'
-import {IconExternal} from './Icons'
+import {IconChevron, IconExternal} from './Icons'
 import {Labels, labelsString} from '../labels'
-import {Alert, GetAlertsResponse, Objective} from '../proto/objectives/v1alpha1/objectives_pb'
+import {
+  Alert,
+  Alert_State,
+  GetAlertsResponse,
+  Objective,
+} from '../proto/objectives/v1alpha1/objectives_pb'
 import {PromiseClient} from '@bufbuild/connect-web'
 import {ObjectiveService} from '../proto/objectives/v1alpha1/objectives_connectweb'
+import BurnrateGraph from './graphs/BurnrateGraph'
+import uPlot from 'uplot'
+import {PrometheusService} from '../proto/prometheus/v1/prometheus_connectweb'
+import {usePrometheusQueryRange} from '../prometheus'
+import {step} from './graphs/step'
+import {convertAlignedData} from './graphs/aligneddata'
 import {formatDuration} from '../duration'
 
 interface AlertsTableProps {
   client: PromiseClient<typeof ObjectiveService>
+  promClient: PromiseClient<typeof PrometheusService>
   objective: Objective
   grouping: Labels
+  from: number
+  to: number
+  uPlotCursor: uPlot.Cursor
 }
 
 const alertStateString = ['inactive', 'pending', 'firing']
 
-const AlertsTable = ({client, objective, grouping}: AlertsTableProps): JSX.Element => {
+const AlertsTable = ({
+  client,
+  promClient,
+  objective,
+  grouping,
+  from,
+  to,
+  uPlotCursor,
+}: AlertsTableProps): JSX.Element => {
   const [alerts, setAlerts] = useState<Alert[]>([])
+  const [showBurnrate, setShowBurnrate] = useState<boolean[]>([false, false, false, false])
+
+  useEffect(() => {
+    if (alerts.length > 0) {
+      setShowBurnrate(alerts.map((a: Alert): boolean => a.state !== Alert_State.inactive))
+    }
+  }, [alerts])
 
   useEffect(() => {
     client
@@ -33,11 +63,21 @@ const AlertsTable = ({client, objective, grouping}: AlertsTableProps): JSX.Eleme
       .catch((err) => console.log(err))
   }, [client, objective, grouping])
 
+  const {response: alertsRangeResponse} = usePrometheusQueryRange(
+    promClient,
+    `ALERTS{slo="${objective.labels.__name__}"}`,
+    from / 1000,
+    to / 1000,
+    step(from, to),
+    {enabled: objective.labels.__name__ !== ''},
+  )
+
   return (
     <div className="table-responsive">
       <Table className="table-alerts">
         <thead>
           <tr>
+            <th style={{width: '5%'}}></th>
             <th style={{width: '10%'}}>State</th>
             <th style={{width: '10%'}}>Severity</th>
             <th style={{width: '10%', textAlign: 'right'}}>Exhaustion</th>
@@ -69,62 +109,97 @@ const AlertsTable = ({client, objective, grouping}: AlertsTableProps): JSX.Eleme
               longCurrent = a.long?.current.toFixed(3)
             }
 
+            const {labels} = convertAlignedData(alertsRangeResponse)
+
+            console.log(labels)
+
             return (
-              <tr key={i} className={alertStateString[a.state]}>
-                <td>{alertStateString[a.state]}</td>
-                <td>{a.severity}</td>
-                <td style={{textAlign: 'right'}}>
-                  <OverlayTrigger
-                    key={i}
-                    overlay={
-                      <OverlayTooltip id={`tooltip-${i}`}>
-                        If this alert is firing, the entire Error Budget can be burnt within that
-                        time frame.
-                      </OverlayTooltip>
-                    }>
-                    <span>
-                      {formatDuration((Number(objective.window?.seconds) * 1000) / a.factor)}
-                    </span>
-                  </OverlayTrigger>
-                </td>
-                <td style={{textAlign: 'right'}}>
-                  <OverlayTrigger
-                    key={i}
-                    overlay={
-                      <OverlayTooltip id={`tooltip-${i}`}>
-                        {a.factor} * (1 - {objective.target})
-                      </OverlayTooltip>
-                    }>
-                    <span>{(a.factor * (1 - objective?.target)).toFixed(3)}</span>
-                  </OverlayTrigger>
-                </td>
-                <td style={{textAlign: 'center'}}>
-                  <small style={{opacity: 0.5}}>&gt;</small>
-                </td>
-                <td style={{textAlign: 'left'}}>
-                  {shortCurrent} ({formatDuration(Number(a.short?.window?.seconds) * 1000)})
-                </td>
-                <td style={{textAlign: 'left'}}>
-                  <small style={{opacity: 0.5}}>and</small>
-                </td>
-                <td style={{textAlign: 'left'}}>
-                  {longCurrent} ({formatDuration(Number(a.long?.window?.seconds) * 1000)})
-                </td>
-                <td style={{textAlign: 'right'}}>
+              <>
+                <tr key={i} className={alertStateString[a.state]}>
+                  <td>
+                    <button
+                      className={showBurnrate[i] ? 'accordion down' : 'accordion'}
+                      onClick={() => {
+                        const updated = [...showBurnrate]
+                        updated[i] = !showBurnrate[i]
+                        setShowBurnrate(updated)
+                      }}>
+                      <IconChevron height={16} width={16} />
+                    </button>
+                  </td>
+                  <td>{alertStateString[a.state]}</td>
+                  <td>{a.severity}</td>
+                  <td style={{textAlign: 'right'}}>
+                    <OverlayTrigger
+                      key={i}
+                      overlay={
+                        <OverlayTooltip id={`tooltip-${i}`}>
+                          If this alert is firing, the entire Error Budget can be burnt within that
+                          time frame.
+                        </OverlayTooltip>
+                      }>
+                      <span>
+                        {formatDuration((Number(objective.window?.seconds) * 1000) / a.factor)}
+                      </span>
+                    </OverlayTrigger>
+                  </td>
+                  <td style={{textAlign: 'right'}}>
+                    <OverlayTrigger
+                      key={i}
+                      overlay={
+                        <OverlayTooltip id={`tooltip-${i}`}>
+                          {a.factor} * (1 - {objective.target})
+                        </OverlayTooltip>
+                      }>
+                      <span>{(a.factor * (1 - objective?.target)).toFixed(3)}</span>
+                    </OverlayTrigger>
+                  </td>
+                  <td style={{textAlign: 'center'}}>
+                    <small style={{opacity: 0.5}}>&gt;</small>
+                  </td>
+                  <td style={{textAlign: 'left'}}>
+                    {shortCurrent} ({formatDuration(Number(a.short?.window?.seconds) * 1000)})
+                  </td>
+                  <td style={{textAlign: 'left'}}>
+                    <small style={{opacity: 0.5}}>and</small>
+                  </td>
+                  <td style={{textAlign: 'left'}}>
+                    {longCurrent} ({formatDuration(Number(a.long?.window?.seconds) * 1000)})
+                  </td>
+                  <td style={{textAlign: 'right'}}>
                   {formatDuration(Number(a.for?.seconds) * 1000)}
                 </td>
-                <td>
-                  <a
-                    className="external-prometheus"
-                    target="_blank"
-                    rel="noreferrer"
-                    href={`${PROMETHEUS_URL}/graph?g0.expr=${encodeURIComponent(
-                      a.long?.query ?? '',
-                    )}&g0.tab=0&g1.expr=${encodeURIComponent(a.short?.query ?? '')}&g1.tab=0`}>
-                    <IconExternal height={20} width={20} />
-                  </a>
-                </td>
-              </tr>
+                  <td>
+                    <a
+                      className="external-prometheus"
+                      target="_blank"
+                      rel="noreferrer"
+                      href={`${PROMETHEUS_URL}/graph?g0.expr=${encodeURIComponent(
+                        a.long?.query ?? '',
+                      )}&g0.tab=0&g1.expr=${encodeURIComponent(a.short?.query ?? '')}&g1.tab=0`}>
+                      <IconExternal height={20} width={20} />
+                    </a>
+                    {showBurnrate[i]}
+                  </td>
+                </tr>
+                {a.short !== undefined && a.long !== undefined && showBurnrate[i] ? (
+                  <tr key={i + 10} className="burnrate">
+                    <td colSpan={11}>
+                      <BurnrateGraph
+                        client={promClient}
+                        short={a.short.query}
+                        long={a.long?.query}
+                        threshold={a.factor * (1 - objective.target)}
+                        from={from}
+                        to={to}
+                        uPlotCursor={uPlotCursor}
+                      />
+                    </td>
+                  </tr>
+                ) : (
+                  <></>
+                )}
+              </>
             )
           })}
         </tbody>

--- a/ui/src/components/AlertsTable.tsx
+++ b/ui/src/components/AlertsTable.tsx
@@ -101,17 +101,17 @@ const AlertsTable = ({
             if (a.short?.current === -1.0) {
               shortCurrent = 'NaN'
             } else if (a.short?.current === undefined) {
-              shortCurrent = (0).toFixed(3).toString()
+              shortCurrent = (0).toFixed(2).toString() + '%'
             } else {
-              shortCurrent = a.short.current.toFixed(3)
+              shortCurrent = (100 * a.short.current).toFixed(2) + '%'
             }
             let longCurrent = ''
             if (a.long?.current === -1.0) {
               longCurrent = 'NaN'
             } else if (a.long?.current === undefined) {
-              longCurrent = (0).toFixed(3).toString()
+              longCurrent = (0).toFixed(2).toString() + '%'
             } else {
-              longCurrent = a.long?.current.toFixed(3)
+              longCurrent = (100 * a.long.current).toFixed(2) + '%'
             }
 
             const seriesFiringIndex = alertsLabels.findIndex((al: Labels): boolean => {
@@ -173,10 +173,10 @@ const AlertsTable = ({
                       key={i}
                       overlay={
                         <OverlayTooltip id={`tooltip-${i}`}>
-                          {a.factor} * (1 - {objective.target})
+                          100 * {a.factor} * (1 - {objective.target})
                         </OverlayTooltip>
                       }>
-                      <span>{(a.factor * (1 - objective?.target)).toFixed(3)}</span>
+                      <span>{(100 * (a.factor * (1 - objective?.target))).toFixed(2)}%</span>
                     </OverlayTrigger>
                   </td>
                   <td style={{textAlign: 'center'}}>

--- a/ui/src/components/AlertsTable.tsx
+++ b/ui/src/components/AlertsTable.tsx
@@ -212,8 +212,7 @@ const AlertsTable = ({
                     <td colSpan={11}>
                       <BurnrateGraph
                         client={promClient}
-                        short={a.short.query}
-                        long={a.long?.query}
+                        alert={a}
                         threshold={a.factor * (1 - objective.target)}
                         from={from}
                         to={to}

--- a/ui/src/components/Icons.tsx
+++ b/ui/src/components/Icons.tsx
@@ -122,13 +122,13 @@ export const IconWarning = ({height, width, fill}: IconWarningProps): JSX.Elemen
   </svg>
 )
 
-interface IconRorateProps {
-  width: number
+interface IconChevronProps {
   height: number
+  width: number
 }
 
-export const IconRotate = ({width, height}: IconRorateProps): JSX.Element => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width={width} height={height}>
-    <path d="M449.9 39.96l-48.5 48.53C362.5 53.19 311.4 32 256 32C161.5 32 78.59 92.34 49.58 182.2c-5.438 16.81 3.797 34.88 20.61 40.28c16.97 5.5 34.86-3.812 40.3-20.59C130.9 138.5 189.4 96 256 96c37.96 0 73 14.18 100.2 37.8L311.1 178C295.1 194.8 306.8 223.4 330.4 224h146.9C487.7 223.7 496 215.3 496 204.9V59.04C496 34.99 466.9 22.95 449.9 39.96zM441.8 289.6c-16.94-5.438-34.88 3.812-40.3 20.59C381.1 373.5 322.6 416 256 416c-37.96 0-73-14.18-100.2-37.8L200 334C216.9 317.2 205.2 288.6 181.6 288H34.66C24.32 288.3 16 296.7 16 307.1v145.9c0 24.04 29.07 36.08 46.07 19.07l48.5-48.53C149.5 458.8 200.6 480 255.1 480c94.45 0 177.4-60.34 206.4-150.2C467.9 313 458.6 294.1 441.8 289.6z" />
+export const IconChevron = ({height, width}: IconChevronProps): JSX.Element => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512" width={width} height={height}>
+    <path d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z" />
   </svg>
 )

--- a/ui/src/components/graphs/BurnrateGraph.scss
+++ b/ui/src/components/graphs/BurnrateGraph.scss
@@ -1,0 +1,11 @@
+div.burnrate {
+  margin: 10px;
+  padding: 15px;
+  background-color: white;
+  border-radius: 5px;
+
+  h5.graphs-headline {
+    margin-top: 20px;
+    margin-left: 50px;
+  }
+}

--- a/ui/src/components/graphs/BurnrateGraph.scss
+++ b/ui/src/components/graphs/BurnrateGraph.scss
@@ -7,5 +7,9 @@ div.burnrate {
   h5.graphs-headline {
     margin-top: 20px;
     margin-left: 50px;
+    margin-bottom: 5px;
+  }
+  .graphs-description{
+    margin-left: 50px;
   }
 }

--- a/ui/src/components/graphs/BurnrateGraph.tsx
+++ b/ui/src/components/graphs/BurnrateGraph.tsx
@@ -1,6 +1,6 @@
 import {PromiseClient} from '@bufbuild/connect-web'
 import {PrometheusService} from '../../proto/prometheus/v1/prometheus_connectweb'
-import uPlot from 'uplot'
+import uPlot, {AlignedData} from 'uplot'
 import React, {useLayoutEffect, useRef, useState} from 'react'
 import {usePrometheusQueryRange} from '../../prometheus'
 import {step} from './step'
@@ -98,7 +98,7 @@ const BurnrateGraph = ({
   }
 
   const {data: mergedData} = mergeAlignedData(responses)
-  const data = [...mergedData, Array(mergedData[0].length).fill(threshold)]
+  const data: AlignedData = [...mergedData, Array(mergedData[0].length).fill(threshold)]
 
   // no data
   if (data[0].length === 0) {

--- a/ui/src/components/graphs/BurnrateGraph.tsx
+++ b/ui/src/components/graphs/BurnrateGraph.tsx
@@ -1,0 +1,181 @@
+import {PromiseClient} from '@bufbuild/connect-web'
+import {PrometheusService} from '../../proto/prometheus/v1/prometheus_connectweb'
+import uPlot from 'uplot'
+import React, {useLayoutEffect, useRef, useState} from 'react'
+import {usePrometheusQueryRange} from '../../prometheus'
+import {step} from './step'
+import UplotReact from 'uplot-react'
+import {AlignedDataResponse, convertAlignedData, mergeAlignedData} from './aligneddata'
+import {Spinner} from 'react-bootstrap'
+import {seriesGaps} from './gaps'
+import {blues, reds} from './colors'
+
+interface BurnrateGraphProps {
+  client: PromiseClient<typeof PrometheusService>
+  short: string
+  long: string
+  threshold: number
+  from: number
+  to: number
+  uPlotCursor: uPlot.Cursor
+}
+
+const BurnrateGraph = ({
+  client,
+  short,
+  threshold,
+  long,
+  from,
+  to,
+  uPlotCursor,
+}: BurnrateGraphProps): JSX.Element => {
+  const targetRef = useRef() as React.MutableRefObject<HTMLDivElement>
+
+  const [width, setWidth] = useState<number>(500)
+
+  const setWidthFromContainer = () => {
+    if (targetRef?.current !== undefined && targetRef?.current !== null) {
+      setWidth(targetRef.current.offsetWidth)
+    }
+  }
+
+  // Set width on first render
+  useLayoutEffect(setWidthFromContainer)
+  // Set width on every window resize
+  window.addEventListener('resize', setWidthFromContainer)
+
+  const {response: shortResponse, status: shortStatus} = usePrometheusQueryRange(
+    client,
+    short,
+    from / 1000,
+    to / 1000,
+    step(from, to),
+  )
+
+  const {response: longResponse, status: longStatus} = usePrometheusQueryRange(
+    client,
+    long,
+    from / 1000,
+    to / 1000,
+    step(from, to),
+  )
+
+  // TODO: Improve to show graph if one is succeeded already
+  if (
+    shortStatus === 'loading' ||
+    shortStatus === 'idle' ||
+    longStatus === 'loading' ||
+    longStatus === 'idle'
+  ) {
+    return (
+      <div style={{display: 'flex', alignItems: 'baseline', justifyContent: 'space-between'}}>
+        <h4 className="graphs-headline">
+          Errors
+          <Spinner
+            animation="border"
+            style={{
+              marginLeft: '1rem',
+              marginBottom: '0.5rem',
+              width: '1rem',
+              height: '1rem',
+              borderWidth: '1px',
+            }}
+          />
+        </h4>
+      </div>
+    )
+  }
+
+  const shortData = convertAlignedData(shortResponse)
+  const longData = convertAlignedData(longResponse)
+
+  const responses: AlignedDataResponse[] = []
+  if (shortData !== null) {
+    responses.push(shortData)
+  }
+  if (longData !== null) {
+    responses.push(longData)
+  }
+
+  const {data: mergedData} = mergeAlignedData(responses)
+  const data = [...mergedData, Array(mergedData[0].length).fill(threshold)]
+
+  // no data
+  if (data[0].length === 0) {
+    return (
+      <div ref={targetRef} className="burnrate">
+        <h5 className="graphs-headline">Burnrate</h5>
+        <UplotReact
+          options={{
+            width: width - (2 * 10 + 2 * 15), // margin and padding
+            height: 150,
+            padding: [15, 0, 0, 0],
+            cursor: uPlotCursor,
+            series: [
+              {},
+              {
+                min: 0,
+                label: 'short',
+                gaps: seriesGaps(from / 1000, to / 1000),
+                stroke: `#${reds[1]}`,
+              },
+              {
+                min: 0,
+                label: 'long',
+                gaps: seriesGaps(from / 1000, to / 1000),
+                stroke: `#${reds[2]}`,
+              },
+              {
+                label: 'threshold',
+                stroke: `#${blues[0]}`,
+              },
+            ],
+            scales: {
+              x: {min: from / 1000, max: to / 1000},
+            },
+          }}
+          data={[[], [], [], []]}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div ref={targetRef} className="burnrate">
+      <h5 className="graphs-headline">Burnrate</h5>
+      <UplotReact
+        options={{
+          width: width - (2 * 10 + 2 * 15), // margin and padding
+          height: 150,
+          padding: [15, 0, 0, 0],
+          cursor: uPlotCursor,
+          series: [
+            {},
+            {
+              min: 0,
+              label: 'short',
+              gaps: seriesGaps(from / 1000, to / 1000),
+              stroke: `#${reds[1]}`,
+            },
+            {
+              min: 0,
+              label: 'long',
+              gaps: seriesGaps(from / 1000, to / 1000),
+              stroke: `#${reds[2]}`,
+            },
+            {
+              label: 'threshold',
+              stroke: `#${blues[0]}`,
+            },
+          ],
+          scales: {
+            x: {min: from / 1000, max: to / 1000},
+          },
+        }}
+        data={data}
+      />
+    </div>
+  )
+}
+
+export default BurnrateGraph

--- a/ui/src/components/graphs/BurnrateGraph.tsx
+++ b/ui/src/components/graphs/BurnrateGraph.tsx
@@ -212,8 +212,8 @@ const BurnrateGraph = ({
 
                 const {ctx} = u
                 const {top, height} = u.bbox
-                const pendingColor = 'rgba(244,163,42,0.2)'
-                const firingColor = 'rgba(244,99,99,0.2)'
+                const pendingColor = 'rgba(244,163,42,0.1)'
+                const firingColor = 'rgba(244,99,99,0.1)'
                 ctx.save()
 
                 let startPending: number = 0

--- a/ui/src/components/graphs/BurnrateGraph.tsx
+++ b/ui/src/components/graphs/BurnrateGraph.tsx
@@ -154,14 +154,14 @@ const BurnrateGraph = ({
                 label: 'short',
                 gaps: seriesGaps(from / 1000, to / 1000),
                 stroke: `#${reds[1]}`,
-                value: (u, v) => (v == null ? '-' : v.toFixed(2) + '%'),
+                value: (u, v) => (v == null ? '-' : (100 * v).toFixed(2) + '%'),
               },
               {
                 min: 0,
                 label: 'long',
                 gaps: seriesGaps(from / 1000, to / 1000),
                 stroke: `#${reds[2]}`,
-                value: (u, v) => (v == null ? '-' : v.toFixed(2) + '%'),
+                value: (u, v) => (v == null ? '-' : (100 * v).toFixed(2) + '%'),
               },
               {
                 label: 'threshold',
@@ -171,6 +171,13 @@ const BurnrateGraph = ({
             scales: {
               x: {min: from / 1000, max: to / 1000},
             },
+            axes: [
+              {},
+              {
+                values: (uplot: uPlot, v: number[]) =>
+                  v.map((v: number) => `${(100 * v).toFixed(2)}%`),
+              },
+            ],
           }}
           data={[[], [], [], []]}
         />
@@ -205,22 +212,32 @@ const BurnrateGraph = ({
               label: `short (${shortFormatted})`,
               gaps: seriesGaps(from / 1000, to / 1000),
               stroke: '#42a5f5',
+              value: (u, v) => (v == null ? '-' : (100 * v).toFixed(2) + '%'),
             },
             {
               min: 0,
               label: `long (${longFormatted})`,
               gaps: seriesGaps(from / 1000, to / 1000),
               stroke: '#651fff',
+              value: (u, v) => (v == null ? '-' : (100 * v).toFixed(2) + '%'),
             },
             {
               label: 'threshold',
               stroke: `#${greys[0]}`,
               dash: [25, 10],
+              value: (u, v) => (v == null ? '-' : (100 * v).toFixed(2) + '%'),
             },
           ],
           scales: {
             x: {min: from / 1000, max: to / 1000},
           },
+          axes: [
+            {},
+            {
+              values: (uplot: uPlot, v: number[]) =>
+                v.map((v: number) => `${(100 * v).toFixed(0)}%`),
+            },
+          ],
           hooks: {
             drawAxes: [
               (u: uPlot) => {

--- a/ui/src/components/graphs/BurnrateGraph.tsx
+++ b/ui/src/components/graphs/BurnrateGraph.tsx
@@ -154,12 +154,14 @@ const BurnrateGraph = ({
                 label: 'short',
                 gaps: seriesGaps(from / 1000, to / 1000),
                 stroke: `#${reds[1]}`,
+                value: (u, v) => (v == null ? '-' : v.toFixed(2) + '%'),
               },
               {
                 min: 0,
                 label: 'long',
                 gaps: seriesGaps(from / 1000, to / 1000),
                 stroke: `#${reds[2]}`,
+                value: (u, v) => (v == null ? '-' : v.toFixed(2) + '%'),
               },
               {
                 label: 'threshold',

--- a/ui/src/components/graphs/BurnrateGraph.tsx
+++ b/ui/src/components/graphs/BurnrateGraph.tsx
@@ -175,7 +175,7 @@ const BurnrateGraph = ({
               {},
               {
                 values: (uplot: uPlot, v: number[]) =>
-                  v.map((v: number) => `${(100 * v).toFixed(2)}%`),
+                  v.map((v: number) => `${(100 * v).toFixed(1)}%`),
               },
             ],
           }}
@@ -187,6 +187,10 @@ const BurnrateGraph = ({
 
   const shortFormatted = formatDuration(Number(alert.short?.window?.seconds) * 1000 ?? 0)
   const longFormatted = formatDuration(Number(alert.long?.window?.seconds) * 1000 ?? 0)
+  const pendingColor = 'rgb(244,163,42)'
+  const pendingBackgroundColor = 'rgba(244,163,42,0.1)'
+  const firingColor = 'rgb(244,99,99)'
+  const firingBackgroundColor = 'rgba(244,99,99,0.1)'
 
   return (
     <div ref={targetRef} className="burnrate">
@@ -194,9 +198,10 @@ const BurnrateGraph = ({
       <div className="graphs-description">
         <p>
           The short ({shortFormatted}) and long ({longFormatted}) burn rates <strong>both</strong>{' '}
-          have to be over the threshold ({threshold.toFixed(2)}). <br />
-          First, the alert is <i>pending</i> for {formatDuration(Number(alert.for?.seconds) * 1000)}{' '}
-          and then the alert will be <i>firing</i>.
+          have to be over the {(100 * threshold).toFixed(2)}% threshold. <br />
+          First, the alert is <i style={{color: pendingColor}}>pending</i> for{' '}
+          {formatDuration(Number(alert.for?.seconds) * 1000)} and then the alert will be{' '}
+          <i style={{color: firingColor}}>firing</i>.
         </p>
       </div>
       <UplotReact
@@ -235,7 +240,7 @@ const BurnrateGraph = ({
             {},
             {
               values: (uplot: uPlot, v: number[]) =>
-                v.map((v: number) => `${(100 * v).toFixed(0)}%`),
+                v.map((v: number) => `${(100 * v).toFixed(1)}%`),
             },
           ],
           hooks: {
@@ -247,8 +252,6 @@ const BurnrateGraph = ({
 
                 const {ctx} = u
                 const {top, height} = u.bbox
-                const pendingColor = 'rgba(244,163,42,0.1)'
-                const firingColor = 'rgba(244,99,99,0.1)'
                 ctx.save()
 
                 let startPending: number = 0
@@ -266,7 +269,7 @@ const BurnrateGraph = ({
                       drawingFiring = true
                     }
                     if (drawingFiring && firingSeries[i] === null) {
-                      ctx.fillStyle = firingColor
+                      ctx.fillStyle = firingBackgroundColor
                       ctx.fillRect(startFiring, top, cx - startFiring, height)
                       drawingFiring = false
                     }
@@ -278,7 +281,7 @@ const BurnrateGraph = ({
                       drawingPending = true
                     }
                     if (drawingPending && pendingSeries[i] === null) {
-                      ctx.fillStyle = pendingColor
+                      ctx.fillStyle = pendingBackgroundColor
                       ctx.fillRect(startPending, top, cx - startPending, height)
                       drawingPending = false
                     }
@@ -290,13 +293,13 @@ const BurnrateGraph = ({
 
                 // Firing until the very last timestamp, we need to draw the final rect
                 if (drawingFiring) {
-                  ctx.fillStyle = firingColor
+                  ctx.fillStyle = firingBackgroundColor
                   ctx.fillRect(startFiring, top, cx - startFiring, height)
                 }
 
                 // Pending until the very last timestamp, we need to draw the final rect
                 if (drawingPending) {
-                  ctx.fillStyle = pendingColor
+                  ctx.fillStyle = pendingBackgroundColor
                   ctx.fillRect(startPending, top, cx - startFiring, height)
                 }
 

--- a/ui/src/components/graphs/DurationGraph.tsx
+++ b/ui/src/components/graphs/DurationGraph.tsx
@@ -5,7 +5,7 @@ import uPlot, {AlignedData} from 'uplot'
 import {PROMETHEUS_URL} from '../../App'
 import {IconExternal} from '../Icons'
 import {Labels, labelsString, parseLabelValue} from '../../labels'
-import {colorful, reds} from './colors'
+import {colorful, greys} from './colors'
 import {seriesGaps} from './gaps'
 import {PromiseClient} from '@bufbuild/connect-web'
 import {ObjectiveService} from '../../proto/objectives/v1alpha1/objectives_connectweb'
@@ -169,7 +169,7 @@ const DurationGraph = ({
                 ...durationLabels.map((label: string, i: number): uPlot.Series => {
                   return {
                     min: 0,
-                    stroke: i === 0 ? `#${reds[0]}` : `#${colorful[i]}`,
+                    stroke: i === 0 ? `#${greys[0]}` : `#${colorful[i]}`,
                     dash: i === 0 ? [25, 10] : undefined,
                     label: parseLabelValue(label),
                     gaps: seriesGaps(from / 1000, to / 1000),

--- a/ui/src/components/graphs/ErrorsGraph.tsx
+++ b/ui/src/components/graphs/ErrorsGraph.tsx
@@ -145,7 +145,7 @@ const ErrorsGraph = ({
                   stroke: `#${reds[i]}`,
                   label: labelValues(label)[0],
                   gaps: seriesGaps(from / 1000, to / 1000),
-                  value: (u, v) => (v == null ? '-' : v.toFixed(2) + '%'),
+                  value: (u, v) => (v == null ? '-' : (100 * v).toFixed(2) + '%'),
                 }
               }),
             ],

--- a/ui/src/components/graphs/ErrorsGraph.tsx
+++ b/ui/src/components/graphs/ErrorsGraph.tsx
@@ -12,6 +12,7 @@ import {PrometheusService} from '../../proto/prometheus/v1/prometheus_connectweb
 import {step} from './step'
 import {convertAlignedData} from './aligneddata'
 import {selectTimeRange} from './selectTimeRange'
+import {Labels, labelValues} from '../../labels'
 import {formatDuration} from '../../duration'
 
 interface ErrorsGraphProps {
@@ -138,11 +139,11 @@ const ErrorsGraph = ({
             cursor: uPlotCursor,
             series: [
               {},
-              ...labels.map((label: string, i: number): uPlot.Series => {
+              ...labels.map((label: Labels, i: number): uPlot.Series => {
                 return {
                   min: 0,
                   stroke: `#${reds[i]}`,
-                  label: label,
+                  label: labelValues(label)[0],
                   gaps: seriesGaps(from / 1000, to / 1000),
                   value: (u, v) => (v == null ? '-' : v.toFixed(2) + '%'),
                 }

--- a/ui/src/components/graphs/ErrorsGraph.tsx
+++ b/ui/src/components/graphs/ErrorsGraph.tsx
@@ -161,7 +161,8 @@ const ErrorsGraph = ({
             axes: [
               {},
               {
-                values: (uplot: uPlot, v: number[]) => v.map((v: number) => `${v}%`),
+                values: (uplot: uPlot, v: number[]) =>
+                  v.map((v: number) => `${(100 * v).toFixed(0)}%`),
               },
             ],
             hooks: {

--- a/ui/src/components/graphs/RequestsGraph.tsx
+++ b/ui/src/components/graphs/RequestsGraph.tsx
@@ -12,6 +12,7 @@ import {PrometheusService} from '../../proto/prometheus/v1/prometheus_connectweb
 import {step} from './step'
 import {convertAlignedData} from './aligneddata'
 import {selectTimeRange} from './selectTimeRange'
+import {Labels, labelValues} from '../../labels'
 import {formatDuration} from '../../duration'
 
 interface RequestsGraphProps {
@@ -131,10 +132,11 @@ const RequestsGraph = ({
               cursor: uPlotCursor,
               series: [
                 {},
-                ...labels.map((label: string): uPlot.Series => {
+                ...labels.map((label: Labels): uPlot.Series => {
+                  const value = labelValues(label)[0]
                   return {
-                    label: label,
-                    stroke: `#${labelColor(pickedColors, label)}`,
+                    label: value,
+                    stroke: `#${labelColor(pickedColors, value)}`,
                     gaps: seriesGaps(from / 1000, to / 1000),
                     value: (u, v) => (v == null ? '-' : `${v.toFixed(2)}req/s`),
                   }
@@ -176,7 +178,7 @@ const RequestsGraph = ({
 }
 
 const labelColor = (picked: {[color: string]: number}, label: string): string => {
-  label = label.toLowerCase()
+  label = label !== undefined ? label.toLowerCase() : ''
   let color = ''
   if (label === '{}' || label === '' || label === 'value') {
     color = greens[picked.greens % greens.length]

--- a/ui/src/components/graphs/aligneddata.spec.tsx
+++ b/ui/src/components/graphs/aligneddata.spec.tsx
@@ -1,4 +1,4 @@
-import {convertAlignedData} from './aligneddata'
+import {convertAlignedData, mergeAlignedData} from './aligneddata'
 import {QueryRangeResponse} from '../../proto/prometheus/v1/prometheus_pb'
 
 describe('convertAlignedData', () => {
@@ -84,6 +84,85 @@ describe('convertAlignedData', () => {
         [1, 2, 3],
         [100, 200, 300],
         [null, 200, 400],
+      ],
+    })
+  })
+})
+
+describe('mergeAlignedData', () => {
+  it('should convert null into empty alignedData', () => {
+    expect(mergeAlignedData([])).toEqual({labels: [], data: []})
+  })
+  it('should merge by returning the single input', () => {
+    expect(
+      mergeAlignedData([
+        {
+          labels: ['pyrra'],
+          data: [
+            [1, 2, 3],
+            [100, 200, 300],
+          ],
+        },
+      ]),
+    ).toEqual({
+      labels: ['pyrra'],
+      data: [
+        [1, 2, 3],
+        [100, 200, 300],
+      ],
+    })
+  })
+  it('should merge two aligned inputs', () => {
+    expect(
+      mergeAlignedData([
+        {
+          labels: ['pyrra'],
+          data: [
+            [1, 2, 3],
+            [100, 200, 300],
+          ],
+        },
+        {
+          labels: ['parca'],
+          data: [
+            [1, 2, 3],
+            [1000, 2000, 3000],
+          ],
+        },
+      ]),
+    ).toEqual({
+      labels: ['pyrra', 'parca'],
+      data: [
+        [1, 2, 3],
+        [100, 200, 300],
+        [1000, 2000, 3000],
+      ],
+    })
+  })
+  it('should merge misaligned inputs', () => {
+    expect(
+      mergeAlignedData([
+        {
+          labels: ['pyrra'],
+          data: [
+            [2, 3, 4],
+            [200, 300, 400],
+          ],
+        },
+        {
+          labels: ['parca'],
+          data: [
+            [1, 2, 3, 4, 5],
+            [1000, 2000, null, 4000, null],
+          ],
+        },
+      ]),
+    ).toEqual({
+      labels: ['pyrra', 'parca'],
+      data: [
+        [1, 2, 3, 4, 5],
+        [null, 200, 300, 400, null],
+        [1000, 2000, null, 4000, null],
       ],
     })
   })

--- a/ui/src/components/graphs/aligneddata.spec.tsx
+++ b/ui/src/components/graphs/aligneddata.spec.tsx
@@ -45,6 +45,21 @@ describe('convertAlignedData', () => {
       ],
     })
   })
+  it('should convert responses with single series and NaNs into alignedData', () => {
+    expect(
+      convertAlignedData(
+        QueryRangeResponse.fromJsonString(
+          '{"matrix":{"samples":[{"values":[{"time":"1","value":100},{"time":"2","value":"NaN"}],"metric":{"job":"pyrra"}}]}}',
+        ),
+      ),
+    ).toEqual({
+      labels: [{job: 'pyrra'}],
+      data: [
+        [1, 2],
+        [100, null],
+      ],
+    })
+  })
   it('should convert responses with two series into alignedData', () => {
     expect(
       convertAlignedData(

--- a/ui/src/components/graphs/aligneddata.spec.tsx
+++ b/ui/src/components/graphs/aligneddata.spec.tsx
@@ -28,7 +28,7 @@ describe('convertAlignedData', () => {
         ),
       ),
     ).toEqual({
-      labels: ['pyrra'],
+      labels: [{job: 'pyrra'}],
       data: [[], []],
     })
     expect(
@@ -38,7 +38,7 @@ describe('convertAlignedData', () => {
         ),
       ),
     ).toEqual({
-      labels: ['pyrra'],
+      labels: [{job: 'pyrra'}],
       data: [
         [1, 2],
         [100, 200],
@@ -53,7 +53,7 @@ describe('convertAlignedData', () => {
         ),
       ),
     ).toEqual({
-      labels: ['pyrra', 'parca'],
+      labels: [{job: 'pyrra'}, {job: 'parca'}],
       data: [[], [], []],
     })
   })
@@ -64,7 +64,7 @@ describe('convertAlignedData', () => {
       ),
     ),
   ).toEqual({
-    labels: ['pyrra', 'parca'],
+    labels: [{job: 'pyrra'}, {job: 'parca'}],
     data: [
       [1, 2],
       [100, 200],
@@ -79,7 +79,7 @@ describe('convertAlignedData', () => {
         ),
       ),
     ).toEqual({
-      labels: ['pyrra', 'parca'],
+      labels: [{job: 'pyrra'}, {job: 'parca'}],
       data: [
         [1, 2, 3],
         [100, 200, 300],
@@ -97,7 +97,7 @@ describe('mergeAlignedData', () => {
     expect(
       mergeAlignedData([
         {
-          labels: ['pyrra'],
+          labels: [{job: 'pyrra'}],
           data: [
             [1, 2, 3],
             [100, 200, 300],
@@ -105,7 +105,7 @@ describe('mergeAlignedData', () => {
         },
       ]),
     ).toEqual({
-      labels: ['pyrra'],
+      labels: [{job: 'pyrra'}],
       data: [
         [1, 2, 3],
         [100, 200, 300],
@@ -116,14 +116,14 @@ describe('mergeAlignedData', () => {
     expect(
       mergeAlignedData([
         {
-          labels: ['pyrra'],
+          labels: [{job: 'pyrra'}],
           data: [
             [1, 2, 3],
             [100, 200, 300],
           ],
         },
         {
-          labels: ['parca'],
+          labels: [{job: 'parca'}],
           data: [
             [1, 2, 3],
             [1000, 2000, 3000],
@@ -131,7 +131,7 @@ describe('mergeAlignedData', () => {
         },
       ]),
     ).toEqual({
-      labels: ['pyrra', 'parca'],
+      labels: [{job: 'pyrra'}, {job: 'parca'}],
       data: [
         [1, 2, 3],
         [100, 200, 300],
@@ -143,14 +143,14 @@ describe('mergeAlignedData', () => {
     expect(
       mergeAlignedData([
         {
-          labels: ['pyrra'],
+          labels: [{job: 'pyrra'}],
           data: [
             [2, 3, 4],
             [200, 300, 400],
           ],
         },
         {
-          labels: ['parca'],
+          labels: [{job: 'parca'}],
           data: [
             [1, 2, 3, 4, 5],
             [1000, 2000, null, 4000, null],
@@ -158,7 +158,7 @@ describe('mergeAlignedData', () => {
         },
       ]),
     ).toEqual({
-      labels: ['pyrra', 'parca'],
+      labels: [{job: 'pyrra'}, {job: 'parca'}],
       data: [
         [1, 2, 3, 4, 5],
         [null, 200, 300, 400, null],

--- a/ui/src/components/graphs/aligneddata.tsx
+++ b/ui/src/components/graphs/aligneddata.tsx
@@ -3,7 +3,7 @@ import {AlignedData} from 'uplot'
 import {Labels} from '../../labels'
 
 export interface AlignedDataResponse {
-  labels: string[]
+  labels: Labels[]
   data: AlignedData
 }
 
@@ -12,7 +12,7 @@ export const convertAlignedData = (response: QueryRangeResponse | null): Aligned
     return {labels: [], data: []}
   }
 
-  const labels: string[] = []
+  const labels: Labels[] = []
   let data: AlignedData = []
 
   if (response?.options.case === 'matrix') {
@@ -20,21 +20,7 @@ export const convertAlignedData = (response: QueryRangeResponse | null): Aligned
 
     const series = response.options.value.samples
     series.forEach((ss: SampleStream, i: number) => {
-      // Add this series' labels to the array of label values
-
-      // TODO: Support multiple labels here and return Labels object
-      const ml = ss.metric as Labels
-      console.log(ml)
-
-      const kvs: string[] = []
-      Object.values(ss.metric).forEach((l: string) => kvs.push(l))
-      if (kvs.length === 1) {
-        labels.push(kvs[0])
-      } else if (kvs.length === 0) {
-        labels.push('value')
-      } else {
-        labels.push('[' + kvs.join(' ') + ']')
-      }
+      labels.push(ss.metric as Labels)
 
       ss.values.forEach((sp: SamplePair) => {
         const time: number = Number(sp.time)
@@ -92,7 +78,7 @@ export const mergeAlignedData = (responses: AlignedDataResponse[]): AlignedDataR
     .map((adr: AlignedDataResponse): number => adr.data.length - 1)
     .reduce((total: number, n: number) => total + n)
 
-  const labels: string[] = []
+  const labels: Labels[] = []
   const series = new Map<number, Array<number | null | undefined>>()
 
   responses.forEach((adr: AlignedDataResponse, i: number) => {

--- a/ui/src/components/graphs/aligneddata.tsx
+++ b/ui/src/components/graphs/aligneddata.tsx
@@ -33,7 +33,12 @@ export const convertAlignedData = (response: QueryRangeResponse | null): Aligned
           }
         }
 
-        values[i] = sp.value
+        if (isNaN(sp.value)) {
+          values[i] = null
+        } else {
+          values[i] = sp.value
+        }
+
         samples.set(time, values)
       })
     })

--- a/ui/src/components/graphs/colors.tsx
+++ b/ui/src/components/graphs/colors.tsx
@@ -51,4 +51,6 @@ export const yellows = [
   'FFF9C4',
 ]
 
+export const greys = ['3c3c3c', '616161']
+
 export const colorful = ['651FFF', '009688', '00BCD4', '3D5AFE', '1DE9B6']

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -155,3 +155,4 @@ a.external-prometheus {
 @import 'pages/Detail';
 @import 'components/Navbar';
 @import 'components/AlertsTable';
+@import 'components/graphs/BurnrateGraph';

--- a/ui/src/labels.tsx
+++ b/ui/src/labels.tsx
@@ -19,6 +19,8 @@ export const labelsString = (lset: Labels | undefined): string => {
   return s
 }
 
+export const labelValues = (lset: Labels): string[] => Object.values(lset)
+
 export const parseLabels = (expr: string | null): Labels => {
   if (expr == null) {
     return {}

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -539,7 +539,15 @@ const Detail = () => {
           <Row>
             <Col>
               <h4>Multi Burn Rate Alerts</h4>
-              <AlertsTable client={client} objective={objective} grouping={groupingLabels} />
+              <AlertsTable
+                client={client}
+                promClient={promClient}
+                objective={objective}
+                grouping={groupingLabels}
+                from={from}
+                to={to}
+                uPlotCursor={uPlotCursor}
+              />
             </Col>
           </Row>
           <Row>


### PR DESCRIPTION
Every multi burn rate alert now has a graph showing the short and long burn rate. It shows the threshold both burn rates have to be above for the alert to start firing (first pending). Once pending or firing the background of the graph changes color depending on the alert's state.

Firing or pending burn rates will automatically show the graph expanded in the table. 

![burnrate-graphs](https://user-images.githubusercontent.com/872251/225148463-6c81fb4a-5816-4aa8-aaea-6afc7c8400fc.png)
