### PR TITLE
api/kubernetes: handle graceful termination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ bin
 
 # dist folder
 /dist
+
+# node
+node_modules
+package*.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ and build the project.
 Build the UI and compile the Go binaries
 
 ```bash
-make
+make all
 ```
 
 ### Run the API and UI
@@ -44,7 +44,7 @@ make
 Run the API binary in one terminal
 
 ```bash
-./bin/api
+./pyrra api
 ```
 
 *Note: the API assumes a Prometheus is running on [localhost:9090](http://localhost:9090) and a backend on [localhost:9444](http://localhost:9444)) by default. Check  `./bin/api --help` flag for the parameters to change those.*
@@ -54,13 +54,13 @@ Run the API binary in one terminal
 Run the filesystem binary in another terminal
 
 ```bash
-./bin/filesystem
+./pyrra filesystem
 ```
 
 Or run the Kubernetes binary in the other terminal
 
 ```bash
-./bin/kubernetes
+./pyrra kubernetes
 ```
 
 *Note: This binary tries to run against your default Kubernetes context. Use the `-kubeconfig` flag to change for another kubeconfig*

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -24,6 +25,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/oklog/run"
 	connectprometheus "github.com/polarsignals/connect-go-prometheus"
 	"github.com/prometheus/client_golang/api"
 	prometheusapiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -299,7 +301,33 @@ func cmdAPI(logger log.Logger, reg *prometheus.Registry, promClient api.Client, 
 		})
 	}
 
-	if err := http.ListenAndServe(":9099", h2c.NewHandler(r, &http2.Server{})); err != nil {
+	var (
+		gr  run.Group
+		ctx = context.Background()
+	)
+	gr.Add(run.SignalHandler(ctx, os.Interrupt, syscall.SIGTERM))
+
+	{
+		httpServer := &http.Server{
+			Addr:    ":9099",
+			Handler: h2c.NewHandler(r, &http2.Server{}),
+		}
+		gr.Add(
+			func() error {
+				return httpServer.ListenAndServe()
+			},
+			func(error) {
+				shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+				_ = httpServer.Shutdown(shutdownCtx)
+			},
+		)
+	}
+	if err := gr.Run(); err != nil {
+		if _, ok := err.(run.SignalError); ok {
+			level.Info(logger).Log("msg", "terminated HTTP server", "reason", err)
+			return 0
+		}
 		level.Error(logger).Log("msg", "failed to run HTTP server", "err", err)
 		return 2
 	}


### PR DESCRIPTION
This PR adds graceful termination to the api command and performs a small refactor of graceful termination in the kubernetes command.

Additionally, the first two commits are maintenance: updates to gitignore and the contributing document.