### PR TITLE
Fix panic in ErrorBudgetGraph

### DIFF
--- a/main.go
+++ b/main.go
@@ -638,7 +638,7 @@ func (s *objectiveServer) GraphErrorBudget(ctx context.Context, req *connect.Req
 		}
 		if objective.Indicator.Latency != nil {
 			groupings := map[string]struct{}{}
-			for _, g := range objective.Indicator.Ratio.Grouping {
+			for _, g := range objective.Indicator.Latency.Grouping {
 				groupings[g] = struct{}{}
 			}
 


### PR DESCRIPTION
The panic happened because within the latency objective we referenced the ratio...

Fixes #666 

I guess we should really look into having interfaces for these things... :grimacing: 