### PR TITLE
Fix: Matcher label of generic rules for Ratio SLOs

### DIFF
--- a/slo/rules.go
+++ b/slo/rules.go
@@ -1022,6 +1022,12 @@ func (o Objective) GenericRules() (monitoringv1.RuleGroup, error) {
 			})
 		}
 
+		totalMatchers = append(totalMatchers, &labels.Matcher{
+			Type:  labels.MatchEqual,
+			Name:  "slo",
+			Value: o.Name(),
+		})
+
 		errorsIncreaseName := increaseName(o.Indicator.Ratio.Errors.Name, o.Window)
 
 		errorMatchers := make([]*labels.Matcher, 0, len(o.Indicator.Ratio.Errors.LabelMatchers))
@@ -1036,6 +1042,12 @@ func (o Objective) GenericRules() (monitoringv1.RuleGroup, error) {
 				Value: value,
 			})
 		}
+
+		errorMatchers = append(errorMatchers, &labels.Matcher{
+			Type:  labels.MatchEqual,
+			Name:  "slo",
+			Value: o.Name(),
+		})
 
 		objectiveReplacer{
 			metric:        totalIncreaseName,

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -1556,7 +1556,7 @@ func TestObjective_GrafanaRules(t *testing.T) {
 				Labels: map[string]string{"slo": "monitoring-http-errors"},
 			}, {
 				Record: "pyrra_availability",
-				Expr:   intstr.FromString(`1 - sum(http_requests:increase4w{code=~"5..",job="thanos-receive-default"} or vector(0)) / sum(http_requests:increase4w{job="thanos-receive-default"})`),
+				Expr:   intstr.FromString(`1 - sum(http_requests:increase4w{code=~"5..",job="thanos-receive-default",slo="monitoring-http-errors"} or vector(0)) / sum(http_requests:increase4w{job="thanos-receive-default",slo="monitoring-http-errors"})`),
 				Labels: map[string]string{"slo": "monitoring-http-errors"},
 			}, {
 				Record: "pyrra_requests_total",
@@ -1592,7 +1592,7 @@ func TestObjective_GrafanaRules(t *testing.T) {
 				Labels: map[string]string{"slo": "monitoring-grpc-errors"},
 			}, {
 				Record: "pyrra_availability",
-				Expr:   intstr.FromString(`1 - sum(grpc_server_handled:increase4w{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"} or vector(0)) / sum(grpc_server_handled:increase4w{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api"})`),
+				Expr:   intstr.FromString(`1 - sum(grpc_server_handled:increase4w{grpc_code=~"Aborted|Unavailable|Internal|Unknown|Unimplemented|DataLoss",grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"} or vector(0)) / sum(grpc_server_handled:increase4w{grpc_method="Write",grpc_service="conprof.WritableProfileStore",job="api",slo="monitoring-grpc-errors"})`),
 				Labels: map[string]string{"slo": "monitoring-grpc-errors"},
 			}, {
 				Record: "pyrra_requests_total",
@@ -1692,7 +1692,7 @@ func TestObjective_GrafanaRules(t *testing.T) {
 				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
 			}, {
 				Record: "pyrra_availability",
-				Expr:   intstr.FromString(`1 - sum(prometheus_operator_reconcile_errors:increase2w or vector(0)) / sum(prometheus_operator_reconcile_operations:increase2w)`),
+				Expr:   intstr.FromString(`1 - sum(prometheus_operator_reconcile_errors:increase2w{slo="monitoring-prometheus-operator-errors"} or vector(0)) / sum(prometheus_operator_reconcile_operations:increase2w{slo="monitoring-prometheus-operator-errors"})`),
 				Labels: map[string]string{"slo": "monitoring-prometheus-operator-errors"},
 			}, {
 				Record: "pyrra_requests_total",
@@ -1724,7 +1724,7 @@ func TestObjective_GrafanaRules(t *testing.T) {
 				Labels: map[string]string{"slo": "apiserver-write-response-errors"},
 			}, {
 				Record: "pyrra_availability",
-				Expr:   intstr.FromString(`1 - sum(apiserver_request:increase2w{code=~"5..",job="apiserver",verb=~"POST|PUT|PATCH|DELETE"} or vector(0)) / sum(apiserver_request:increase2w{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"})`),
+				Expr:   intstr.FromString(`1 - sum(apiserver_request:increase2w{code=~"5..",job="apiserver",slo="apiserver-write-response-errors",verb=~"POST|PUT|PATCH|DELETE"} or vector(0)) / sum(apiserver_request:increase2w{job="apiserver",slo="apiserver-write-response-errors",verb=~"POST|PUT|PATCH|DELETE"})`),
 				Labels: map[string]string{"slo": "apiserver-write-response-errors"},
 			}, {
 				Record: "pyrra_requests_total",


### PR DESCRIPTION
This issue was uncovered after activating the generation of generic rules, one error budget in particular was extremely low on Grafana but all OK according to pyrra / manual checks.

We have 2 SLOs setup for one of our application:

```yaml
  indicator:
    ratio:
      errors:
        metric: grpc_server_processing_duration_seconds_count{app_kubernetes_io_name="grpc_server", statusCode!="OK"}
      total:
        metric: grpc_server_processing_duration_seconds_count{app_kubernetes_io_name="grpc_server"}
  target: "99"
  window: 2w
```

And a second one:

```yaml
  indicator:
    latency:
      success:
        metric: grpc_server_processing_duration_seconds_bucket{app_kubernetes_io_name="grpc_server", le="0.1"}
      total:
        metric: grpc_server_processing_duration_seconds_count{app_kubernetes_io_name="grpc_server"}
  target: "95"
  window: 2w
```

Both rules create recording rules named `grpc_server_processing_duration_seconds:increase2w`, as expected. The only way to differentiate the values to use for a specific SLO is to match on the SLO name.

The generic rule for latency was working perfectly, but not the ratio one: the matcher on SLO was missing.

This is what this PR does: add the matching on SLO name for generic rules generated from ratio SLOs.