### PR TITLE
feat: propgate custom labels to generic rules

### DIFF
--- a/slo/rules.go
+++ b/slo/rules.go
@@ -1145,9 +1145,7 @@ func (o Objective) GenericRules() (monitoringv1.RuleGroup, error) {
 			return monitoringv1.RuleGroup{}, ErrGroupingUnsupported
 		}
 
-		ruleLabels := map[string]string{
-			"slo": sloName,
-		}
+		ruleLabels := o.commonRuleLabels(sloName)
 
 		rules = append(rules, monitoringv1.Rule{
 			Record: "pyrra_objective",
@@ -1260,9 +1258,7 @@ func (o Objective) GenericRules() (monitoringv1.RuleGroup, error) {
 			return monitoringv1.RuleGroup{}, ErrGroupingUnsupported
 		}
 
-		ruleLabels := map[string]string{
-			"slo": sloName,
-		}
+		ruleLabels := o.commonRuleLabels(sloName)
 
 		rules = append(rules, monitoringv1.Rule{
 			Record: "pyrra_objective",


### PR DESCRIPTION
Closes #727

Use the o.commonRuleLabels method when generating the generic rules which allows for specifying custom labels.