### PR TITLE
fix(filesystem): only watch for files with the .yaml extension

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -22,14 +22,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/pyrra-dev/pyrra/kubernetes/api/v1alpha1"
-	objectivesv1alpha1 "github.com/pyrra-dev/pyrra/proto/objectives/v1alpha1"
-	"github.com/pyrra-dev/pyrra/proto/objectives/v1alpha1/objectivesv1alpha1connect"
-	"github.com/pyrra-dev/pyrra/slo"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/pyrra-dev/pyrra/kubernetes/api/v1alpha1"
+	objectivesv1alpha1 "github.com/pyrra-dev/pyrra/proto/objectives/v1alpha1"
+	"github.com/pyrra-dev/pyrra/proto/objectives/v1alpha1/objectivesv1alpha1connect"
+	"github.com/pyrra-dev/pyrra/slo"
 )
 
 type Objectives struct {

--- a/filesystem.go
+++ b/filesystem.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/bufbuild/connect-go"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
-	"github.com/bufbuild/connect-go"
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -152,7 +152,10 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 						continue
 					}
 					if event.Op&fsnotify.Write == fsnotify.Write {
-						files <- event.Name
+						// We only care about watching for file with the .yaml extension
+						if filepath.Ext(event.Name) == ".yaml" {
+							files <- event.Name
+						}
 					}
 				case err := <-watcher.Errors:
 					level.Warn(logger).Log("msg", "encountered file watcher error", "err", err)

--- a/filesystem.go
+++ b/filesystem.go
@@ -151,10 +151,7 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 						continue
 					}
 					if event.Op&fsnotify.Write == fsnotify.Write {
-						// We only care about watching for file with the .yaml extension
-						if filepath.Ext(event.Name) == ".yaml" {
-							files <- event.Name
-						}
+						files <- event.Name
 					}
 				case err := <-watcher.Errors:
 					level.Warn(logger).Log("msg", "encountered file watcher error", "err", err)
@@ -172,7 +169,7 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 				case <-ctx.Done():
 					return nil
 				case f := <-files:
-					// We only care about watching for files with the .yaml extension
+					// We only care about watching for files with a valid yaml extension
 					if filepath.Ext(f) != ".yaml" && filepath.Ext(f) != ".yml" {
 						level.Warn(logger).Log("msg", "ignoring non YAML file", "file", f)
 						continue

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -10,16 +10,16 @@ import (
 )
 
 func TestMatchObjectives(t *testing.T) {
-	o1 := slo.Objective{Labels: labels.FromStrings("foo", "bar")}
-	o2 := slo.Objective{Labels: labels.FromStrings("foo", "bar", "ying", "yang")}
-	o3 := slo.Objective{Labels: labels.FromStrings("foo", "bar", "yes", "no")}
-	o4 := slo.Objective{Labels: labels.FromStrings("foo", "baz")}
+	obj1 := slo.Objective{Labels: labels.FromStrings("foo", "bar")}
+	obj2 := slo.Objective{Labels: labels.FromStrings("foo", "bar", "ying", "yang")}
+	obj3 := slo.Objective{Labels: labels.FromStrings("foo", "bar", "yes", "no")}
+	obj4 := slo.Objective{Labels: labels.FromStrings("foo", "baz")}
 
 	objectives := Objectives{objectives: map[string]slo.Objective{}}
-	objectives.Set(o1)
-	objectives.Set(o2)
-	objectives.Set(o3)
-	objectives.Set(o4)
+	objectives.Set(obj1)
+	objectives.Set(obj2)
+	objectives.Set(obj3)
+	objectives.Set(obj4)
 
 	matches := objectives.Match([]*labels.Matcher{
 		labels.MustNewMatcher(labels.MatchEqual, "foo", "foo"),
@@ -38,7 +38,7 @@ func TestMatchObjectives(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "foo", "baz"),
 	})
 	require.Len(t, matches, 1)
-	require.Contains(t, matches, o4)
+	require.Contains(t, matches, obj4)
 
 	matches = objectives.Match([]*labels.Matcher{
 		labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
@@ -51,8 +51,8 @@ func TestMatchObjectives(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchRegexp, "foo", "ba."),
 	})
 	require.Len(t, matches, 4)
-	require.Contains(t, matches, o1)
-	require.Contains(t, matches, o2)
-	require.Contains(t, matches, o3)
-	require.Contains(t, matches, o4)
+	require.Contains(t, matches, obj1)
+	require.Contains(t, matches, obj2)
+	require.Contains(t, matches, obj3)
+	require.Contains(t, matches, obj4)
 }

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -30,9 +30,9 @@ func TestMatchObjectives(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "foo", "bar"),
 	})
 	require.Len(t, matches, 3)
-	require.Contains(t, matches, o1)
-	require.Contains(t, matches, o2)
-	require.Contains(t, matches, o3)
+	require.Contains(t, matches, obj1)
+	require.Contains(t, matches, obj2)
+	require.Contains(t, matches, obj3)
 
 	matches = objectives.Match([]*labels.Matcher{
 		labels.MustNewMatcher(labels.MatchEqual, "foo", "baz"),
@@ -45,7 +45,7 @@ func TestMatchObjectives(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "ying", "yang"),
 	})
 	require.Len(t, matches, 1)
-	require.Contains(t, matches, o2)
+	require.Contains(t, matches, obj2)
 
 	matches = objectives.Match([]*labels.Matcher{
 		labels.MustNewMatcher(labels.MatchRegexp, "foo", "ba."),

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ var CLI struct {
 		PrometheusBasicAuthPassword promconfig.Secret `default:"" help:"The HTTP basic authentication password"`
 	} `cmd:"" help:"Runs Pyrra's API and UI."`
 	Filesystem struct {
-		ConfigFiles      string   `default:"/etc/pyrra/*.yaml" help:"The folder where Pyrra finds the config files to use."`
+		ConfigFiles      string   `default:"/etc/pyrra/*.yaml" help:"The folder where Pyrra finds the config files to use. Any non yaml files will be ignored."`
 		PrometheusURL    *url.URL `default:"http://localhost:9090" help:"The URL to the Prometheus to query."`
 		PrometheusFolder string   `default:"/etc/prometheus/pyrra/" help:"The folder where Pyrra writes the generates Prometheus rules and alerts."`
 		GenericRules     bool     `default:"false" help:"Enabled generic recording rules generation to make it easier for tools like Grafana."`


### PR DESCRIPTION
I changed the test in `filesystem_test.go` because my IDE was complaining about the variable shadowing between [here](https://github.com/pyrra-dev/pyrra/blob/dfc8e4b819309fc0e132795cbf760d879063a1c3/kubernetes_test.go#L21) and [here](https://github.com/pyrra-dev/pyrra/blob/dfc8e4b819309fc0e132795cbf760d879063a1c3/filesystem_test.go#LL13C3-L13C3)

I guess there are two ways of solving this? I think using the regex approach suggested in the issue we would have to not use `filepath.Glob` anymore?

I felt this approach was slightly easier and wouldn't technically break anyone by changing the behaviour of the `--config-files` flag.

Should we accept `.yaml` or `.yml`? 


fixes #726