### PR TITLE
feat: adding --log-format and --log-level as global flags

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+var errInvalidLogFormatFlag = errors.New("--log-format must be either 'json' or 'logfmt'")
+
+type LoggerConfig struct {
+	LogLevel  string `default:"info" help:"Used to set the logging level of the application. Valid options are 'debug', 'info', 'warn' or 'error'"`
+	LogFormat string `default:"logfmt" help:"Used to set the logging format. Valid options are 'logfmt' or 'json'"`
+}
+
+// Validate is a method called automatically by the kong cli framework so this deals with validating our LoggerConfig struct.
+func (lc *LoggerConfig) Validate() error {
+	if _, err := level.Parse(lc.LogLevel); err != nil {
+		return fmt.Errorf("%w: must be 'debug', 'info', 'warn' or 'error'", err)
+	}
+
+	if lc.LogFormat != "json" && lc.LogFormat != "logfmt" {
+		return errInvalidLogFormatFlag
+	}
+	return nil
+}
+
+// configureLogger returns a go-lit logger which is customizable via the loggerConfig struct.
+func configureLogger(loggerConfig LoggerConfig) log.Logger {
+	var logger log.Logger
+	switch loggerConfig.LogFormat {
+	case "logfmt":
+		logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	case "json":
+		logger = log.NewJSONLogger(log.NewSyncWriter(os.Stderr))
+	}
+
+	logger = level.NewFilter(logger, level.Allow(level.ParseDefault(loggerConfig.LogLevel, level.InfoValue())))
+	logger = log.WithPrefix(logger, "caller", log.DefaultCaller)
+	logger = log.WithPrefix(logger, "ts", log.DefaultTimestampUTC)
+	return logger
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/go-kit/log/level"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggerConfig_Validate(t *testing.T) {
+	type fields struct {
+		LogLevel  string
+		LogFormat string
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		wantFunc func(t *testing.T, err error)
+	}{
+		{
+			name: "bad log level",
+			fields: fields{
+				LogLevel:  "notALogLevel",
+				LogFormat: "logfmt",
+			},
+			wantFunc: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, level.ErrInvalidLevelString, "log level should be invalid")
+			},
+		},
+		{
+			name: "bad log format",
+			fields: fields{
+				LogLevel:  "debug",
+				LogFormat: "notALogFormat",
+			},
+			wantFunc: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, errInvalidLogFormatFlag, "log format flag should be invalid")
+			},
+		},
+		{
+			name: "good config",
+			fields: fields{
+				LogLevel:  "debug",
+				LogFormat: "json",
+			},
+			wantFunc: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			lc := &LoggerConfig{
+				LogLevel:  tt.fields.LogLevel,
+				LogFormat: tt.fields.LogFormat,
+			}
+			err := lc.Validate()
+			tt.wantFunc(t, err)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ import (
 var ui embed.FS
 
 var CLI struct {
+	LoggerConfig
 	API struct {
 		PrometheusURL               *url.URL          `default:"http://localhost:9090" help:"The URL to the Prometheus to query."`
 		PrometheusExternalURL       *url.URL          `help:"The URL for the UI to redirect users to when opening Prometheus. If empty the same as prometheus.url"`
@@ -82,9 +83,7 @@ var CLI struct {
 func main() {
 	ctx := kong.Parse(&CLI)
 
-	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
-	logger = log.WithPrefix(logger, "caller", log.DefaultCaller)
-	logger = log.WithPrefix(logger, "ts", log.DefaultTimestampUTC)
+	logger := configureLogger(CLI.LoggerConfig)
 
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(


### PR DESCRIPTION
Added two new global command line flags to the pyrra binary.

```
      --log-level="info"       Used to set the logging level of the application. Valid options are 'debug', 'info', 'warn' or 'error'
      --log-format="logfmt"    Used to set the logging format. Valid options are 'logfmt' or 'json'
```

We also validate these options with the level.Parse function from go-kit itself and some custom validation about the two options for logging formats.


<details>

<summary>View Manual Test Cases</summary>

```bash
pyrra git:(feat/configurable-logger/769) ✗ go run . api --log-level=ciccio
pyrra: error: pyrra: invalid level string: must be 'debug', 'info', 'warn' or 'error'
exit status 1

pyrra git:(feat/configurable-logger/769) ✗ go run . api --log-level=debug 
level=info ts=2023-06-14T20:50:32.933428291Z caller=main.go:127 msg="using Prometheus" url=http://localhost:9090
level=info ts=2023-06-14T20:50:32.933472491Z caller=main.go:188 msg="UI redirect to Prometheus" url=http://localhost:9090
level=info ts=2023-06-14T20:50:32.933480181Z caller=main.go:189 msg="using API at" url=http://localhost:9444
level=info ts=2023-06-14T20:50:32.933483931Z caller=main.go:190 msg="using route prefix" prefix=/
^Clevel=info ts=2023-06-14T20:50:34.864403285Z caller=main.go:329 msg="terminated HTTP server" reason="received signal interrupt"

pyrra git:(feat/configurable-logger/769) ✗ go run . api --log-level=debug --log-format=json
{"caller":"main.go:127","level":"info","msg":"using Prometheus","ts":"2023-06-14T20:50:40.923999399Z","url":"http://localhost:9090"}
{"caller":"main.go:188","level":"info","msg":"UI redirect to Prometheus","ts":"2023-06-14T20:50:40.924055928Z","url":"http://localhost:9090"}
{"caller":"main.go:189","level":"info","msg":"using API at","ts":"2023-06-14T20:50:40.924087248Z","url":"http://localhost:9444"}
{"caller":"main.go:190","level":"info","msg":"using route prefix","prefix":"/","ts":"2023-06-14T20:50:40.924098888Z"}
^C{"caller":"main.go:329","level":"info","msg":"terminated HTTP server","reason":"received signal interrupt","ts":"2023-06-14T20:51:21.794672401Z"}

pyrra git:(feat/configurable-logger/769) ✗ go run . api --log-level=debug --log-format=json
{"caller":"main.go:87","level":"debug","this is a debug log":"(MISSING)","ts":"2023-06-14T20:51:24.525999744Z"}
{"caller":"main.go:128","level":"info","msg":"using Prometheus","ts":"2023-06-14T20:51:24.526160163Z","url":"http://localhost:9090"}
{"caller":"main.go:189","level":"info","msg":"UI redirect to Prometheus","ts":"2023-06-14T20:51:24.526199773Z","url":"http://localhost:9090"}
{"caller":"main.go:190","level":"info","msg":"using API at","ts":"2023-06-14T20:51:24.526230653Z","url":"http://localhost:9444"}
{"caller":"main.go:191","level":"info","msg":"using route prefix","prefix":"/","ts":"2023-06-14T20:51:24.526267773Z"}
^C{"caller":"main.go:330","level":"info","msg":"terminated HTTP server","reason":"received signal interrupt","ts":"2023-06-14T20:51:26.430117889Z"}

pyrra git:(feat/configurable-logger/769) ✗ go run . api --log-level=info --log-format=json
{"caller":"main.go:128","level":"info","msg":"using Prometheus","ts":"2023-06-14T20:51:32.266882477Z","url":"http://localhost:9090"}
{"caller":"main.go:189","level":"info","msg":"UI redirect to Prometheus","ts":"2023-06-14T20:51:32.266940217Z","url":"http://localhost:9090"}
{"caller":"main.go:190","level":"info","msg":"using API at","ts":"2023-06-14T20:51:32.266972336Z","url":"http://localhost:9444"}
{"caller":"main.go:191","level":"info","msg":"using route prefix","prefix":"/","ts":"2023-06-14T20:51:32.267002096Z"}
^C{"caller":"main.go:330","level":"info","msg":"terminated HTTP server","reason":"received signal interrupt","ts":"2023-06-14T20:51:33.613325544Z"}

pyrra git:(feat/configurable-logger/769) ✗ go run . api --log-level=ciccio --log-format=json
pyrra: error: pyrra: invalid level string: must be 'debug', 'info', 'warn' or 'error'
exit status 1
```

</details>

Fixes #769