### PR TITLE
filesystem: First validate objectives

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -307,6 +307,20 @@ func writeRuleFile(logger log.Logger, file, prometheusFolder string, genericRule
 		return fmt.Errorf("failed to get objective: %w", err)
 	}
 
+	warn, err := kubeObjective.ValidateCreate()
+	if len(warn) > 0 {
+		for _, w := range warn {
+			level.Warn(logger).Log(
+				"msg", "validation warning",
+				"file", file,
+				"warning", w,
+			)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("invalid objective: %s - %w", file, err)
+	}
+
 	increases, err := objective.IncreaseRules()
 	if err != nil {
 		return fmt.Errorf("failed to get increase rules: %w", err)


### PR DESCRIPTION
Pyrra's filesystem component is now going to validate the given config file. If there is an error it will be returned and logged. Nothing will be done with that file. If there are warnings, the warnings will be logged, but the Prometheus rules are generated.

These metrics are increased and can be alerted on too:
```
# HELP pyrra_filesystem_reconciles_errors_total The total amount of errors during reconciles.
# TYPE pyrra_filesystem_reconciles_errors_total counter
pyrra_filesystem_reconciles_errors_total 7
# HELP pyrra_filesystem_reconciles_total The total amount of reconciles.
# TYPE pyrra_filesystem_reconciles_total counter
pyrra_filesystem_reconciles_total 23
```