### PR TITLE
Kubernetes: Update SLO resource's status

### DIFF
--- a/config/crd/bases/pyrra.dev_servicelevelobjectives.json
+++ b/config/crd/bases/pyrra.dev_servicelevelobjectives.json
@@ -22,6 +22,28 @@
     "scope": "Namespaced",
     "versions": [
       {
+        "additionalPrinterColumns": [
+          {
+            "jsonPath": ".spec.window",
+            "name": "Window",
+            "type": "string"
+          },
+          {
+            "jsonPath": ".spec.target",
+            "name": "Target",
+            "type": "string"
+          },
+          {
+            "jsonPath": ".status.type",
+            "name": "Type",
+            "type": "string"
+          },
+          {
+            "jsonPath": ".metadata.creationTimestamp",
+            "name": "Age",
+            "type": "date"
+          }
+        ],
         "name": "v1alpha1",
         "schema": {
           "openAPIV3Schema": {
@@ -135,8 +157,7 @@
                           },
                           "latency": {
                             "description": "Latency the requests should be faster than.",
-                            "format": "int64",
-                            "type": "integer"
+                            "type": "string"
                           },
                           "total": {
                             "description": "Total is the metric that returns how many requests there are in total.",
@@ -219,6 +240,12 @@
               },
               "status": {
                 "description": "ServiceLevelObjectiveStatus defines the observed state of ServiceLevelObjective.",
+                "properties": {
+                  "type": {
+                    "description": "Type is the generated resource type, like PrometheusRule or ConfigMap",
+                    "type": "string"
+                  }
+                },
                 "type": "object"
               }
             },
@@ -226,7 +253,10 @@
           }
         },
         "served": true,
-        "storage": true
+        "storage": true,
+        "subresources": {
+          "status": {}
+        }
       }
     ]
   }

--- a/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
+++ b/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
@@ -17,7 +17,20 @@ spec:
     singular: servicelevelobjective
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.window
+      name: Window
+      type: string
+    - jsonPath: .spec.target
+      name: Target
+      type: string
+    - jsonPath: .status.type
+      name: Type
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ServiceLevelObjective is the Schema for the ServiceLevelObjectives
@@ -121,8 +134,7 @@ spec:
                         type: array
                       latency:
                         description: Latency the requests should be faster than.
-                        format: int64
-                        type: integer
+                        type: string
                       total:
                         description: Total is the metric that returns how many requests
                           there are in total.
@@ -186,7 +198,14 @@ spec:
           status:
             description: ServiceLevelObjectiveStatus defines the observed state of
               ServiceLevelObjective.
+            properties:
+              type:
+                description: Type is the generated resource type, like PrometheusRule
+                  or ConfigMap
+                type: string
             type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -53,6 +53,11 @@ type ServiceLevelObjectiveList struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=slo
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Window",type=string,JSONPath=`.spec.window`
+// +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.spec.target`
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.status.type`
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ServiceLevelObjective is the Schema for the ServiceLevelObjectives API.
 type ServiceLevelObjective struct {
@@ -162,7 +167,10 @@ type Query struct {
 }
 
 // ServiceLevelObjectiveStatus defines the observed state of ServiceLevelObjective.
-type ServiceLevelObjectiveStatus struct{}
+type ServiceLevelObjectiveStatus struct {
+	// Type is the generated resource type, like PrometheusRule or ConfigMap
+	Type string `json:"type,omitempty"`
+}
 
 func (in *ServiceLevelObjective) ValidateCreate() (admission.Warnings, error) {
 	return in.validate()

--- a/kubernetes/controllers/servicelevelobjective.go
+++ b/kubernetes/controllers/servicelevelobjective.go
@@ -92,6 +92,11 @@ func (r *ServiceLevelObjectiveReconciler) reconcilePrometheusRule(ctx context.Co
 		return ctrl.Result{}, fmt.Errorf("failed to update prometheus rule: %w", err)
 	}
 
+	kubeObjective.Status.Type = "PrometheusRule"
+	if err := r.Status().Update(ctx, &kubeObjective); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -128,6 +133,11 @@ func (r *ServiceLevelObjectiveReconciler) reconcileConfigMap(
 	level.Info(logger).Log("msg", "updating config map", "namespace", newConfigMap.GetNamespace(), "name", newConfigMap.GetName())
 	if err := r.Update(ctx, newConfigMap); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update config map: %w", err)
+	}
+
+	kubeObjective.Status.Type = "ConfigMap"
+	if err := r.Status().Update(ctx, &kubeObjective); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
So far running `kubectl get slo` would only show something similar to this:
```
NAMESPACE    NAME                                                      AGE
monitoring   servicelevelobjective.pyrra.dev/pyrra-filesystem-errors   18h
monitoring   servicelevelobjective.pyrra.dev/thanos-query              18h
```

With these changes the status contains the resource type that was generated. Either `PrometheusRule` or `ConfigMap`. Additionally, some fields from the spec are extracted and shown in the output too:

`kubectl get slo,prometheusrule`
```
NAMESPACE    NAME                                                      WINDOW   TARGET   TYPE            AGE
monitoring   servicelevelobjective.pyrra.dev/pyrra-filesystem-errors   1w       99       PrometheusRule  18h
monitoring   servicelevelobjective.pyrra.dev/thanos-query              4w       99       PrometheusRule  18h

NAMESPACE    NAME                                                           AGE
monitoring   prometheusrule.monitoring.coreos.com/pyrra-filesystem-errors   18h
monitoring   prometheusrule.monitoring.coreos.com/thanos-query              18h
```

Closes #790 partially