### PR TITLE
slo: If alerting is disabled absent alert is info

### DIFF
--- a/slo/promql_test.go
+++ b/slo/promql_test.go
@@ -54,6 +54,11 @@ var (
 		o.Indicator.Ratio.Errors.LabelMatchers = append(o.Indicator.Ratio.Errors.LabelMatchers, matcher)
 		return o
 	}
+	objectiveHTTPRatioAlertingDisabled = func() Objective {
+		o := objectiveHTTPRatio()
+		o.Alerting.Disabled = true
+		return o
+	}
 	objectiveGRPCRatio = func() Objective {
 		return Objective{
 			Labels:      labels.FromStrings(labels.MetricName, "monitoring-grpc-errors"),

--- a/slo/rules.go
+++ b/slo/rules.go
@@ -707,7 +707,11 @@ func (o Objective) IncreaseRules() (monitoringv1.RuleGroup, error) {
 			alertLabels[k] = v
 		}
 		// Add severity label for alerts
-		alertLabels["severity"] = string(critical)
+		if !o.Alerting.Disabled {
+			alertLabels["severity"] = string(critical)
+		} else {
+			alertLabels["severity"] = string(info)
+		}
 
 		rules = append(rules, monitoringv1.Rule{
 			Alert: "SLOMetricAbsent",
@@ -855,7 +859,11 @@ func (o Objective) IncreaseRules() (monitoringv1.RuleGroup, error) {
 			alertLabels[k] = v
 		}
 		// Add severity label for alerts
-		alertLabels["severity"] = string(critical)
+		if !o.Alerting.Disabled {
+			alertLabels["severity"] = string(critical)
+		} else {
+			alertLabels["severity"] = string(info)
+		}
 
 		rules = append(rules, monitoringv1.Rule{
 			Alert: "SLOMetricAbsent",
@@ -882,7 +890,11 @@ func (o Objective) IncreaseRules() (monitoringv1.RuleGroup, error) {
 			alertLabelsLe[k] = v
 		}
 		// Add severity label for alerts
-		alertLabelsLe["severity"] = string(critical)
+		if !o.Alerting.Disabled {
+			alertLabelsLe["severity"] = string(critical)
+		} else {
+			alertLabelsLe["severity"] = string(info)
+		}
 
 		rules = append(rules, monitoringv1.Rule{
 			Alert: "SLOMetricAbsent",
@@ -1035,7 +1047,11 @@ func (o Objective) IncreaseRules() (monitoringv1.RuleGroup, error) {
 			alertLabels[k] = v
 		}
 		// Add severity label for alerts
-		alertLabels["severity"] = string(critical)
+		if !o.Alerting.Disabled {
+			alertLabels["severity"] = string(critical)
+		} else {
+			alertLabels["severity"] = string(info)
+		}
 
 		rules = append(rules, monitoringv1.Rule{
 			Alert: "SLOMetricAbsent",
@@ -1084,6 +1100,7 @@ type severity string
 const (
 	critical severity = "critical"
 	warning  severity = "warning"
+	info     severity = "info"
 )
 
 type Window struct {

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -1245,6 +1245,23 @@ func TestObjective_IncreaseRules(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "http-ratio-alerting-disabled",
+		slo:  objectiveHTTPRatioAlertingDisabled(),
+		rules: monitoringv1.RuleGroup{
+			Name:     "monitoring-http-errors-increase",
+			Interval: monitoringDuration("2m30s"),
+			Rules: []monitoringv1.Rule{{
+				Record: "http_requests:increase4w",
+				Expr:   intstr.FromString(`sum by (code) (increase(http_requests_total{job="thanos-receive-default"}[4w]))`),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors"},
+			}, {
+				Alert:  "SLOMetricAbsent",
+				Expr:   intstr.FromString(`absent(http_requests_total{job="thanos-receive-default"}) == 1`),
+				For:    monitoringDuration("2m"),
+				Labels: map[string]string{"job": "thanos-receive-default", "slo": "monitoring-http-errors", "severity": "info"},
+			}},
+		},
+	}, {
 		name: "grpc-errors",
 		slo:  objectiveGRPCRatio(),
 		rules: monitoringv1.RuleGroup{
@@ -1568,7 +1585,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 		},
 	}}
 
-	require.Len(t, testcases, 17)
+	require.Len(t, testcases, 18)
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
While implementing to remove the absent alert entirely I got the idea to instead set the severity to info rather than warning or critical.

While critical and warning should page and route through Alertmanager, info severity is usually not routed anywhere. This has the nice effect that it'll still show up just in case, but not page any one at all.

Closes #820 