### PR TITLE
ui: Add option to make graphs absolute or relative

### DIFF
--- a/ui/src/components/Icons.tsx
+++ b/ui/src/components/Icons.tsx
@@ -145,3 +145,29 @@ export const IconTableColumns = ({height, width}: IconTableColumnsProps): JSX.El
     <path d="M0 96C0 60.7 28.7 32 64 32H448c35.3 0 64 28.7 64 64V416c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V96zm64 64V416H224V160H64zm384 0H288V416H448V160z" />
   </svg>
 )
+
+interface IconChartLineProps extends SizeProps {
+  fill?: string
+}
+
+export const IconChartLine = ({height, width, fill = 'black'}: IconChartLineProps): JSX.Element => (
+  <svg xmlns="http://www.w3.org/2000/svg" height={height} width={width} viewBox="0 0 512 512">
+    <path
+      fill={fill}
+      d="M64 64c0-17.7-14.3-32-32-32S0 46.3 0 64V400c0 44.2 35.8 80 80 80H480c17.7 0 32-14.3 32-32s-14.3-32-32-32H80c-8.8 0-16-7.2-16-16V64zm406.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L320 210.7l-57.4-57.4c-12.5-12.5-32.8-12.5-45.3 0l-112 112c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L240 221.3l57.4 57.4c12.5 12.5 32.8 12.5 45.3 0l128-128z"
+    />
+  </svg>
+)
+
+interface IconChartAreaProps extends SizeProps {
+  fill?: string
+}
+
+export const IconChartArea = ({height, width, fill = 'black'}: IconChartAreaProps): JSX.Element => (
+  <svg xmlns="http://www.w3.org/2000/svg" height={height} width={width} viewBox="0 0 512 512">
+    <path
+      fill={fill}
+      d="M64 64c0-17.7-14.3-32-32-32S0 46.3 0 64V400c0 44.2 35.8 80 80 80H480c17.7 0 32-14.3 32-32s-14.3-32-32-32H80c-8.8 0-16-7.2-16-16V64zm96 288H448c17.7 0 32-14.3 32-32V251.8c0-7.6-2.7-15-7.7-20.8l-65.8-76.8c-12.1-14.2-33.7-15-46.9-1.8l-21 21c-10 10-26.4 9.2-35.4-1.6l-39.2-47c-12.6-15.1-35.7-15.4-48.7-.6L135.9 215c-5.1 5.8-7.9 13.3-7.9 21.1v84c0 17.7 14.3 32 32 32z"
+    />
+  </svg>
+)

--- a/ui/src/components/graphs/ErrorBudgetGraph.tsx
+++ b/ui/src/components/graphs/ErrorBudgetGraph.tsx
@@ -21,6 +21,7 @@ interface ErrorBudgetGraphProps {
   to: number
   uPlotCursor: uPlot.Cursor
   updateTimeRange: (min: number, max: number, absolute: boolean) => void
+  absolute: boolean
 }
 
 const ErrorBudgetGraph = ({
@@ -30,6 +31,7 @@ const ErrorBudgetGraph = ({
   to,
   uPlotCursor,
   updateTimeRange,
+  absolute = false,
 }: ErrorBudgetGraphProps): JSX.Element => {
   const targetRef = useRef() as React.MutableRefObject<HTMLDivElement>
 
@@ -178,8 +180,8 @@ const ErrorBudgetGraph = ({
                 x: {min: from / 1000, max: to / 1000},
                 y: {
                   range: {
-                    min: {},
-                    max: {hard: 100},
+                    min: absolute ? {mode: 1, soft: 0} : {},
+                    max: absolute ? {hard: 100, mode: 1, soft: 0} : {hard: 100},
                   },
                 },
               },

--- a/ui/src/components/graphs/ErrorsGraph.tsx
+++ b/ui/src/components/graphs/ErrorsGraph.tsx
@@ -23,6 +23,7 @@ interface ErrorsGraphProps {
   to: number
   uPlotCursor: uPlot.Cursor
   updateTimeRange: (min: number, max: number, absolute: boolean) => void
+  absolute: boolean
 }
 
 const ErrorsGraph = ({
@@ -33,6 +34,7 @@ const ErrorsGraph = ({
   to,
   uPlotCursor,
   updateTimeRange,
+  absolute = false,
 }: ErrorsGraphProps): JSX.Element => {
   const targetRef = useRef() as React.MutableRefObject<HTMLDivElement>
 
@@ -155,8 +157,8 @@ const ErrorsGraph = ({
               x: {min: from / 1000, max: to / 1000},
               y: {
                 range: {
-                  min: {hard: 0},
-                  max: {hard: 100},
+                  min: absolute ? {hard: 0, mode: 1, soft: 0} : {hard: 0},
+                  max: absolute ? {hard: 1, mode: 1, soft: 1} : {hard: 1},
                 },
               },
             },

--- a/ui/src/pages/Detail.scss
+++ b/ui/src/pages/Detail.scss
@@ -13,8 +13,10 @@
     background: linear-gradient(0deg, rgba(0, 0, 0, 0) 45%, $gray-300 50%, rgba(0, 0, 0, 0) 55%);
 
     .inner {
+      display: flex;
       margin: 0 auto;
       background-color: $body-bg;
+      column-gap: 20px;
 
       @media (min-width: 576px) {
         width: 66%;

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -33,6 +33,7 @@ import ObjectiveTile from '../components/tiles/ObjectiveTile'
 import AvailabilityTile from '../components/tiles/AvailabilityTile'
 import ErrorBudgetTile from '../components/tiles/ErrorBudgetTile'
 import Tiles from '../components/tiles/Tiles'
+import {IconChartArea, IconChartLine} from '../components/Icons'
 
 const Detail = () => {
   const baseUrl = API_BASEPATH === undefined ? 'http://localhost:9099' : API_BASEPATH
@@ -88,6 +89,7 @@ const Detail = () => {
   }, [search])
 
   const [autoReload, setAutoReload] = useState<boolean>(true)
+  const [absolute, setAbsolute] = useState<boolean>(true)
 
   const {
     response: objectiveResponse,
@@ -296,7 +298,6 @@ const Detail = () => {
                     </Button>
                   ))}
                 </ButtonGroup>
-                &nbsp; &nbsp; &nbsp;
                 <OverlayTrigger
                   key="auto-reload"
                   overlay={
@@ -310,6 +311,36 @@ const Detail = () => {
                     />
                   </span>
                 </OverlayTrigger>
+                <ButtonGroup aria-label="Time Range">
+                  <OverlayTrigger
+                    key="auto-reload"
+                    overlay={
+                      <OverlayTooltip id={`tooltip-auto-reload`}>Absolute Chart</OverlayTooltip>
+                    }>
+                    <Button
+                      variant="light"
+                      onClick={() => {
+                        setAbsolute(true)
+                      }}
+                      active={absolute}>
+                      <IconChartArea width={16} height={16} fill={absolute ? 'white' : 'black'} />
+                    </Button>
+                  </OverlayTrigger>
+                  <OverlayTrigger
+                    key="auto-reload"
+                    overlay={
+                      <OverlayTooltip id={`tooltip-auto-reload`}>Relative Chart</OverlayTooltip>
+                    }>
+                    <Button
+                      variant="light"
+                      onClick={() => {
+                        setAbsolute(false)
+                      }}
+                      active={!absolute}>
+                      <IconChartLine width={16} height={16} fill={!absolute ? 'white' : 'black'} />
+                    </Button>
+                  </OverlayTrigger>
+                </ButtonGroup>
               </div>
             </Col>
           </Row>
@@ -323,6 +354,7 @@ const Detail = () => {
                   to={to}
                   uPlotCursor={uPlotCursor}
                   updateTimeRange={updateTimeRangeSelect}
+                  absolute={absolute}
                 />
               ) : (
                 <></>
@@ -361,6 +393,7 @@ const Detail = () => {
                   to={to}
                   uPlotCursor={uPlotCursor}
                   updateTimeRange={updateTimeRangeSelect}
+                  absolute={absolute}
                 />
               ) : (
                 <></>


### PR DESCRIPTION
By default, they are now absolute, but if some graph looks too flat they can be made relative.

cc @paulfantom

Closes #540

## Absolute (default)
_Notice the `0%`at the bottom left in the graph_
![brave_screenshot_localhost (1)](https://github.com/pyrra-dev/pyrra/assets/872251/c773d141-4ebf-4332-9fab-b29101f4ee5a)

## Relative 
_Notice the `7.90%`at the bottom left in the graph_

![brave_screenshot_localhost](https://github.com/pyrra-dev/pyrra/assets/872251/2cb09176-16b2-4d38-adc6-6da57a37120e)
