### PR TITLE
feat: accept new SLO specs using the filesystem HTTP api

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ picked up by a Prometheus instance. While running Pyrra on its own works, there
 won't be any SLO configured, nor will there be any data from a Prometheus to
 work with. It's designed to work alongside a Prometheus.
 
+SLO specs may be published using the `/ingest` endpoint. This will cause `pyrra` to
+generate the corresponding recordingRules, write them out to disk and trigger a reload
+of Prometheus.
+
+Example:
+```
+% curl -i -X POST -H "content-type: multipart/form-data" -F "spec=@service-levels/some-slo.yaml" http://localhost:9444/ingest
+HTTP/1.1 200 OK
+Date: Fri, 15 Sep 2023 14:21:54 GMT
+Content-Length: 2
+Content-Type: text/plain; charset=utf-8
+
+ok
+```
+
 ## Tech Stack
 
 **Client:** TypeScript with React, Bootstrap, and uPlot.


### PR DESCRIPTION
Implement an HTTP endpoint at which new SLO specs may be published when using the _filesystem_ operating mode.

Accept files over HTTP at `/ingest` and writes them to disk, creates new rules and reloads prometheus.

Sadly, the fsnotify watcher never managed to see any of the newly uploaded files so I had to force the rules creation a bit 🤔 

It seems to work, likely a little rough on the edges 😅 