### PR TITLE
CI: add job to check Jsonnet

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,0 +1,21 @@
+name: generate
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - examples/**
+  pull_request:
+
+jobs:
+  jsonnet:
+    runs-on: ubuntu-latest
+    name: Generate Jsonnet examples
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+    - uses: zendesk/setup-jsonnet@v11
+    - run: go install github.com/brancz/gojsontoyaml@latest
+    - run: make --always-make examples && git diff --exit-code


### PR DESCRIPTION
This commit adds a workflow for generated files with a job to check
Jsonnet in the examples/ directory. I tested this locally with act and
correctly got a diff and a failure when bumping the Pyrra version in
examples/openshift.main.jsonnet.

Fixes: https://github.com/pyrra-dev/pyrra/issues/934

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
