### PR TITLE
Fix invalid PrometheusRule when adding grouping to a ratio indicator

### DIFF
--- a/kubernetes/controllers/servicelevelobjective.go
+++ b/kubernetes/controllers/servicelevelobjective.go
@@ -180,9 +180,9 @@ func makeConfigMap(name string, kubeObjective pyrrav1alpha1.ServiceLevelObjectiv
 				return nil, fmt.Errorf("failed to get generic rules: %w", err)
 			}
 			// ignore these rules
+		} else {
+			rule.Groups = append(rule.Groups, rules)
 		}
-
-		rule.Groups = append(rule.Groups, rules)
 	}
 
 	bytes, err := yaml.Marshal(rule)
@@ -244,9 +244,9 @@ func makePrometheusRule(kubeObjective pyrrav1alpha1.ServiceLevelObjective, gener
 				return nil, fmt.Errorf("failed to get generic rules: %w", err)
 			}
 			// ignore these rules
+		} else {
+			rule.Groups = append(rule.Groups, rules)
 		}
-
-		rule.Groups = append(rule.Groups, rules)
 	}
 
 	isController := true


### PR DESCRIPTION
The `rules` here were being added to `rule.Groups`, even if we have had an `ErrGroupingUnsupported` error returned by the `objective.GenericRules()` function. This results in an empty rule being added to the `PrometheusRule` spec, which fails validation.

I just added an `else` branch so the rule is not added to the spec if an `ErrGroupingUnsupported` error has been raised.

I think this should fix https://github.com/pyrra-dev/pyrra/issues/976.