### PR TITLE
Fix the display of the "Errors" panel in the SLO detail dashboard

### DIFF
--- a/examples/grafana/detail.json
+++ b/examples/grafana/detail.json
@@ -598,7 +598,7 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "reqps"
         },
         "overrides": [
           {


### PR DESCRIPTION
This panel actually shows the rate of errors occurring but is configured to display this as percentunit. This results in it showing a 200% error rate when there are actually 2 errors occurring per second. Change the unit for this panel to reqps instead.