### PR TITLE
jsonnet/pyrra: Add prometheusURL configuration option

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -122,7 +122,7 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 			}
 			<-ctx.Done()
 			return nil
-		}, func(err error) {
+		}, func(_ error) {
 			cancel()
 		})
 	}
@@ -158,7 +158,7 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 					level.Warn(logger).Log("msg", "encountered file watcher error", "err", err)
 				}
 			}
-		}, func(err error) {
+		}, func(_ error) {
 			_ = watcher.Close()
 			cancel()
 		})
@@ -195,7 +195,7 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 					reload <- struct{}{} // Trigger a Prometheus reload
 				}
 			}
-		}, func(err error) {
+		}, func(_ error) {
 			cancel()
 		})
 	}
@@ -235,7 +235,7 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 					}
 				}
 			}
-		}, func(err error) {
+		}, func(_ error) {
 			cancel()
 			close(reload)
 		})
@@ -260,7 +260,7 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 		gr.Add(func() error {
 			level.Info(logger).Log("msg", "starting up HTTP API", "address", server.Addr)
 			return server.ListenAndServe()
-		}, func(err error) {
+		}, func(_ error) {
 			_ = server.Shutdown(context.Background())
 		})
 	}

--- a/jsonnet/pyrra/kubernetes.libsonnet
+++ b/jsonnet/pyrra/kubernetes.libsonnet
@@ -12,6 +12,7 @@
       namespace: $.values.common.namespace,
       version: $.values.common.versions.pyrra,
       image: $.values.common.images.pyrra,
+      prometheusURL: 'http://prometheus-k8s.%s.svc.cluster.local:9090' % $.values.common.namespace,
     },
   },
 
@@ -78,7 +79,7 @@
         args: [
           'api',
           '--api-url=http://%s.%s.svc.cluster.local:9444' % [pyrra.kubernetesService.metadata.name, pyrra.kubernetesService.metadata.namespace],
-          '--prometheus-url=http://prometheus-k8s.%s.svc.cluster.local:9090' % pyrra._config.namespace,
+          '--prometheus-url=%s' % pyrra._config.prometheusURL,
         ],
         // resources: pyrra._config.resources,
         ports: [{ containerPort: pyrra._config.port }],

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -116,7 +116,7 @@ func cmdKubernetes(
 			}
 			setupLog.Info("starting manager")
 			return mgr.Start(ctx)
-		}, func(err error) {
+		}, func(_ error) {
 			cancel()
 		})
 	}
@@ -137,7 +137,7 @@ func cmdKubernetes(
 				return server.ListenAndServeTLS(certFile, privateKeyFile)
 			}
 			return server.ListenAndServe()
-		}, func(err error) {
+		}, func(_ error) {
 			shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 			_ = server.Shutdown(shutdownCtx)

--- a/main.go
+++ b/main.go
@@ -299,7 +299,7 @@ func cmdAPI(
 		}
 
 		r.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-		r.Get("/objectives", func(w http.ResponseWriter, r *http.Request) {
+		r.Get("/objectives", func(w http.ResponseWriter, _ *http.Request) {
 			err := tmpl.Execute(w, struct {
 				PrometheusURL string
 				PathPrefix    string


### PR DESCRIPTION
This adds a configuration option for the `prometheus-url` parameter to the API server, making it easier to point the server at thanos-query or a differently named Prometheus instance.