### PR TITLE
chore: Use the latest version for the examples

### DIFF
--- a/examples/docker-compose/docker-compose.yaml
+++ b/examples/docker-compose/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - ./prometheus_pyrra:/etc/prometheus/pyrra
 
   pyrra-api:
-    image: ghcr.io/pyrra-dev/pyrra:v0.7.0
+    image: ghcr.io/pyrra-dev/pyrra:v0.7.5
     restart: always
     command:
       - api
@@ -36,7 +36,7 @@ services:
       - pyrra
 
   pyrra-filesystem:
-    image: ghcr.io/pyrra-dev/pyrra:v0.7.0
+    image: ghcr.io/pyrra-dev/pyrra:v0.7.5
     restart: always
     command:
       - filesystem

--- a/examples/kubernetes/main-webhook.jsonnet
+++ b/examples/kubernetes/main-webhook.jsonnet
@@ -8,7 +8,7 @@ local kp =
       common+: {
         namespace: 'monitoring',
         versions+: {
-          pyrra: '0.7.0',
+          pyrra: '0.7.5',
         },
       },
     },

--- a/examples/kubernetes/main.jsonnet
+++ b/examples/kubernetes/main.jsonnet
@@ -7,7 +7,7 @@ local kp =
       common+: {
         namespace: 'monitoring',
         versions+: {
-          pyrra: '0.7.0',
+          pyrra: '0.7.5',
         },
       },
     },

--- a/examples/kubernetes/manifests-webhook/pyrra-apiDeployment.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-apiDeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: monitoring
 spec:
@@ -22,14 +22,14 @@ spec:
       labels:
         app.kubernetes.io/component: api
         app.kubernetes.io/name: pyrra
-        app.kubernetes.io/version: 0.7.0
+        app.kubernetes.io/version: 0.7.5
     spec:
       containers:
       - args:
         - api
         - --api-url=http://pyrra-kubernetes.monitoring.svc.cluster.local:9444
         - --prometheus-url=http://prometheus-k8s.monitoring.svc.cluster.local:9090
-        image: ghcr.io/pyrra-dev/pyrra:v0.7.0
+        image: ghcr.io/pyrra-dev/pyrra:v0.7.5
         name: pyrra
         ports:
         - containerPort: 9099

--- a/examples/kubernetes/manifests-webhook/pyrra-apiService.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-apiService.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: monitoring
 spec:

--- a/examples/kubernetes/manifests-webhook/pyrra-apiServiceAccount.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-apiServiceAccount.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: monitoring

--- a/examples/kubernetes/manifests-webhook/pyrra-apiServiceMonitor.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-apiServiceMonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: monitoring
 spec:

--- a/examples/kubernetes/manifests-webhook/pyrra-kubernetesClusterRole.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-kubernetesClusterRole.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 rules:

--- a/examples/kubernetes/manifests-webhook/pyrra-kubernetesClusterRoleBinding.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-kubernetesClusterRoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 roleRef:

--- a/examples/kubernetes/manifests-webhook/pyrra-kubernetesDeployment.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-kubernetesDeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 spec:
@@ -22,13 +22,13 @@ spec:
       labels:
         app.kubernetes.io/component: kubernetes
         app.kubernetes.io/name: pyrra
-        app.kubernetes.io/version: 0.7.0
+        app.kubernetes.io/version: 0.7.5
     spec:
       containers:
       - args:
         - kubernetes
         - --disable-webhooks=false
-        image: ghcr.io/pyrra-dev/pyrra:v0.7.0
+        image: ghcr.io/pyrra-dev/pyrra:v0.7.5
         name: pyrra
         ports:
         - containerPort: 9099

--- a/examples/kubernetes/manifests-webhook/pyrra-kubernetesService.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-kubernetesService.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 spec:

--- a/examples/kubernetes/manifests-webhook/pyrra-kubernetesServiceAccount.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-kubernetesServiceAccount.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring

--- a/examples/kubernetes/manifests-webhook/pyrra-kubernetesServiceMonitor.yaml
+++ b/examples/kubernetes/manifests-webhook/pyrra-kubernetesServiceMonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 spec:

--- a/examples/kubernetes/manifests/pyrra-apiDeployment.yaml
+++ b/examples/kubernetes/manifests/pyrra-apiDeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: monitoring
 spec:
@@ -22,14 +22,14 @@ spec:
       labels:
         app.kubernetes.io/component: api
         app.kubernetes.io/name: pyrra
-        app.kubernetes.io/version: 0.7.0
+        app.kubernetes.io/version: 0.7.5
     spec:
       containers:
       - args:
         - api
         - --api-url=http://pyrra-kubernetes.monitoring.svc.cluster.local:9444
         - --prometheus-url=http://prometheus-k8s.monitoring.svc.cluster.local:9090
-        image: ghcr.io/pyrra-dev/pyrra:v0.7.0
+        image: ghcr.io/pyrra-dev/pyrra:v0.7.5
         name: pyrra
         ports:
         - containerPort: 9099

--- a/examples/kubernetes/manifests/pyrra-apiService.yaml
+++ b/examples/kubernetes/manifests/pyrra-apiService.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: monitoring
 spec:

--- a/examples/kubernetes/manifests/pyrra-apiServiceAccount.yaml
+++ b/examples/kubernetes/manifests/pyrra-apiServiceAccount.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: monitoring

--- a/examples/kubernetes/manifests/pyrra-apiServiceMonitor.yaml
+++ b/examples/kubernetes/manifests/pyrra-apiServiceMonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: monitoring
 spec:

--- a/examples/kubernetes/manifests/pyrra-kubernetesClusterRole.yaml
+++ b/examples/kubernetes/manifests/pyrra-kubernetesClusterRole.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 rules:

--- a/examples/kubernetes/manifests/pyrra-kubernetesClusterRoleBinding.yaml
+++ b/examples/kubernetes/manifests/pyrra-kubernetesClusterRoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 roleRef:

--- a/examples/kubernetes/manifests/pyrra-kubernetesDeployment.yaml
+++ b/examples/kubernetes/manifests/pyrra-kubernetesDeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 spec:
@@ -22,12 +22,12 @@ spec:
       labels:
         app.kubernetes.io/component: kubernetes
         app.kubernetes.io/name: pyrra
-        app.kubernetes.io/version: 0.7.0
+        app.kubernetes.io/version: 0.7.5
     spec:
       containers:
       - args:
         - kubernetes
-        image: ghcr.io/pyrra-dev/pyrra:v0.7.0
+        image: ghcr.io/pyrra-dev/pyrra:v0.7.5
         name: pyrra
         ports:
         - containerPort: 9099

--- a/examples/kubernetes/manifests/pyrra-kubernetesService.yaml
+++ b/examples/kubernetes/manifests/pyrra-kubernetesService.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 spec:

--- a/examples/kubernetes/manifests/pyrra-kubernetesServiceAccount.yaml
+++ b/examples/kubernetes/manifests/pyrra-kubernetesServiceAccount.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring

--- a/examples/kubernetes/manifests/pyrra-kubernetesServiceMonitor.yaml
+++ b/examples/kubernetes/manifests/pyrra-kubernetesServiceMonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: monitoring
 spec:

--- a/examples/openshift/main.jsonnet
+++ b/examples/openshift/main.jsonnet
@@ -10,7 +10,7 @@ local kp =
       common+: {
         namespace: 'openshift-monitoring',
         versions+: {
-          pyrra: '0.7.0',
+          pyrra: '0.7.5',
         },
       },
     },

--- a/examples/openshift/manifests/pyrra-apiDeployment.yaml
+++ b/examples/openshift/manifests/pyrra-apiDeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: openshift-monitoring
 spec:
@@ -24,7 +24,7 @@ spec:
       labels:
         app.kubernetes.io/component: api
         app.kubernetes.io/name: pyrra
-        app.kubernetes.io/version: 0.7.0
+        app.kubernetes.io/version: 0.7.5
     spec:
       containers:
       - args:
@@ -35,7 +35,7 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --tls-client-ca-file=/etc/tls/certs/service-ca.crt
-        image: ghcr.io/pyrra-dev/pyrra:v0.7.0
+        image: ghcr.io/pyrra-dev/pyrra:v0.7.5
         name: pyrra
         ports:
         - containerPort: 9099

--- a/examples/openshift/manifests/pyrra-apiService.yaml
+++ b/examples/openshift/manifests/pyrra-apiService.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: openshift-monitoring
 spec:

--- a/examples/openshift/manifests/pyrra-apiServiceAccount.yaml
+++ b/examples/openshift/manifests/pyrra-apiServiceAccount.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: openshift-monitoring

--- a/examples/openshift/manifests/pyrra-apiServiceMonitor.yaml
+++ b/examples/openshift/manifests/pyrra-apiServiceMonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: api
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-api
   namespace: openshift-monitoring
 spec:

--- a/examples/openshift/manifests/pyrra-kubernetesClusterRole.yaml
+++ b/examples/openshift/manifests/pyrra-kubernetesClusterRole.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: openshift-monitoring
 rules:

--- a/examples/openshift/manifests/pyrra-kubernetesClusterRoleBinding.yaml
+++ b/examples/openshift/manifests/pyrra-kubernetesClusterRoleBinding.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: openshift-monitoring
 roleRef:

--- a/examples/openshift/manifests/pyrra-kubernetesDeployment.yaml
+++ b/examples/openshift/manifests/pyrra-kubernetesDeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: openshift-monitoring
 spec:
@@ -22,14 +22,14 @@ spec:
       labels:
         app.kubernetes.io/component: kubernetes
         app.kubernetes.io/name: pyrra
-        app.kubernetes.io/version: 0.7.0
+        app.kubernetes.io/version: 0.7.5
     spec:
       containers:
       - args:
         - kubernetes
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
-        image: ghcr.io/pyrra-dev/pyrra:v0.7.0
+        image: ghcr.io/pyrra-dev/pyrra:v0.7.5
         name: pyrra
         ports:
         - containerPort: 9099

--- a/examples/openshift/manifests/pyrra-kubernetesService.yaml
+++ b/examples/openshift/manifests/pyrra-kubernetesService.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: openshift-monitoring
 spec:

--- a/examples/openshift/manifests/pyrra-kubernetesServiceAccount.yaml
+++ b/examples/openshift/manifests/pyrra-kubernetesServiceAccount.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: openshift-monitoring

--- a/examples/openshift/manifests/pyrra-kubernetesServiceMonitor.yaml
+++ b/examples/openshift/manifests/pyrra-kubernetesServiceMonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: pyrra
-    app.kubernetes.io/version: 0.7.0
+    app.kubernetes.io/version: 0.7.5
   name: pyrra-kubernetes
   namespace: openshift-monitoring
 spec:


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

I have a use case where I used the examples directly, and they were out of date. I can only afford to use the latest and the greatest.

I'm not sure about the release procedure here, but I've targeted the release branch for these example updates. 

Let me know how to proceed @metalmatze 