### PR TITLE
webhook: fix panic on unedpected parser expression

### DIFF
--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -284,14 +284,20 @@ func (in *ServiceLevelObjective) validate() (admission.Warnings, error) {
 
 		switch parsedTotal.Type() {
 		case parser.ValueTypeVector:
-			v := parsedTotal.(*parser.VectorSelector)
+			v, ok := parsedTotal.(*parser.VectorSelector)
+			if !ok {
+				return warnings, fmt.Errorf("latency total metric must be a vector selector, but got %T", parsedTotal)
+			}
 			if !strings.HasSuffix(v.Name, "_count") {
 				warnings = append(warnings, "latency total metric should usually be a histogram count")
 			}
 		}
 		switch parsedSuccess.Type() {
 		case parser.ValueTypeVector:
-			v := parsedSuccess.(*parser.VectorSelector)
+			v, ok := parsedSuccess.(*parser.VectorSelector)
+			if !ok {
+				return warnings, fmt.Errorf("latency success metric must be a vector selector, but got %T", parsedSuccess)
+			}
 			var bucketFound bool
 			for _, matcher := range v.LabelMatchers {
 				if matcher.Name == labels.BucketLabel {

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
@@ -586,6 +586,13 @@ func TestServiceLevelObjective_Validate(t *testing.T) {
 			latency.Spec.ServiceLevelIndicator.Latency.Success.Metric = `foo{le="foo"}`
 			_, err = latency.ValidateCreate()
 			require.EqualError(t, err, `latency success metric must contain a le label matcher with a float value: strconv.ParseFloat: parsing "foo": invalid syntax`)
+
+			latency.Spec.ServiceLevelIndicator.Latency.Success.Metric = `foo{le="1.0"} or vector(0)`
+			_, err = latency.ValidateCreate()
+			require.EqualError(t, err, `latency success metric must be a vector selector, but got *parser.BinaryExpr`)
+			latency.Spec.ServiceLevelIndicator.Latency.Total.Metric = `foo{le="1.0"} or vector(0)`
+			_, err = latency.ValidateCreate()
+			require.EqualError(t, err, `latency total metric must be a vector selector, but got *parser.BinaryExpr`)
 		})
 	})
 


### PR DESCRIPTION
Even if a vector expression in an SLO returns a vector, the webhook API
handler will panic if the underlying expression is not a vector selctor.

Fixes: https://github.com/pyrra-dev/pyrra/issues/1181

Signed-off-by: squat <lserven@gmail.com>
