### PR TITLE
Round target to 5 decimal points

### DIFF
--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -352,6 +352,8 @@ func (in *ServiceLevelObjective) Internal() (slo.Objective, error) {
 	if err != nil {
 		return slo.Objective{}, fmt.Errorf("failed to parse objective target: %w", err)
 	}
+	// round to 5 decimal places before diving by 100
+	target = (target * 10000) / 1000000
 
 	window, err := model.ParseDuration(in.Spec.Window)
 	if err != nil {
@@ -554,7 +556,7 @@ func (in *ServiceLevelObjective) Internal() (slo.Objective, error) {
 		Labels:      ls,
 		Annotations: in.Annotations,
 		Description: in.Spec.Description,
-		Target:      target / 100,
+		Target:      target,
 		Window:      window,
 		Config:      string(config),
 		Alerting:    alerting,

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
@@ -88,7 +88,7 @@ metadata:
    prometheus: k8s
    role: alert-rules
 spec:
- target: 99.9
+ target: 99.999
  window: 1w
  indicator:
    ratio:
@@ -103,7 +103,7 @@ spec:
 				"namespace", "monitoring",
 			),
 			Description: "",
-			Target:      0.9990000000000001, // TODO fix this? maybe not /100?
+			Target:      0.99999,
 			Window:      model.Duration(7 * 24 * time.Hour),
 			Alerting: slo.Alerting{
 				Burnrates: true,

--- a/main.go
+++ b/main.go
@@ -1567,7 +1567,7 @@ func (s *objectiveServer) GraphDuration(ctx context.Context, req *connect.Reques
 
 			timeseries = append(timeseries,
 				&objectivesv1alpha1.Timeseries{
-					Labels: []string{fmt.Sprintf(`{quantile="p%.f"}`, 100*percentile)}, // TODO: Nicer format float
+					Labels: []string{fmt.Sprintf(`{quantile="p%g"}`, 100*percentile)}, // TODO: Nicer format float
 					Query:  query,
 					Series: series,
 				},


### PR DESCRIPTION
This gets rid of a "bug" where having `0.9990000000000001` instead of `0.999`.

Fixes #1197
