### PR TITLE
Update the golangci lint config

### DIFF
--- a/.errcheck_excludes.txt
+++ b/.errcheck_excludes.txt
@@ -1,1 +1,0 @@
-(github.com/go-kit/log.Logger).Log

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
   deadline: 5m
-  go: 1.19
-  skip-dirs:
-    - proto/
+  go: 1.20
 
 linters:
   enable:
@@ -14,6 +12,8 @@ linters:
     - whitespace
 
 issues:
+  exclude-dirs:
+    - proto/
   exclude-rules:
     - path: _test.go
       linters:
@@ -39,7 +39,8 @@ linters-settings:
           - pkg: github.com/pkg/errors
             desc: "Use fmt.Errorf instead"
   errcheck:
-    exclude: ./.errcheck_excludes.txt
+    exclude-functions:
+      - "(github.com/go-kit/log.Logger).Log"
   goimports:
     local-prefixes: github.com/pyrra-dev/pyrra
   gofumpt:


### PR DESCRIPTION
Some of these were deprecated and printed warnings.
