### PR TITLE
fix(slos): Use apiserver_request_sli.* metrics

### DIFF
--- a/examples/kubernetes/manifests-webhook/slos/slo-apiserver-read-cluster-latency.yaml
+++ b/examples/kubernetes/manifests-webhook/slos/slo-apiserver-read-cluster-latency.yaml
@@ -11,8 +11,8 @@ spec:
   indicator:
     latency:
       success:
-        metric: apiserver_request_slo_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="5"}
+        metric: apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="5"}
       total:
-        metric: apiserver_request_slo_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/examples/kubernetes/manifests-webhook/slos/slo-apiserver-read-namespace-latency.yaml
+++ b/examples/kubernetes/manifests-webhook/slos/slo-apiserver-read-namespace-latency.yaml
@@ -11,8 +11,8 @@ spec:
   indicator:
     latency:
       success:
-        metric: apiserver_request_slo_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="5"}
+        metric: apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="5"}
       total:
-        metric: apiserver_request_slo_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/examples/kubernetes/manifests-webhook/slos/slo-apiserver-read-resource-latency.yaml
+++ b/examples/kubernetes/manifests-webhook/slos/slo-apiserver-read-resource-latency.yaml
@@ -11,8 +11,8 @@ spec:
   indicator:
     latency:
       success:
-        metric: apiserver_request_slo_duration_seconds_bucket{verb=~"LIST|GET",le="0.1"}
+        metric: apiserver_request_sli_duration_seconds_bucket{verb=~"LIST|GET",le="0.1"}
       total:
-        metric: apiserver_request_slo_duration_seconds_count{verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/examples/kubernetes/manifests/slos/slo-apiserver-read-cluster-latency.yaml
+++ b/examples/kubernetes/manifests/slos/slo-apiserver-read-cluster-latency.yaml
@@ -11,8 +11,8 @@ spec:
   indicator:
     latency:
       success:
-        metric: apiserver_request_slo_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="5"}
+        metric: apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="5"}
       total:
-        metric: apiserver_request_slo_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/examples/kubernetes/manifests/slos/slo-apiserver-read-namespace-latency.yaml
+++ b/examples/kubernetes/manifests/slos/slo-apiserver-read-namespace-latency.yaml
@@ -11,8 +11,8 @@ spec:
   indicator:
     latency:
       success:
-        metric: apiserver_request_slo_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="5"}
+        metric: apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="5"}
       total:
-        metric: apiserver_request_slo_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/examples/kubernetes/manifests/slos/slo-apiserver-read-resource-latency.yaml
+++ b/examples/kubernetes/manifests/slos/slo-apiserver-read-resource-latency.yaml
@@ -11,8 +11,8 @@ spec:
   indicator:
     latency:
       success:
-        metric: apiserver_request_slo_duration_seconds_bucket{verb=~"LIST|GET",le="0.1"}
+        metric: apiserver_request_sli_duration_seconds_bucket{verb=~"LIST|GET",le="0.1"}
       total:
-        metric: apiserver_request_slo_duration_seconds_count{verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/examples/openshift/manifests/slos/slo-apiserver-read-cluster-latency.yaml
+++ b/examples/openshift/manifests/slos/slo-apiserver-read-cluster-latency.yaml
@@ -11,8 +11,8 @@ spec:
   indicator:
     latency:
       success:
-        metric: apiserver_request_slo_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="5"}
+        metric: apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="5"}
       total:
-        metric: apiserver_request_slo_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/examples/openshift/manifests/slos/slo-apiserver-read-namespace-latency.yaml
+++ b/examples/openshift/manifests/slos/slo-apiserver-read-namespace-latency.yaml
@@ -11,8 +11,8 @@ spec:
   indicator:
     latency:
       success:
-        metric: apiserver_request_slo_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="5"}
+        metric: apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="5"}
       total:
-        metric: apiserver_request_slo_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/examples/openshift/manifests/slos/slo-apiserver-read-resource-latency.yaml
+++ b/examples/openshift/manifests/slos/slo-apiserver-read-resource-latency.yaml
@@ -11,8 +11,8 @@ spec:
   indicator:
     latency:
       success:
-        metric: apiserver_request_slo_duration_seconds_bucket{verb=~"LIST|GET",le="0.1"}
+        metric: apiserver_request_sli_duration_seconds_bucket{verb=~"LIST|GET",le="0.1"}
       total:
-        metric: apiserver_request_slo_duration_seconds_count{verb=~"LIST|GET"}
+        metric: apiserver_request_sli_duration_seconds_count{verb=~"LIST|GET"}
   target: "99"
   window: 2w

--- a/jsonnet/pyrra/kubernetes.libsonnet
+++ b/jsonnet/pyrra/kubernetes.libsonnet
@@ -339,10 +339,10 @@
         indicator: {
           latency: {
             success: {
-              metric: 'apiserver_request_slo_duration_seconds_bucket{verb=~"LIST|GET",le="0.1"}',
+              metric: 'apiserver_request_sli_duration_seconds_bucket{verb=~"LIST|GET",le="0.1"}',
             },
             total: {
-              metric: 'apiserver_request_slo_duration_seconds_count{verb=~"LIST|GET"}',
+              metric: 'apiserver_request_sli_duration_seconds_count{verb=~"LIST|GET"}',
             },
           },
         },
@@ -367,10 +367,10 @@
         indicator: {
           latency: {
             success: {
-              metric: 'apiserver_request_slo_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="5"}',
+              metric: 'apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"namespace|",verb=~"LIST|GET",le="5"}',
             },
             total: {
-              metric: 'apiserver_request_slo_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}',
+              metric: 'apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"namespace|",verb=~"LIST|GET"}',
             },
           },
         },
@@ -395,10 +395,10 @@
         indicator: {
           latency: {
             success: {
-              metric: 'apiserver_request_slo_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="5"}',
+              metric: 'apiserver_request_sli_duration_seconds_bucket{component="apiserver",scope=~"cluster|",verb=~"LIST|GET",le="5"}',
             },
             total: {
-              metric: 'apiserver_request_slo_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}',
+              metric: 'apiserver_request_sli_duration_seconds_count{component="apiserver",scope=~"cluster|",verb=~"LIST|GET"}',
             },
           },
         },


### PR DESCRIPTION
Since the k8s-mixin is moved to [using the SLI.* metrics](https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/874/files), can we change the default SLOs to use the SLI.* metrics? Is it set/pinned to support older k8s versions (https://github.com/pyrra-dev/pyrra/pull/915/commits/12e7e5eab303b1707a5af1ad580109e95fe45918)?