### PR TITLE
fix(docker-compose): minor changes

### DIFF
--- a/examples/docker-compose/docker-compose.yaml
+++ b/examples/docker-compose/docker-compose.yaml
@@ -9,6 +9,7 @@ volumes:
 services:
   prometheus:
     image: prom/prometheus:v2.47.0
+    container_name: prometheus
     restart: always
     networks:
       - pyrra
@@ -18,12 +19,14 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=33d
+      - --web.enable-lifecycle
     volumes:
       - ./prometheus/prometheus.yaml:/etc/prometheus/prometheus.yml:ro
-      - ./prometheus_pyrra:/etc/prometheus/pyrra
+      - prometheus_pyrra:/etc/prometheus/pyrra
 
   pyrra-api:
     image: ghcr.io/pyrra-dev/pyrra:v0.7.5
+    container_name: pyrra_api
     restart: always
     command:
       - api
@@ -37,6 +40,8 @@ services:
 
   pyrra-filesystem:
     image: ghcr.io/pyrra-dev/pyrra:v0.7.5
+    user: root
+    container_name: pyrra_filesystem
     restart: always
     command:
       - filesystem
@@ -45,4 +50,4 @@ services:
       - pyrra
     volumes:
       - ./pyrra:/etc/pyrra
-      - ./prometheus_pyrra:/etc/prometheus/pyrra
+      - prometheus_pyrra:/etc/prometheus/pyrra


### PR DESCRIPTION
- Enable lifecycle API to reload.
- Change running user to be able to write to share volume.

```
level=info ts=2024-07-12T10:15:32.058814841Z caller=main.go:142 msg="using Prometheus" url=http://prometheus:9090
level=info ts=2024-07-12T10:15:32.058882208Z caller=filesystem.go:131 msg="watching directory for changes" directory=/etc/pyrra
level=info ts=2024-07-12T10:15:32.059549038Z caller=filesystem.go:261 msg="starting up HTTP API" address=:9444
level=error ts=2024-07-12T10:15:32.064182232Z caller=filesystem.go:185 msg="error creating rule file" file=/etc/pyrra/prometheus-http.yaml err="failed to write file \"/etc/prometheus/pyrra/prometheus-http.yaml\": open /etc/prometheus/pyrra/prometheus-http.yaml: permission denied"
level=warn ts=2024-07-12T10:15:37.073472514Z caller=filesystem.go:227 msg="failed to reload Prometheus" url=http://prometheus:9090/-/reload status="403 Forbidden" body="Lifecycle API is not enabled."
```