### PR TITLE
Fix nil pointer reference in GetStatus()

### DIFF
--- a/main.go
+++ b/main.go
@@ -849,7 +849,8 @@ func (s *objectiveServer) GetStatus(ctx context.Context, req *connect.Request[ob
 			statuses[v.Metric.Fingerprint()] = &objectivesv1alpha1.ObjectiveStatus{
 				Labels: objectiveLabels,
 				Availability: &objectivesv1alpha1.Availability{
-					Percentage: 1 - (s.Availability.Errors / s.Availability.Total),
+					Percentage: 0,
+					Errors:     float64(v.Value),
 					Total:      float64(v.Value),
 				},
 			}


### PR DESCRIPTION
We explicitly check for existence in status before adding this metric, but then we reference the status we know we didn't retrieve. I think the broader bug might be that the fingerprints for the total value is different than the one for the errors, so we might need to collate by closest objective label or something, but this should fix the Nil pointer exceptions.

fixes #1393