### PR TITLE
fix: incorrect array length in mergeAlignedData

### DIFF
--- a/ui/src/components/graphs/aligneddata.tsx
+++ b/ui/src/components/graphs/aligneddata.tsx
@@ -118,6 +118,9 @@ export const mergeAlignedData = (responses: AlignedDataResponse[]): AlignedDataR
     const timeValues = series.get(t)
     if (timeValues !== undefined) {
       timeValues.forEach((s: number | null | undefined, j: number) => {
+        while (values.length <= j) {
+          values.push([])
+        }
         values[j].push(s)
       })
     }


### PR DESCRIPTION
We had the same issue as #1130. I tried to find the minimum reproducible example:

```yaml
apiVersion: pyrra.dev/v1alpha1
kind: ServiceLevelObjective
metadata:
  name: prometheus-api-query
  namespace: monitoring
  labels:
    prometheus: k8s
    role: alert-rules
spec:
  target: "99.0"
  window: 7d
  indicator:
    ratio:
      errors:
        metric: prometheus_http_requests_total{handler=~"/.*", code=~"5.."}
      total:
        metric: prometheus_http_requests_total{handler=~"/.*"}
```

Adding the handler to the example SLO triggers the issue on every UI load for me.

I don't fully understand the code, but I guess that the logic can be improved in a better way to not rely on the hacky loop extending the array just enough.

Anyway, I wanted to share my finding and a workaround at least.