### PR TITLE
feat: support Grafana Explore integration in the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,43 @@ picked up by a Prometheus instance. While running Pyrra on its own works, there
 won't be any SLO configured, nor will there be any data from a Prometheus to
 work with. It's designed to work alongside a Prometheus.
 
+## Configuration Options
+
+### API Command Flags
+
+When running `pyrra api`, you can configure various options:
+
+#### Prometheus Configuration
+- `--prometheus-url` - The URL to the Prometheus to query (default: `http://localhost:9090`)
+- `--prometheus-external-url` - The URL for the UI to redirect users to when opening Prometheus
+
+#### Grafana Integration
+As an alternative to redirecting to Prometheus, Pyrra can redirect to Grafana Explore for a richer query experience:
+
+- `--grafana-external-url` - The URL for the UI to redirect users to Grafana Explore page
+- `--grafana-external-org-id` - The Grafana Explore organization id (default: `1`)
+- `--grafana-external-datasource-id` - The Grafana Explore prometheus datasource id (required when using `--grafana-external-url`)
+
+**Note:** You cannot use both `--prometheus-external-url` and `--grafana-external-url` at the same time. Choose one based on your preference.
+
+#### Example Usage
+
+Using Prometheus external URL:
+```bash
+pyrra api \
+  --prometheus-url=http://prometheus:9090 \
+  --prometheus-external-url=http://prometheus.example.com \
+  --api-url=http://pyrra-filesystem:9444
+```
+
+Using Grafana external URL:
+```bash
+pyrra api \
+  --grafana-external-url=http://grafana:3000 \
+  --grafana-external-datasource-id=cemv8t0tc1hq8b \
+  --api-url=http://pyrra-filesystem:9444
+```
+
 ## Tech Stack
 
 **Client:** TypeScript with React, Bootstrap, and uPlot.

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -22,3 +22,40 @@ Pyrra is available on [localhost:9099](http://localhost:9099) and Prometheus at 
 Pyrra should show you the available SLOs on its overview page and you can click on the individual ones to see the specific SLO and all it's details.
 
 Prometheus is configured by Pyrra with the necessary [recording rules](http://localhost:9090/rules) and [alerting rules](http://localhost:9090/alerts).
+
+## Using Grafana Instead of Prometheus for External Links
+
+If you prefer to use Grafana Explore for viewing metrics instead of Prometheus, you can modify the `docker-compose.yaml` file to use Grafana external URL. Replace the `pyrra-api` service command with:
+
+```yaml
+command:
+  - api
+  - --prometheus-url=http://prometheus:9090
+  - --grafana-external-url=http://your-grafana-instance:3000
+  - --grafana-external-datasource-id=your-prometheus-datasource-uid
+  - --api-url=http://pyrra-filesystem:9444
+```
+
+Make sure to replace:
+- `http://your-grafana-instance:3000` with your actual Grafana URL
+- `your-prometheus-datasource-uid` with the UID of your Prometheus datasource in Grafana
+
+### Finding Your Grafana Datasource UID
+
+1. Log into your Grafana instance
+2. Go to Configuration → Data Sources
+3. Click on your Prometheus datasource
+4. The UID is shown in the settings (or can be found in the URL)
+
+### Complete Example with Grafana
+
+We've included a `docker-compose-with-grafana.yaml` file that demonstrates a complete setup with Prometheus, Grafana, and Pyrra configured to use Grafana for external links.
+
+To use it:
+1. Start all services: `docker-compose -f docker-compose-with-grafana.yaml up -d`
+2. Access Grafana at http://localhost:3000 (default login: admin/admin)
+3. Add Prometheus as a datasource:
+   - URL: `http://prometheus:9090`
+   - Save and note the datasource UID
+4. Update the `docker-compose-with-grafana.yaml` file with the actual datasource UID
+5. Restart Pyrra API: `docker-compose -f docker-compose-with-grafana.yaml restart pyrra-api`

--- a/examples/docker-compose/docker-compose-with-grafana.yaml
+++ b/examples/docker-compose/docker-compose-with-grafana.yaml
@@ -1,0 +1,71 @@
+version: "3"
+
+networks:
+  pyrra:
+
+volumes:
+  prometheus_pyrra: {}
+  grafana_data: {}
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.47.0
+    container_name: prometheus
+    restart: always
+    networks:
+      - pyrra
+    ports:
+      - "9090:9090"
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=33d
+      - --web.enable-lifecycle
+    volumes:
+      - ./prometheus/prometheus.yaml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_pyrra:/etc/prometheus/pyrra
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: always
+    networks:
+      - pyrra
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana_data:/var/lib/grafana
+
+  pyrra-api:
+    image: ghcr.io/pyrra-dev/pyrra:v0.7.5
+    container_name: pyrra_api
+    restart: always
+    command:
+      - api
+      - --prometheus-url=http://prometheus:9090
+      # Use Grafana for external links instead of Prometheus
+      # Note: You'll need to configure the datasource in Grafana first and get its UID
+      - --grafana-external-url=http://localhost:3000
+      - --grafana-external-datasource-id=prometheus-uid  # Replace with actual datasource UID
+      - --api-url=http://pyrra-filesystem:9444
+    ports:
+      - "9099:9099"
+    networks:
+      - pyrra
+
+  pyrra-filesystem:
+    image: ghcr.io/pyrra-dev/pyrra:v0.7.5
+    user: root
+    container_name: pyrra_filesystem
+    restart: always
+    command:
+      - filesystem
+      - --prometheus-url=http://prometheus:9090
+    networks:
+      - pyrra
+    volumes:
+      - ./pyrra:/etc/pyrra
+      - prometheus_pyrra:/etc/prometheus/pyrra

--- a/main.go
+++ b/main.go
@@ -57,8 +57,8 @@ var CLI struct {
 		PrometheusURL               *url.URL          `default:"http://localhost:9090" help:"The URL to the Prometheus to query."`
 		PrometheusExternalURL       *url.URL          `help:"The URL for the UI to redirect users to when opening Prometheus. If empty the same as prometheus.url"`
 		GrafanaExternalURL          *url.URL          `help:"The URL for the UI to redirect users to Grafana Explore page"`
-		GrafanaExternalOrgId        string            `default:"1" help:"The Grafana Explore organization id"`
-		GrafanaExternalDatasourceId string            `help:"The Grafana Explore prometheus datasource id"`
+		GrafanaExternalOrgID        string            `default:"1" help:"The Grafana Explore organization id"`
+		GrafanaExternalDatasourceID string            `help:"The Grafana Explore prometheus datasource id"`
 		APIURL                      *url.URL          `name:"api-url" default:"http://localhost:9444" help:"The URL to the API service like a Kubernetes Operator."`
 		RoutePrefix                 string            `default:"" help:"The route prefix Pyrra uses. If run behind a proxy you can change it to something like /pyrra here."`
 		UIRoutePrefix               string            `default:"" help:"The route prefix Pyrra's UI uses. This is helpful for when the prefix is stripped by a proxy but still runs on /pyrra. Defaults to --route-prefix"`
@@ -151,21 +151,21 @@ func main() {
 	level.Info(logger).Log("msg", "using Prometheus", "url", prometheusURL.String())
 
 	// Default external url to prometheus if not defined
-	externalUrl := prometheusURL
+	externalURL := prometheusURL
 	if CLI.API.PrometheusExternalURL != nil && CLI.API.GrafanaExternalURL != nil {
 		level.Error(logger).Log("msg", "prometheus external URL set alongside grafana external url")
 		os.Exit(1)
-	} else if CLI.API.GrafanaExternalURL == nil && CLI.API.GrafanaExternalDatasourceId != "" {
+	} else if CLI.API.GrafanaExternalURL == nil && CLI.API.GrafanaExternalDatasourceID != "" {
 		level.Error(logger).Log("msg", "grafana external datasource id set without grafana external url")
 		os.Exit(1)
 	} else if CLI.API.PrometheusExternalURL != nil {
-		externalUrl = CLI.API.PrometheusExternalURL
+		externalURL = CLI.API.PrometheusExternalURL
 	} else if CLI.API.GrafanaExternalURL != nil {
-		if CLI.API.GrafanaExternalDatasourceId == "" {
+		if CLI.API.GrafanaExternalDatasourceID == "" {
 			level.Error(logger).Log("msg", "grafana external datasource id cannot be empty when using an external grafana url")
 			os.Exit(1)
 		}
-		externalUrl = CLI.API.GrafanaExternalURL
+		externalURL = CLI.API.GrafanaExternalURL
 	}
 
 	// Mimir Client
@@ -200,10 +200,10 @@ func main() {
 			logger,
 			reg,
 			client,
-			externalUrl,
+			externalURL,
 			CLI.API.APIURL,
-			CLI.API.GrafanaExternalOrgId,
-			CLI.API.GrafanaExternalDatasourceId,
+			CLI.API.GrafanaExternalOrgID,
+			CLI.API.GrafanaExternalDatasourceID,
 			CLI.API.RoutePrefix,
 			CLI.API.UIRoutePrefix,
 			CLI.API.TLSCertFile,
@@ -246,8 +246,8 @@ func cmdAPI(
 	logger log.Logger,
 	reg *prometheus.Registry,
 	promClient api.Client,
-	externalUrl, apiURL *url.URL,
-	externalGrafanaOrgId, externalGrafanaDatasourceId string,
+	externalURL, apiURL *url.URL,
+	externalGrafanaOrgID, externalGrafanaDatasourceID string,
 	routePrefix, uiRoutePrefix string,
 	tlsCertFile, tlsPrivateKeyFile string,
 ) int {
@@ -265,11 +265,11 @@ func cmdAPI(
 		uiRoutePrefix = "/" + strings.Trim(uiRoutePrefix, "/")
 	}
 
-	if externalGrafanaDatasourceId == "" {
-		level.Info(logger).Log("msg", "UI redirect to Prometheus", "url", externalUrl.String())
+	if externalGrafanaDatasourceID == "" {
+		level.Info(logger).Log("msg", "UI redirect to Prometheus", "url", externalURL.String())
 	} else {
-		level.Info(logger).Log("msg", "UI redirect to Grafana", "url", externalUrl.String(),
-			"datasourceId", externalGrafanaDatasourceId, "orgId", externalGrafanaOrgId)
+		level.Info(logger).Log("msg", "UI redirect to Grafana", "url", externalURL.String(),
+			"datasourceId", externalGrafanaDatasourceID, "orgId", externalGrafanaOrgID)
 	}
 	level.Info(logger).Log("msg", "using API at", "url", apiURL.String())
 	level.Info(logger).Log("msg", "using route prefix", "prefix", routePrefix)
@@ -360,14 +360,14 @@ func cmdAPI(
 		r.Get("/objectives", func(w http.ResponseWriter, _ *http.Request) {
 			err := tmpl.Execute(w, struct {
 				ExternalURL                 string
-				ExternalGrafanaDatasourceId string
-				ExternalGrafanaOrgId        string
+				ExternalGrafanaDatasourceID string
+				ExternalGrafanaOrgID        string
 				PathPrefix                  string
 				APIBasepath                 string
 			}{
-				ExternalURL:                 externalUrl.String(),
-				ExternalGrafanaDatasourceId: externalGrafanaDatasourceId,
-				ExternalGrafanaOrgId:        externalGrafanaOrgId,
+				ExternalURL:                 externalURL.String(),
+				ExternalGrafanaDatasourceID: externalGrafanaDatasourceID,
+				ExternalGrafanaOrgID:        externalGrafanaOrgID,
 				PathPrefix:                  uiRoutePrefix,
 				APIBasepath:                 uiRoutePrefix,
 			})
@@ -380,14 +380,14 @@ func cmdAPI(
 			if r.URL.Path == "/" || strings.TrimSuffix(r.URL.Path, "/") == routePrefix {
 				err := tmpl.Execute(w, struct {
 					ExternalURL                 string
-					ExternalGrafanaDatasourceId string
-					ExternalGrafanaOrgId        string
+					ExternalGrafanaDatasourceID string
+					ExternalGrafanaOrgID        string
 					PathPrefix                  string
 					APIBasepath                 string
 				}{
-					ExternalURL:                 externalUrl.String(),
-					ExternalGrafanaDatasourceId: externalGrafanaDatasourceId,
-					ExternalGrafanaOrgId:        externalGrafanaOrgId,
+					ExternalURL:                 externalURL.String(),
+					ExternalGrafanaDatasourceID: externalGrafanaDatasourceID,
+					ExternalGrafanaOrgID:        externalGrafanaOrgID,
 					PathPrefix:                  uiRoutePrefix,
 					APIBasepath:                 uiRoutePrefix,
 				})

--- a/main.go
+++ b/main.go
@@ -56,6 +56,9 @@ var CLI struct {
 	API struct {
 		PrometheusURL               *url.URL          `default:"http://localhost:9090" help:"The URL to the Prometheus to query."`
 		PrometheusExternalURL       *url.URL          `help:"The URL for the UI to redirect users to when opening Prometheus. If empty the same as prometheus.url"`
+		GrafanaExternalURL          *url.URL          `help:"The URL for the UI to redirect users to Grafana Explore page"`
+		GrafanaExternalOrgId        string            `default:"1" help:"The Grafana Explore organization id"`
+		GrafanaExternalDatasourceId string            `help:"The Grafana Explore prometheus datasource id"`
 		APIURL                      *url.URL          `name:"api-url" default:"http://localhost:9444" help:"The URL to the API service like a Kubernetes Operator."`
 		RoutePrefix                 string            `default:"" help:"The route prefix Pyrra uses. If run behind a proxy you can change it to something like /pyrra here."`
 		UIRoutePrefix               string            `default:"" help:"The route prefix Pyrra's UI uses. This is helpful for when the prefix is stripped by a proxy but still runs on /pyrra. Defaults to --route-prefix"`
@@ -147,8 +150,22 @@ func main() {
 	client = newThanosClient(client)
 	level.Info(logger).Log("msg", "using Prometheus", "url", prometheusURL.String())
 
-	if CLI.API.PrometheusExternalURL == nil {
-		CLI.API.PrometheusExternalURL = prometheusURL
+	// Default external url to prometheus if not defined
+	externalUrl := prometheusURL
+	if CLI.API.PrometheusExternalURL != nil && CLI.API.GrafanaExternalURL != nil {
+		level.Error(logger).Log("msg", "prometheus external URL set alongside grafana external url")
+		os.Exit(1)
+	} else if CLI.API.GrafanaExternalURL == nil && CLI.API.GrafanaExternalDatasourceId != "" {
+		level.Error(logger).Log("msg", "grafana external datasource id set without grafana external url")
+		os.Exit(1)
+	} else if CLI.API.PrometheusExternalURL != nil {
+		externalUrl = CLI.API.PrometheusExternalURL
+	} else if CLI.API.GrafanaExternalURL != nil {
+		if CLI.API.GrafanaExternalDatasourceId == "" {
+			level.Error(logger).Log("msg", "grafana external datasource id cannot be empty when using an external grafana url")
+			os.Exit(1)
+		}
+		externalUrl = CLI.API.GrafanaExternalURL
 	}
 
 	// Mimir Client
@@ -183,8 +200,10 @@ func main() {
 			logger,
 			reg,
 			client,
-			CLI.API.PrometheusExternalURL,
+			externalUrl,
 			CLI.API.APIURL,
+			CLI.API.GrafanaExternalOrgId,
+			CLI.API.GrafanaExternalDatasourceId,
 			CLI.API.RoutePrefix,
 			CLI.API.UIRoutePrefix,
 			CLI.API.TLSCertFile,
@@ -227,7 +246,8 @@ func cmdAPI(
 	logger log.Logger,
 	reg *prometheus.Registry,
 	promClient api.Client,
-	prometheusExternal, apiURL *url.URL,
+	externalUrl, apiURL *url.URL,
+	externalGrafanaOrgId, externalGrafanaDatasourceId string,
 	routePrefix, uiRoutePrefix string,
 	tlsCertFile, tlsPrivateKeyFile string,
 ) int {
@@ -245,7 +265,12 @@ func cmdAPI(
 		uiRoutePrefix = "/" + strings.Trim(uiRoutePrefix, "/")
 	}
 
-	level.Info(logger).Log("msg", "UI redirect to Prometheus", "url", prometheusExternal.String())
+	if externalGrafanaDatasourceId == "" {
+		level.Info(logger).Log("msg", "UI redirect to Prometheus", "url", externalUrl.String())
+	} else {
+		level.Info(logger).Log("msg", "UI redirect to Grafana", "url", externalUrl.String(),
+			"datasourceId", externalGrafanaDatasourceId, "orgId", externalGrafanaOrgId)
+	}
 	level.Info(logger).Log("msg", "using API at", "url", apiURL.String())
 	level.Info(logger).Log("msg", "using route prefix", "prefix", routePrefix)
 
@@ -334,13 +359,17 @@ func cmdAPI(
 		r.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 		r.Get("/objectives", func(w http.ResponseWriter, _ *http.Request) {
 			err := tmpl.Execute(w, struct {
-				PrometheusURL string
-				PathPrefix    string
-				APIBasepath   string
+				ExternalURL                 string
+				ExternalGrafanaDatasourceId string
+				ExternalGrafanaOrgId        string
+				PathPrefix                  string
+				APIBasepath                 string
 			}{
-				PrometheusURL: prometheusExternal.String(),
-				PathPrefix:    uiRoutePrefix,
-				APIBasepath:   uiRoutePrefix,
+				ExternalURL:                 externalUrl.String(),
+				ExternalGrafanaDatasourceId: externalGrafanaDatasourceId,
+				ExternalGrafanaOrgId:        externalGrafanaOrgId,
+				PathPrefix:                  uiRoutePrefix,
+				APIBasepath:                 uiRoutePrefix,
 			})
 			if err != nil {
 				level.Warn(logger).Log("msg", "failed to populate HTML template", "err", err)
@@ -350,13 +379,17 @@ func cmdAPI(
 			// Trim trailing slash to not care about matching e.g. /pyrra and /pyrra/
 			if r.URL.Path == "/" || strings.TrimSuffix(r.URL.Path, "/") == routePrefix {
 				err := tmpl.Execute(w, struct {
-					PrometheusURL string
-					PathPrefix    string
-					APIBasepath   string
+					ExternalURL                 string
+					ExternalGrafanaDatasourceId string
+					ExternalGrafanaOrgId        string
+					PathPrefix                  string
+					APIBasepath                 string
 				}{
-					PrometheusURL: prometheusExternal.String(),
-					PathPrefix:    uiRoutePrefix,
-					APIBasepath:   uiRoutePrefix,
+					ExternalURL:                 externalUrl.String(),
+					ExternalGrafanaDatasourceId: externalGrafanaDatasourceId,
+					ExternalGrafanaOrgId:        externalGrafanaOrgId,
+					PathPrefix:                  uiRoutePrefix,
+					APIBasepath:                 uiRoutePrefix,
 				})
 				if err != nil {
 					level.Warn(logger).Log("msg", "failed to populate HTML template", "err", err)

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -24,7 +24,9 @@
     <title>Pyrra</title>
     <script>window.PATH_PREFIX = {{.PathPrefix}}</script>
     <script>window.API_BASEPATH = {{.APIBasepath}}</script>
-    <script>window.PROMETHEUS_URL = {{.PrometheusURL}}</script>
+    <script>window.EXTERNAL_URL = {{.ExternalURL}}</script>
+    <script>window.EXTERNAL_GRAFANA_DATASOURCE_ID = {{.ExternalGrafanaDatasourceId}}</script>
+    <script>window.EXTERNAL_GRAFANA_ORG_ID = {{.ExternalGrafanaOrgId}}</script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -25,8 +25,8 @@
     <script>window.PATH_PREFIX = {{.PathPrefix}}</script>
     <script>window.API_BASEPATH = {{.APIBasepath}}</script>
     <script>window.EXTERNAL_URL = {{.ExternalURL}}</script>
-    <script>window.EXTERNAL_GRAFANA_DATASOURCE_ID = {{.ExternalGrafanaDatasourceId}}</script>
-    <script>window.EXTERNAL_GRAFANA_ORG_ID = {{.ExternalGrafanaOrgId}}</script>
+    <script>window.EXTERNAL_GRAFANA_DATASOURCE_ID = {{.ExternalGrafanaDatasourceID}}</script>
+    <script>window.EXTERNAL_GRAFANA_ORG_ID = {{.ExternalGrafanaOrgID}}</script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,7 +16,11 @@ export const PATH_PREFIX: string = window.PATH_PREFIX
 // @ts-expect-error - this is passed from the HTML template.
 export const API_BASEPATH: string = window.API_BASEPATH
 // @ts-expect-error - this is passed from the HTML template.
-export const PROMETHEUS_URL: string = window.PROMETHEUS_URL
+export const EXTERNAL_URL: string = window.EXTERNAL_URL
+// @ts-expect-error - this is passed from the HTML template.
+export const EXTERNAL_GRAFANA_DATASOURCE_ID: string = window.EXTERNAL_GRAFANA_DATASOURCE_ID
+// @ts-expect-error - this is passed from the HTML template.
+export const EXTERNAL_GRAFANA_ORG_ID: string = window.EXTERNAL_GRAFANA_ORG_ID
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/ui/src/components/AlertsTable.tsx
+++ b/ui/src/components/AlertsTable.tsx
@@ -1,6 +1,5 @@
 import {OverlayTrigger, Table, Tooltip as OverlayTooltip} from 'react-bootstrap'
 import React, {useEffect, useState} from 'react'
-import {PROMETHEUS_URL} from '../App'
 import {IconChevron, IconExternal} from './Icons'
 import {Labels, labelsString} from '../labels'
 import {
@@ -18,6 +17,7 @@ import {usePrometheusQueryRange} from '../prometheus'
 import {step} from './graphs/step'
 import {convertAlignedData} from './graphs/aligneddata'
 import {formatDuration} from '../duration'
+import {buildExternalHRef, externalName} from '../external';
 
 interface AlertsTableProps {
   client: PromiseClient<typeof ObjectiveService>
@@ -91,7 +91,7 @@ const AlertsTable = ({
             <th style={{width: '5%'}} />
             <th style={{width: '10%', textAlign: 'left'}}>Long Burn</th>
             <th style={{width: '5%', textAlign: 'right'}}>For</th>
-            <th style={{width: '10%', textAlign: 'left'}}>Prometheus</th>
+            <th style={{width: '10%', textAlign: 'left'}}>{externalName()}</th>
           </tr>
         </thead>
         <tbody>
@@ -199,9 +199,7 @@ const AlertsTable = ({
                       className="external-prometheus"
                       target="_blank"
                       rel="noreferrer"
-                      href={`${PROMETHEUS_URL}/graph?g0.expr=${encodeURIComponent(
-                        a.long?.query ?? '',
-                      )}&g0.tab=0&g1.expr=${encodeURIComponent(a.short?.query ?? '')}&g1.tab=0`}>
+                      href={buildExternalHRef([a.long?.query ?? '', a.short?.query ?? ''], from, to)}>
                       <IconExternal height={20} width={20} />
                     </a>
                     {showBurnrate[i]}

--- a/ui/src/components/graphs/DurationGraph.tsx
+++ b/ui/src/components/graphs/DurationGraph.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useLayoutEffect, useRef, useState} from 'react'
 import {Spinner} from 'react-bootstrap'
 import UplotReact from 'uplot-react'
 import uPlot, {AlignedData} from 'uplot'
-import {PROMETHEUS_URL} from '../../App'
+import {EXTERNAL_URL} from '../../App'
 import {IconExternal} from '../Icons'
 import {Labels, labelsString, parseLabelValue} from '../../labels'
 import {colorful, greys} from './colors'
@@ -17,6 +17,7 @@ import {
 } from '../../proto/objectives/v1alpha1/objectives_pb'
 import {selectTimeRange} from './selectTimeRange'
 import {formatDuration} from '../../duration'
+import {buildExternalHRef, externalName} from '../../external'
 
 interface DurationGraphProps {
   client: PromiseClient<typeof ObjectiveService>
@@ -107,15 +108,6 @@ const DurationGraph = ({
       })
   }, [client, labels, grouping, from, to, latency])
 
-  const prometheusURLQuery = durationQueries.map(
-    (query: string, index: number) =>
-      `g${index}.expr=${encodeURIComponent(query)}&g${index}.range_input=${formatDuration(
-        to - from,
-      )}&g${index}.tab=0`,
-  )
-
-  const prometheusURL = `${PROMETHEUS_URL}/graph?${prometheusURLQuery.join('&')}`
-
   return (
     <>
       <div style={{display: 'flex', alignItems: 'baseline', justifyContent: 'space-between'}}>
@@ -137,9 +129,9 @@ const DurationGraph = ({
           )}
         </h4>
         {durationQueries.length > 0 ? (
-          <a className="external-prometheus" target="_blank" rel="noreferrer" href={prometheusURL}>
+          <a className="external-prometheus" target="_blank" rel="noreferrer" href={buildExternalHRef(durationQueries, from, to)}>
             <IconExternal height={20} width={20} />
-            Prometheus
+            {externalName()}
           </a>
         ) : (
           <></>

--- a/ui/src/components/graphs/ErrorBudgetGraph.tsx
+++ b/ui/src/components/graphs/ErrorBudgetGraph.tsx
@@ -3,7 +3,6 @@ import {Spinner} from 'react-bootstrap'
 import UplotReact from 'uplot-react'
 import uPlot, {AlignedData} from 'uplot'
 
-import {PROMETHEUS_URL} from '../../App'
 import {IconExternal} from '../Icons'
 import {greens, reds} from './colors'
 import {seriesGaps} from './gaps'
@@ -12,7 +11,7 @@ import {PrometheusService} from '../../proto/prometheus/v1/prometheus_connect'
 import {usePrometheusQueryRange} from '../../prometheus'
 import {SamplePair, SampleStream} from '../../proto/prometheus/v1/prometheus_pb'
 import {selectTimeRange} from './selectTimeRange'
-import {formatDuration} from '../../duration'
+import {buildExternalHRef, externalName} from '../../external'
 
 interface ErrorBudgetGraphProps {
   client: PromiseClient<typeof PrometheusService>
@@ -146,11 +145,9 @@ const ErrorBudgetGraph = ({
             className="external-prometheus"
             target="_blank"
             rel="noreferrer"
-            href={`${PROMETHEUS_URL}/graph?g0.expr=${encodeURIComponent(
-              query,
-            )}&g0.range_input=${formatDuration(to - from)}&g0.tab=0`}>
+            href={buildExternalHRef([query], from, to)}>
             <IconExternal height={20} width={20} />
-            Prometheus
+            {externalName()}
           </a>
         ) : (
           <></>

--- a/ui/src/components/graphs/ErrorsGraph.tsx
+++ b/ui/src/components/graphs/ErrorsGraph.tsx
@@ -2,7 +2,7 @@ import React, {useLayoutEffect, useRef, useState} from 'react'
 import {Spinner} from 'react-bootstrap'
 import UplotReact from 'uplot-react'
 import uPlot from 'uplot'
-import {ObjectiveType, PROMETHEUS_URL} from '../../App'
+import {ObjectiveType} from '../../App'
 import {IconExternal} from '../Icons'
 import {reds} from './colors'
 import {seriesGaps} from './gaps'
@@ -13,7 +13,7 @@ import {step} from './step'
 import {convertAlignedData} from './aligneddata'
 import {selectTimeRange} from './selectTimeRange'
 import {Labels, labelValues} from '../../labels'
-import {formatDuration} from '../../duration'
+import {buildExternalHRef, externalName} from '../../external';
 
 interface ErrorsGraphProps {
   client: PromiseClient<typeof PrometheusService>
@@ -123,11 +123,9 @@ const ErrorsGraph = ({
           className="external-prometheus"
           target="_blank"
           rel="noreferrer"
-          href={`${PROMETHEUS_URL}/graph?g0.expr=${encodeURIComponent(
-            query,
-          )}&g0.range_input=${formatDuration(to - from)}&g0.tab=0`}>
+          href={buildExternalHRef([query], from, to)}>
           <IconExternal height={20} width={20} />
-          Prometheus
+          {externalName()}
         </a>
       </div>
       <div>

--- a/ui/src/components/graphs/RequestsGraph.tsx
+++ b/ui/src/components/graphs/RequestsGraph.tsx
@@ -2,7 +2,7 @@ import React, {useLayoutEffect, useRef, useState} from 'react'
 import {Spinner} from 'react-bootstrap'
 import UplotReact from 'uplot-react'
 import uPlot from 'uplot'
-import {ObjectiveType, PROMETHEUS_URL} from '../../App'
+import {ObjectiveType} from '../../App'
 import {IconExternal} from '../Icons'
 import {blues, greens, reds, yellows} from './colors'
 import {seriesGaps} from './gaps'
@@ -13,7 +13,7 @@ import {step} from './step'
 import {convertAlignedData} from './aligneddata'
 import {selectTimeRange} from './selectTimeRange'
 import {Labels, labelValues} from '../../labels'
-import {formatDuration} from '../../duration'
+import {buildExternalHRef, externalName} from '../../external';
 
 interface RequestsGraphProps {
   client: PromiseClient<typeof PrometheusService>
@@ -113,11 +113,9 @@ const RequestsGraph = ({
           className="external-prometheus"
           target="_blank"
           rel="noreferrer"
-          href={`${PROMETHEUS_URL}/graph?g0.expr=${encodeURIComponent(
-            query,
-          )}&g0.range_input=${formatDuration(to - from)}&g0.tab=0`}>
+          href={buildExternalHRef([query], from, to)}>
           <IconExternal height={20} width={20} />
-          Prometheus
+          {externalName()}
         </a>
       </div>
       <div>

--- a/ui/src/external.tsx
+++ b/ui/src/external.tsx
@@ -1,0 +1,46 @@
+import {EXTERNAL_GRAFANA_DATASOURCE_ID, EXTERNAL_GRAFANA_ORG_ID, EXTERNAL_URL} from './App'
+import {formatDuration} from './duration';
+
+export const buildExternalHRef = (
+  queries: string[],
+  from: number,
+  to: number
+): string => {
+  const rangeDuration = formatDuration(to - from)
+  if (EXTERNAL_GRAFANA_DATASOURCE_ID !== "") {
+    const panes = {
+      "A": {
+        queries: queries.map((query, i) => {
+          return {
+            refId: `Q${i}`,
+            datasource: {
+              type: "prometheus",
+              uid: EXTERNAL_GRAFANA_DATASOURCE_ID
+            },
+            expr: query
+          }
+        }),
+        range: {
+          from: `now-${rangeDuration}`,
+          to: "now"
+        }
+      }
+    }
+    const encodedQuery = encodeURIComponent(JSON.stringify(panes));
+    return `${EXTERNAL_URL}/explore?schemaVersion=1&panes=${encodedQuery}&orgId=${EXTERNAL_GRAFANA_ORG_ID}`
+  } else {
+    const queryParams = queries.map((query, i) => {
+      const encodedQuery = encodeURIComponent(query);
+      return `g${i}.expr=${encodedQuery}&g${i}.range_input=${rangeDuration}&g${i}.tab=0`;
+    }).join("&");
+    return `${EXTERNAL_URL}/graph?${queryParams}`
+  }
+}
+
+export const externalName = () => {
+  if (EXTERNAL_GRAFANA_DATASOURCE_ID !== "") {
+    return "Grafana"
+  } else {
+    return "Prometheus"
+  }
+}


### PR DESCRIPTION
Issue: https://github.com/pyrra-dev/pyrra/issues/768

Support Grafana Explore integration in the UI by setting:
- `--grafana-external-url`: Grafana url
- `--grafana-external-datasource-id`: Prometheus datasource id to use in the Explore page
- `--grafana-external-org-id`: Grafana organization id (defaults to 1)

I added a `grafana-external-url` option instead of re-using the `prometheus-external-url` to make it explicit that we're using Grafana and changing this parameter to something more _general_ lile `external-url` wouldn't be backward compatible. This way there's no breaking change.

It uses the Explore URL format (as shown [here](https://grafana.com/docs/grafana/v12.0/explore/get-started-with-explore/#generate-explore-urls-from-external-tools)) and tested with Grafana versions 10, 11 and 12.