### PR TITLE
Support empty histogram series

### DIFF
--- a/slo/promql.go
+++ b/slo/promql.go
@@ -714,7 +714,7 @@ func (o Objective) ErrorsRange(timerange time.Duration) string {
 
 		return expr.String()
 	case LatencyNative:
-		expr, err := parser.ParseExpr(`1 - sum(histogram_fraction(0,0.696969, rate(metric{matchers="total"}[1s])))`)
+		expr, err := parser.ParseExpr(`1 - histogram_fraction(0,0.696969, sum(rate(metric{matchers="total"}[1s])))`)
 		if err != nil {
 			return err.Error()
 		}

--- a/slo/promql_test.go
+++ b/slo/promql_test.go
@@ -842,7 +842,7 @@ func TestObjective_ErrorsRange(t *testing.T) {
 		name:      "http-latency-native",
 		objective: objectiveHTTPNativeLatency(),
 		timerange: time.Hour,
-		expected:  `1 - sum(histogram_fraction(0, 1, rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[1h])))`,
+		expected:  `1 - histogram_fraction(0, 1, sum(rate(http_request_duration_seconds{code=~"2..",job="metrics-service-thanos-receive-default"}[1h])))`,
 	}, {
 		name:      "http-latency-grouping",
 		objective: objectiveHTTPLatencyGrouping(),


### PR DESCRIPTION
A histogram can be created with no data in (for example, an application might have a 5xx series with no data in, so that increases can be caluclated). Using `histogram_fraction` against series that contains NaN results in NaN, even if other series exist. However, if we sum before histogram_fraction, then the NaNs are essentially ignored.