### PR TITLE
fix: display error message for invalid SLOs with window=0s

### DIFF
--- a/ui/src/pages/List.tsx
+++ b/ui/src/pages/List.tsx
@@ -282,7 +282,11 @@ const columns = [
     id: 'window',
     header: 'Window',
     cell: (props) => {
-      return formatDuration(Number(props.getValue()?.seconds) * 1000)
+      const window = props.getValue()
+      if (Number(window?.seconds) === 0) {
+        return <span className="text-danger">Error: Invalid SLO configuration</span>
+      }
+      return formatDuration(Number(window?.seconds) * 1000)
     },
     sortingFn: (a, b, column): number => {
       const av: Duration = a.getValue(column)
@@ -791,6 +795,11 @@ const List = () => {
                   <tr
                     key={row.id}
                     onClick={() => {
+                      const window: Duration | undefined = row.getValue('window')
+                      if (Number(window?.seconds) === 0) {
+                        // Don't navigate for invalid SLOs
+                        return
+                      }
                       const labels: {lset: Labels; grouping: Labels} = row.getValue('lset')
                       navigate(objectivePage(labels.lset, labels.grouping))
                     }}


### PR DESCRIPTION
## Summary

This PR fixes the display of invalid SLOs in the List view. When the filesystem component encounters an error for an SLO configuration, it returns `{window: "0s", queries: {}}`. Previously, this would display an almost empty row in the table.

![error](https://github.com/user-attachments/assets/684685cd-afac-4b5e-8cf2-3c87c0f2ad2a)

## Changes

- Added error detection in the List component to check for `window.seconds === 0`
- Display "Error: Invalid SLO configuration" in red text when this condition is detected
- Disabled row click navigation for invalid SLOs to prevent navigating to a broken detail page

## Test Plan

1. Create an invalid SLO configuration that causes the filesystem component to return an error
2. View the objectives list page
3. Verify that the invalid SLO shows "Error: Invalid SLO configuration" in the Window column
4. Verify that clicking on the invalid SLO row does not navigate to the detail page