### PR TITLE
feat: support querying data from multiple Mimir tenants

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ var CLI struct {
 		TLSCertFile                 string            `default:"" help:"File containing the default x509 Certificate for HTTPS."`
 		TLSPrivateKeyFile           string            `default:"" help:"File containing the default x509 private key matching --tls-cert-file."`
 		TLSClientCAFile             string            `default:"" help:"File containing the CA certificate for the client"`
+		MimirTenantIds              []string          `default:"" help:"Mimir tenant IDs to query if multi-tenancy is enabled."`
 	} `cmd:"" help:"Runs Pyrra's API and UI."`
 	Filesystem struct {
 		ConfigFiles      string   `default:"/etc/pyrra/*.yaml" help:"The folder where Pyrra finds the config files to use. Any non yaml files will be ignored."`
@@ -130,6 +131,16 @@ func main() {
 	}
 	if CLI.API.TLSClientCAFile != "" {
 		clientConfig.TLSConfig = promconfig.TLSConfig{CAFile: CLI.API.TLSClientCAFile}
+	}
+	if len(CLI.API.MimirTenantIds) > 0 {
+		mimirHeaderValue := strings.Join(CLI.API.MimirTenantIds, "|")
+		clientConfig.HTTPHeaders = &promconfig.Headers{
+			Headers: map[string]promconfig.Header{
+				"X-Scope-OrgID": {
+					Values: []string{mimirHeaderValue},
+				},
+			},
+		}
 	}
 
 	roundTripper, err := promconfig.NewRoundTripperFromConfig(clientConfig, "prometheus")

--- a/main.go
+++ b/main.go
@@ -132,8 +132,8 @@ func main() {
 	if CLI.API.TLSClientCAFile != "" {
 		clientConfig.TLSConfig = promconfig.TLSConfig{CAFile: CLI.API.TLSClientCAFile}
 	}
-	if len(CLI.API.MimirTenantIds) > 0 {
-		mimirHeaderValue := strings.Join(CLI.API.MimirTenantIds, "|")
+	if len(CLI.API.MimirTenantIDs) > 0 {
+		mimirHeaderValue := strings.Join(CLI.API.MimirTenantIDs, "|")
 		clientConfig.HTTPHeaders = &promconfig.Headers{
 			Headers: map[string]promconfig.Header{
 				"X-Scope-OrgID": {

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ var CLI struct {
 		TLSCertFile                 string            `default:"" help:"File containing the default x509 Certificate for HTTPS."`
 		TLSPrivateKeyFile           string            `default:"" help:"File containing the default x509 private key matching --tls-cert-file."`
 		TLSClientCAFile             string            `default:"" help:"File containing the CA certificate for the client"`
-		MimirTenantIds              []string          `default:"" help:"Mimir tenant IDs to query if multi-tenancy is enabled."`
+		MimirTenantIDs              []string          `default:"" help:"Mimir tenant IDs to query if multi-tenancy is enabled."`
 	} `cmd:"" help:"Runs Pyrra's API and UI."`
 	Filesystem struct {
 		ConfigFiles      string   `default:"/etc/pyrra/*.yaml" help:"The folder where Pyrra finds the config files to use. Any non yaml files will be ignored."`


### PR DESCRIPTION
I want to add support for multi-tenant Mimir in the read path. The goal is to be able to have a single Pyrra instance query SLOs from multiple tenants in a Mimir instance. This does not include generating rules and pushing them to the Mimir tenants as that would involve adding multi-tenancy support to Pyrra itself.

The use case for this is running Pyrra in a CI pipeline generating the rule files and pushing the rules through the Mimir CLI. These rules get pushed to different tenants, but then the Pyrra UI should be able to query the SLO for all the tenants. This is achieved by providing multiple tenants in the `X-Scope-OrgID` header. A single tenant can also be set through this flag.

The Mimir [documentation](https://grafana.com/docs/mimir/latest/manage/secure/authentication-and-authorization/#grafana-mimir-authentication-and-authorization) should cover more detail on multi-tenant queries.

Here is a diagram showing our approach to bridging the gap between the lack of multi-tenancy in Pyrra and our multi-tenant Mimir setup:

![image](https://github.com/user-attachments/assets/b1ad9a75-54b7-450a-b074-6be7f1b5996f)