### PR TITLE
Pass SLO annotations to ConfigMap 

### DIFF
--- a/kubernetes/controllers/servicelevelobjective.go
+++ b/kubernetes/controllers/servicelevelobjective.go
@@ -169,7 +169,6 @@ func (r *ServiceLevelObjectiveReconciler) reconcileConfigMap(
 	req ctrl.Request,
 	kubeObjective pyrrav1alpha1.ServiceLevelObjective,
 ) (ctrl.Result, error) {
-	// TODO: make configurable
 	name := fmt.Sprintf("pyrra-recording-rule-%s", kubeObjective.GetName())
 
 	newConfigMap, err := makeConfigMap(name, kubeObjective, r.GenericRules)


### PR DESCRIPTION
When in ConfigMap mode (`--config-map-mode`) we need to pass annotations to the created ConfigMaps.
Just like with Labels, the easiest way is to pass the annotations down to the ConfigMap as well.

This PR introduces that: To just pass the annotation map down to the created configmap in the slo controller.

Note: I didn't add a test for this. If you prefer to have a test, just let me know 😃 