### PR TITLE
README: update link to PrometheusRule page

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ operator. For the first deployment, start the binary with the `api` argument.
 
 When starting the binary with the `kubernetes` argument, the service will watch
 the apiserver for `ServiceLevelObjectives`. Once a new SLO is picked up,
-Pyrra will create [PrometheusRule](https://prometheus-operator.dev/docs/operator/design/#prometheusrule)
+Pyrra will create [PrometheusRule](https://prometheus-operator.dev/docs/developer/alerting/#deploying-prometheus-rules)
 objects that are automatically picked up by the [Prometheus Operator](https://prometheus-operator.dev).
 
 If you're unable to run the Prometheus Operator inside your cluster, you can add


### PR DESCRIPTION
The old link was pointing at https://prometheus-operator.dev/docs/operator/design/#prometheusrule , which is now a 404. The legacy URL seems to be shown at https://web.archive.org/web/20240207130911/https://prometheus-operator.dev/docs/operator/design/#prometheusrule . Although https://prometheus-operator.dev/docs/getting-started/design/#prometheusrule could be the new target link, it feels like https://prometheus-operator.dev/docs/developer/alerting/?#deploying-prometheus-rules is maybe a little more descriptive with more pointers.