### PR TITLE
feat: Add Mimir tenant capabilities

### DIFF
--- a/mimir/client.go
+++ b/mimir/client.go
@@ -13,6 +13,8 @@ type Client struct {
 	client           http.Client
 	address          *url.URL
 	prometheusPrefix string
+	orgID            string
+	deploymentMode   string
 }
 
 // Config is used to configure the client.
@@ -21,6 +23,8 @@ type Config struct {
 	PrometheusPrefix  string
 	BasicAuthUsername string
 	BasicAuthPassword string
+	OrgID             string
+	DeploymentMode    string
 }
 
 // NewClient creates a new client with the given configuration.
@@ -48,6 +52,8 @@ func NewClient(config Config) (*Client, error) {
 		client:           httpClient,
 		address:          addr,
 		prometheusPrefix: config.PrometheusPrefix,
+		orgID:            config.OrgID,
+		deploymentMode:   config.DeploymentMode,
 	}, nil
 }
 
@@ -66,11 +72,21 @@ func (t *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 
 // Ready checks if mimir is ready to serve traffic.
 func (c *Client) Ready(ctx context.Context) error {
-	path := c.address.JoinPath("/ready")
+	path := c.address.JoinPath("/")
+
+	if c.deploymentMode == "distributed" {
+		path = c.address.JoinPath("/api/v1/status/buildinfo")
+	} else {
+		path = c.address.JoinPath("/ready")
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path.String(), nil)
 	if err != nil {
 		return err
+	}
+
+	if c.orgID != "" {
+		req.Header.Set("X-Scope-OrgID", c.orgID)
 	}
 
 	resp, err := c.client.Do(req)

--- a/mimir/rulegroup.go
+++ b/mimir/rulegroup.go
@@ -27,6 +27,10 @@ func (c *Client) SetRuleGroup(ctx context.Context, namespace string, ruleGroup r
 
 	req.Header.Set("Content-Type", "application/yaml")
 
+	if c.orgID != "" {
+		req.Header.Set("X-Scope-OrgID", c.orgID)
+	}
+
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return err
@@ -47,6 +51,10 @@ func (c *Client) DeleteNamespace(ctx context.Context, namespace string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, path.String(), nil)
 	if err != nil {
 		return err
+	}
+
+	if c.orgID != "" {
+		req.Header.Set("X-Scope-OrgID", c.orgID)
 	}
 
 	resp, err := c.client.Do(req)


### PR DESCRIPTION
Hello @metalmatze :) ! 

I saw this ["abandoned" PRs](https://github.com/pyrra-dev/pyrra/pull/1290) but the need is still alive, so I cleaned it a bit and try to merge it

Here I am adding tenant capabilities for G.Mimir in both places (Kubernetes and API). Could you please review and merge it if you find it useful?

I deleted the slice of tenant IDs in API calls because I am not sure if this is useful enough, as most of the times, SLXs are stored in a tenant: separated from the rest of the metrics or common to them) so what is the need for querying several tenants at the same time?

The idea is to solve #1289
