### PR TITLE
fix: exclude regex matchers from burnrate queries

### DIFF
--- a/slo/promql.go
+++ b/slo/promql.go
@@ -436,42 +436,79 @@ func (o Objective) QueryErrorBudget() string {
 func (o Objective) QueryBurnrate(timerange time.Duration, groupingMatchers []*labels.Matcher) (string, error) {
 	metric := ""
 	matchers := map[string]*labels.Matcher{}
+	var groupingMap map[string]struct{}
 
 	switch o.IndicatorType() {
 	case Ratio:
 		metric = o.BurnrateName(timerange)
+		groupingMap = map[string]struct{}{}
+		for _, g := range o.Indicator.Ratio.Grouping {
+			groupingMap[g] = struct{}{}
+		}
+		// Only include MatchEqual labels that aren't in the grouping, matching the recording rule labels
 		for _, m := range o.Indicator.Ratio.Total.LabelMatchers {
-			matchers[m.Name] = &labels.Matcher{ // Copy labels by value to avoid race
-				Type:  m.Type,
-				Name:  m.Name,
-				Value: m.Value,
+			if m.Type == labels.MatchEqual && m.Name != labels.MetricName {
+				if _, ok := groupingMap[m.Name]; !ok {
+					matchers[m.Name] = &labels.Matcher{ // Copy labels by value to avoid race
+						Type:  m.Type,
+						Name:  m.Name,
+						Value: m.Value,
+					}
+				}
 			}
 		}
 	case Latency:
 		metric = o.BurnrateName(timerange)
+		groupingMap = map[string]struct{}{}
+		for _, g := range o.Indicator.Latency.Grouping {
+			groupingMap[g] = struct{}{}
+		}
+		// Only include MatchEqual labels that aren't in the grouping, matching the recording rule labels
 		for _, m := range o.Indicator.Latency.Total.LabelMatchers {
-			matchers[m.Name] = &labels.Matcher{ // Copy labels by value to avoid race
-				Type:  m.Type,
-				Name:  m.Name,
-				Value: m.Value,
+			if m.Type == labels.MatchEqual && m.Name != labels.MetricName {
+				if _, ok := groupingMap[m.Name]; !ok {
+					matchers[m.Name] = &labels.Matcher{ // Copy labels by value to avoid race
+						Type:  m.Type,
+						Name:  m.Name,
+						Value: m.Value,
+					}
+				}
 			}
 		}
 	case LatencyNative:
 		metric = o.BurnrateName(timerange)
+		groupingMap = map[string]struct{}{}
+		for _, g := range o.Indicator.LatencyNative.Grouping {
+			groupingMap[g] = struct{}{}
+		}
+		// Only include MatchEqual labels that aren't in the grouping, matching the recording rule labels
 		for _, m := range o.Indicator.LatencyNative.Total.LabelMatchers {
-			matchers[m.Name] = &labels.Matcher{
-				Type:  m.Type,
-				Name:  m.Name,
-				Value: m.Value,
+			if m.Type == labels.MatchEqual && m.Name != labels.MetricName {
+				if _, ok := groupingMap[m.Name]; !ok {
+					matchers[m.Name] = &labels.Matcher{
+						Type:  m.Type,
+						Name:  m.Name,
+						Value: m.Value,
+					}
+				}
 			}
 		}
 	case BoolGauge:
 		metric = o.BurnrateName(timerange)
+		groupingMap = map[string]struct{}{}
+		for _, g := range o.Indicator.BoolGauge.Grouping {
+			groupingMap[g] = struct{}{}
+		}
+		// Only include MatchEqual labels that aren't in the grouping, matching the recording rule labels
 		for _, m := range o.Indicator.BoolGauge.LabelMatchers {
-			matchers[m.Name] = &labels.Matcher{ // Copy labels by value to avoid race
-				Type:  m.Type,
-				Name:  m.Name,
-				Value: m.Value,
+			if m.Type == labels.MatchEqual && m.Name != labels.MetricName {
+				if _, ok := groupingMap[m.Name]; !ok {
+					matchers[m.Name] = &labels.Matcher{ // Copy labels by value to avoid race
+						Type:  m.Type,
+						Name:  m.Name,
+						Value: m.Value,
+					}
+				}
 			}
 		}
 	}

--- a/slo/promql_test.go
+++ b/slo/promql_test.go
@@ -614,14 +614,14 @@ func TestObjective_QueryBurnrate(t *testing.T) {
 		grouping: []*labels.Matcher{
 			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
 		},
-		expected: `http_requests:burnrate5m{handler="/api/v1/query",job="thanos-receive-default",slo="monitoring-http-errors"}`,
+		expected: `http_requests:burnrate5m{handler="/api/v1/query",slo="monitoring-http-errors"}`,
 	}, {
 		name:      "http-ratio-grouping-regex",
 		objective: objectiveHTTPRatioGroupingRegex(),
 		grouping: []*labels.Matcher{
 			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
 		},
-		expected: `http_requests:burnrate5m{handler="/api/v1/query",job="thanos-receive-default",slo="monitoring-http-errors"}`,
+		expected: `http_requests:burnrate5m{handler="/api/v1/query",slo="monitoring-http-errors"}`,
 	}, {
 		name:      "grpc-ratio",
 		objective: objectiveGRPCRatio(),
@@ -632,29 +632,29 @@ func TestObjective_QueryBurnrate(t *testing.T) {
 		grouping: []*labels.Matcher{
 			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
 		},
-		expected: `grpc_server_handled:burnrate5m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",handler="/api/v1/query",job="api",slo="monitoring-grpc-errors"}`,
+		expected: `grpc_server_handled:burnrate5m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",handler="/api/v1/query",slo="monitoring-grpc-errors"}`,
 	}, {
 		name:      "http-latency",
 		objective: objectiveHTTPLatency(),
-		expected:  `http_request_duration_seconds:burnrate5m{code=~"2..",job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"}`,
+		expected:  `http_request_duration_seconds:burnrate5m{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"}`,
 	}, {
 		name:      "http-latency-native",
 		objective: objectiveHTTPNativeLatency(),
-		expected:  `http_request_duration_seconds:burnrate5m{code=~"2..",job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"}`,
+		expected:  `http_request_duration_seconds:burnrate5m{job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"}`,
 	}, {
 		name:      "http-latency-grouping",
 		objective: objectiveHTTPLatencyGrouping(),
 		grouping: []*labels.Matcher{
 			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
 		},
-		expected: `http_request_duration_seconds:burnrate5m{code=~"2..",handler="/api/v1/query",job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"}`,
+		expected: `http_request_duration_seconds:burnrate5m{handler="/api/v1/query",slo="monitoring-http-latency"}`,
 	}, {
 		name:      "http-latency-grouping-regex",
 		objective: objectiveHTTPLatencyGroupingRegex(),
 		grouping: []*labels.Matcher{
 			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
 		},
-		expected: `http_request_duration_seconds:burnrate5m{code=~"2..",handler="/api/v1/query",job="metrics-service-thanos-receive-default",slo="monitoring-http-latency"}`,
+		expected: `http_request_duration_seconds:burnrate5m{handler="/api/v1/query",slo="monitoring-http-latency"}`,
 	}, {
 		name:      "grpc-latency",
 		objective: objectiveGRPCLatency(),
@@ -665,7 +665,7 @@ func TestObjective_QueryBurnrate(t *testing.T) {
 		grouping: []*labels.Matcher{
 			{Type: labels.MatchEqual, Name: "handler", Value: "/api/v1/query"},
 		},
-		expected: `grpc_server_handling_seconds:burnrate5m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",handler="/api/v1/query",job="api",slo="monitoring-grpc-latency"}`,
+		expected: `grpc_server_handling_seconds:burnrate5m{grpc_method="Write",grpc_service="conprof.WritableProfileStore",handler="/api/v1/query",slo="monitoring-grpc-latency"}`,
 	}, {
 		name:      "operator-ratio",
 		objective: objectiveOperator(),
@@ -680,11 +680,11 @@ func TestObjective_QueryBurnrate(t *testing.T) {
 	}, {
 		name:      "apiserver-write-response-errors",
 		objective: objectiveAPIServerRatio(),
-		expected:  `apiserver_request:burnrate5m{job="apiserver",slo="apiserver-write-response-errors",verb=~"POST|PUT|PATCH|DELETE"}`,
+		expected:  `apiserver_request:burnrate5m{job="apiserver",slo="apiserver-write-response-errors"}`,
 	}, {
 		name:      "apiserver-read-resource-latency",
 		objective: objectiveAPIServerRatio(),
-		expected:  `apiserver_request:burnrate5m{job="apiserver",slo="apiserver-write-response-errors",verb=~"POST|PUT|PATCH|DELETE"}`,
+		expected:  `apiserver_request:burnrate5m{job="apiserver",slo="apiserver-write-response-errors"}`,
 	}, {
 		name:      "up-targets",
 		objective: objectiveUpTargets(),
@@ -692,7 +692,7 @@ func TestObjective_QueryBurnrate(t *testing.T) {
 	}, {
 		name:      "up-targets",
 		objective: objectiveUpTargetsGroupingRegex(),
-		expected:  `up:burnrate5m{instance!~"(127.0.0.1|localhost).*",slo="up-targets"}`,
+		expected:  `up:burnrate5m{slo="up-targets"}`,
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #1506

The QueryBurnrate function was including all label matchers from the original metrics, including regex matchers (e.g., status=~"2xx"). However, recording rules only include MatchEqual labels (excluding grouped labels), causing burnrate queries to fail with NaN values.

This fix ensures QueryBurnrate only includes:
- MatchEqual type labels (not MatchRegexp/MatchNotRegexp)
- Labels that are NOT in the grouping configuration
- Plus the 'slo' label

Changes:
- slo/promql.go: Filter matchers to only include MatchEqual labels that aren't grouped, matching the recording rule label structure
- slo/promql_test.go: Updated test expectations to reflect correct behavior where regex matchers are excluded from queries

All tests pass: TestObjective_QueryBurnrate (17/17) and TestObjective_Burnrates (21/21).