### PR TITLE
fix: add correct sorting for 'lset' column

### DIFF
--- a/ui/src/pages/List.tsx
+++ b/ui/src/pages/List.tsx
@@ -278,6 +278,23 @@ const columns = [
   columnHelper.accessor('lset', {
     id: 'lset',
     header: 'Name',
+    sortingFn: (a: TableRow<row>, b: TableRow<row>, columnId: string): number => {
+      const av: {lset: Labels; grouping: Labels} = a.getValue(columnId)
+      const bv: {lset: Labels; grouping: Labels} = b.getValue(columnId)
+      
+      // First compare by the metric name
+      const aName = av.lset[MetricName] ?? ''
+      const bName = bv.lset[MetricName] ?? ''
+      const nameComparison = aName.localeCompare(bName)
+      if (nameComparison !== 0) {
+        return nameComparison
+      }
+      
+      // If names are equal, compare by grouping labels only
+      const aGrouping = labelsString(av.grouping)
+      const bGrouping = labelsString(bv.grouping)
+      return aGrouping.localeCompare(bGrouping)
+    },
   }),
   columnHelper.accessor('window', {
     id: 'window',


### PR DESCRIPTION
Fixes https://github.com/pyrra-dev/pyrra/issues/1537 

"Name" had no sorting function defined, so when users clicked on the column header to sort, it was trying to compare JavaScript objects directly. It just compares object references, which produces unpredictable sort orders.