### PR TITLE
Fix encoding/decoding error in Pyrra UI

### DIFF
--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -122,7 +122,7 @@ const Detail = () => {
         toStr = 'now'
       }
       navigate(
-        `/objectives?expr=${expr}&grouping=${groupingExpr ?? ''}&from=${fromStr}&to=${toStr}`,
+        `/objectives?expr=${encodeURI(expr)}&grouping=${encodeURI(groupingExpr ?? '')}&from=${fromStr}&to=${toStr}`,
       )
     },
     [navigate, expr, groupingExpr],


### PR DESCRIPTION
When SLO labels contained special characters like `+` (e.g., in regex patterns like `[0-9]+`), the auto-refresh functionality caused repeated URL encoding issues, which broke the display of metrics.

The updateTimeRange callback was constructing URLs without encoding the expr and groupingExpr parameters, resulting in inconsistent encoding by the browser on each auto-refresh cycle.

This fix applies encodeURI() to both expr and groupingExpr parameters, matching the pattern used elsewhere in the codebase (List.tsx).

Fixes #1621