### PR TITLE
fix: restore ExternalURL field for /objectives handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -411,16 +411,17 @@ func cmdAPI(
 		}
 
 		r.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-		r.Get("/objectives", func(w http.ResponseWriter, _ *http.Request) {
+
+		renderIndex := func(w http.ResponseWriter) {
 			err := tmpl.Execute(w, struct {
-				ExternalDatasourceURL       string
+				ExternalURL                 string
 				ExternalGrafanaDatasourceID string
 				ExternalGrafanaOrgID        string
 				PathPrefix                  string
 				APIBasepath                 string
 				Version                     string
 			}{
-				ExternalDatasourceURL:       externalDatasourceURL.String(),
+				ExternalURL:                 externalDatasourceURL.String(),
 				ExternalGrafanaDatasourceID: externalGrafanaDatasourceID,
 				ExternalGrafanaOrgID:        externalGrafanaOrgID,
 				PathPrefix:                  uiRoutePrefix,
@@ -430,28 +431,15 @@ func cmdAPI(
 			if err != nil {
 				level.Warn(logger).Log("msg", "failed to populate HTML template", "err", err)
 			}
+		}
+
+		r.Get("/objectives", func(w http.ResponseWriter, _ *http.Request) {
+			renderIndex(w)
 		})
 		r.Handle("/*", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Trim trailing slash to not care about matching e.g. /pyrra and /pyrra/
 			if r.URL.Path == "/" || strings.TrimSuffix(r.URL.Path, "/") == routePrefix {
-				err := tmpl.Execute(w, struct {
-					ExternalURL                 string
-					ExternalGrafanaDatasourceID string
-					ExternalGrafanaOrgID        string
-					PathPrefix                  string
-					APIBasepath                 string
-					Version                     string
-				}{
-					ExternalURL:                 externalDatasourceURL.String(),
-					ExternalGrafanaDatasourceID: externalGrafanaDatasourceID,
-					ExternalGrafanaOrgID:        externalGrafanaOrgID,
-					PathPrefix:                  uiRoutePrefix,
-					APIBasepath:                 uiRoutePrefix,
-					Version:                     version,
-				})
-				if err != nil {
-					level.Warn(logger).Log("msg", "failed to populate HTML template", "err", err)
-				}
+				renderIndex(w)
 				return
 			}
 


### PR DESCRIPTION
Hitting `/pyrra/objectives` currently serves a blank page. The handler passes an anonymous struct with field `ExternalDatasourceURL`, but `ui/index.html` binds to `{{.ExternalURL}}`, so template execution aborts mid-render with:

```
template: index.html:14:36: executing "index.html" at <.ExternalURL>: can't evaluate field ExternalURL in type struct { ExternalDatasourceURL string; ... }
```

and the response cuts off at `window.EXTERNAL_URL = `.

This slipped in with #1522, where renaming the Go variable `externalURL` to `externalDatasourceURL` over-applied into the struct field name of the `/objectives` handler. The catch-all handler kept the correct field, which is why `/pyrra` and `/pyrra/` still worked.

Fix is to extract a shared `renderIndex` helper used by both `/objectives` and the catch-all so the two can't drift apart again.