### PR TITLE
Fix inverted condition for MimirOrgID check

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func main() {
 		clientConfig.TLSConfig = promconfig.TLSConfig{CAFile: CLI.API.TLSClientCAFile}
 	}
 
-	if strings.EqualFold(CLI.API.MimirOrgID, "") {
+	if !strings.EqualFold(CLI.API.MimirOrgID, "") {
 		clientConfig.HTTPHeaders = &promconfig.Headers{
 			Headers: map[string]promconfig.Header{
 				mimir.TenantHeaderName: {


### PR DESCRIPTION
using `--mimir-org-id` is not working right now since the check condition is inverted: it only sets the tenant header when the value passed is empty.

Origin: introduced in [#1592](https://github.com/pyrra-dev/pyrra/pull/1592) (the same PR that added the flag).