### PR TITLE
fix: rename split PrometheusRules to {name}-short and {name}-long

### DIFF
--- a/docs/performance-mode.md
+++ b/docs/performance-mode.md
@@ -12,9 +12,9 @@ Enable performance mode if you're seeing slow rule evaluation or high memory usa
 
 When `performanceOverAccuracy: true` is set, Pyrra generates two PrometheusRule resources instead of one.
 
-The first rule, named `{slo-name}-increase`, records short 5-minute increases at a 30-second interval. These are cheap for Prometheus to evaluate since they only scan 5 minutes of data at a time.
+The first rule, named `{slo-name}-short`, records short 5-minute increases at a 30-second interval together with the burnrate recording rules and alerts. The 5-minute increases are cheap for Prometheus to evaluate since they only scan 5 minutes of data at a time, and the alerts evaluate frequently against them.
 
-The second rule, named `{slo-name}`, uses a subquery to sum those 5-minute values across the full window, for example `sum_over_time(metric:increase5m[4w:5m])`. Its evaluation interval is computed from the window length, typically 2 to 3 minutes, and is not user-configurable. This rule is well-suited for ThanosRuler, which handles the full-window aggregation without touching raw samples.
+The second rule, named `{slo-name}-long`, uses a subquery to sum those 5-minute values across the full window, for example `sum_over_time(metric:increase5m[4w:5m])`. Its evaluation interval is computed from the window length, typically 2 to 3 minutes, and is not user-configurable. This rule is well-suited for ThanosRuler, which handles the full-window aggregation without touching raw samples.
 
 In Thanos setups this reduces the data transferred across the wire by around 20x, since queries consume pre-aggregated 5-minute values rather than raw samples. This figure comes from real-world measurements described in the blog post linked above.
 

--- a/examples/kubernetes/manifests-webhook/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/kubernetes/manifests-webhook/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev

--- a/examples/kubernetes/manifests-webhook/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/kubernetes/manifests-webhook/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev
@@ -213,8 +213,8 @@ spec:
                 description: |-
                   RuleOutput configures labels on the generated PrometheusRule resources
                   when performance_over_accuracy is enabled. This allows routing the short
-                  (5m increase) rules and long (subquery + burnrate) rules to different
-                  Prometheus/Thanos instances via label selectors.
+                  (5m increase + burnrate + alert) rules and long (subquery) rules to
+                  different Prometheus/Thanos instances via label selectors.
                 properties:
                   enableDescriptionAsLabel:
                     description: |-
@@ -229,14 +229,16 @@ spec:
                       type: string
                     description: |-
                       LongRulesLabels are merged into the labels of the PrometheusRule
-                      containing the long (subquery + burnrate + alert) rules.
+                      containing the long (full-window subquery) recording rule.
+                      This PrometheusRule is named "{slo-name}-long".
                     type: object
                   shortRulesLabels:
                     additionalProperties:
                       type: string
                     description: |-
                       ShortRulesLabels are merged into the labels of the PrometheusRule
-                      containing the short (5m increase) recording rules.
+                      containing the short (5m increase + burnrate + alert) recording rules.
+                      This PrometheusRule is named "{slo-name}-short".
                     type: object
                 type: object
               target:

--- a/examples/kubernetes/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/kubernetes/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev

--- a/examples/kubernetes/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/kubernetes/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev
@@ -213,8 +213,8 @@ spec:
                 description: |-
                   RuleOutput configures labels on the generated PrometheusRule resources
                   when performance_over_accuracy is enabled. This allows routing the short
-                  (5m increase) rules and long (subquery + burnrate) rules to different
-                  Prometheus/Thanos instances via label selectors.
+                  (5m increase + burnrate + alert) rules and long (subquery) rules to
+                  different Prometheus/Thanos instances via label selectors.
                 properties:
                   enableDescriptionAsLabel:
                     description: |-
@@ -229,14 +229,16 @@ spec:
                       type: string
                     description: |-
                       LongRulesLabels are merged into the labels of the PrometheusRule
-                      containing the long (subquery + burnrate + alert) rules.
+                      containing the long (full-window subquery) recording rule.
+                      This PrometheusRule is named "{slo-name}-long".
                     type: object
                   shortRulesLabels:
                     additionalProperties:
                       type: string
                     description: |-
                       ShortRulesLabels are merged into the labels of the PrometheusRule
-                      containing the short (5m increase) recording rules.
+                      containing the short (5m increase + burnrate + alert) recording rules.
+                      This PrometheusRule is named "{slo-name}-short".
                     type: object
                 type: object
               target:

--- a/examples/openshift/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/openshift/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev

--- a/examples/openshift/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/openshift/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev
@@ -213,8 +213,8 @@ spec:
                 description: |-
                   RuleOutput configures labels on the generated PrometheusRule resources
                   when performance_over_accuracy is enabled. This allows routing the short
-                  (5m increase) rules and long (subquery + burnrate) rules to different
-                  Prometheus/Thanos instances via label selectors.
+                  (5m increase + burnrate + alert) rules and long (subquery) rules to
+                  different Prometheus/Thanos instances via label selectors.
                 properties:
                   enableDescriptionAsLabel:
                     description: |-
@@ -229,14 +229,16 @@ spec:
                       type: string
                     description: |-
                       LongRulesLabels are merged into the labels of the PrometheusRule
-                      containing the long (subquery + burnrate + alert) rules.
+                      containing the long (full-window subquery) recording rule.
+                      This PrometheusRule is named "{slo-name}-long".
                     type: object
                   shortRulesLabels:
                     additionalProperties:
                       type: string
                     description: |-
                       ShortRulesLabels are merged into the labels of the PrometheusRule
-                      containing the short (5m increase) recording rules.
+                      containing the short (5m increase + burnrate + alert) recording rules.
+                      This PrometheusRule is named "{slo-name}-short".
                     type: object
                 type: object
               target:

--- a/filesystem.go
+++ b/filesystem.go
@@ -380,28 +380,19 @@ func writeRuleFileSplit(logger log.Logger, kubeObjective v1alpha1.ServiceLevelOb
 		return fmt.Errorf("failed to get burn rate rules: %w", err)
 	}
 
-	// Write short rules (5m increase) to {name}-increase.yaml
-	shortSpec := monitoringv1.PrometheusRuleSpec{
-		Groups: []monitoringv1.RuleGroup{shortGroup},
-	}
-
 	_, f := filepath.Split(file)
 	ext := filepath.Ext(f)
-	shortFile := strings.TrimSuffix(f, ext) + "-increase" + ext
+	base := strings.TrimSuffix(f, ext)
 
-	if err := writeRuleSpec(logger, kubeObjective, shortSpec, shortFile, prometheusFolder, operatorRule); err != nil {
-		return fmt.Errorf("failed to write short rules: %w", err)
-	}
-
-	// Write long rules (subquery + burnrates + generic) to {name}.yaml
-	longSpec := monitoringv1.PrometheusRuleSpec{
-		Groups: []monitoringv1.RuleGroup{longGroup, burnrates},
+	// Write short rules (5m increase + burnrates + alerts + generic) to {name}-short.yaml
+	shortSpec := monitoringv1.PrometheusRuleSpec{
+		Groups: []monitoringv1.RuleGroup{shortGroup, burnrates},
 	}
 
 	if genericRules {
 		rules, err := objective.GenericRules(opts)
 		if err == nil {
-			longSpec.Groups = append(longSpec.Groups, rules)
+			shortSpec.Groups = append(shortSpec.Groups, rules)
 		} else {
 			if err != slo.ErrGroupingUnsupported {
 				return fmt.Errorf("failed to get generic rules: %w", err)
@@ -413,7 +404,18 @@ func writeRuleFileSplit(logger log.Logger, kubeObjective v1alpha1.ServiceLevelOb
 		}
 	}
 
-	return writeRuleSpec(logger, kubeObjective, longSpec, file, prometheusFolder, operatorRule)
+	shortFile := base + "-short" + ext
+	if err := writeRuleSpec(logger, kubeObjective, shortSpec, shortFile, prometheusFolder, operatorRule); err != nil {
+		return fmt.Errorf("failed to write short rules: %w", err)
+	}
+
+	// Write long rules (subquery for the full window) to {name}-long.yaml
+	longSpec := monitoringv1.PrometheusRuleSpec{
+		Groups: []monitoringv1.RuleGroup{longGroup},
+	}
+
+	longFile := base + "-long" + ext
+	return writeRuleSpec(logger, kubeObjective, longSpec, longFile, prometheusFolder, operatorRule)
 }
 
 func writeRuleSpec(_ log.Logger, kubeObjective v1alpha1.ServiceLevelObjective, rule monitoringv1.PrometheusRuleSpec, file, prometheusFolder string, operatorRule bool) error {

--- a/jsonnet/controller-gen/pyrra.dev_servicelevelobjectives.json
+++ b/jsonnet/controller-gen/pyrra.dev_servicelevelobjectives.json
@@ -3,7 +3,7 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.20.0"
+      "controller-gen.kubebuilder.io/version": "v0.20.1"
     },
     "name": "servicelevelobjectives.pyrra.dev"
   },

--- a/jsonnet/controller-gen/pyrra.dev_servicelevelobjectives.json
+++ b/jsonnet/controller-gen/pyrra.dev_servicelevelobjectives.json
@@ -3,7 +3,7 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.20.1"
+      "controller-gen.kubebuilder.io/version": "v0.20.0"
     },
     "name": "servicelevelobjectives.pyrra.dev"
   },
@@ -268,7 +268,7 @@
                     "type": "boolean"
                   },
                   "ruleOutput": {
-                    "description": "RuleOutput configures labels on the generated PrometheusRule resources\nwhen performance_over_accuracy is enabled. This allows routing the short\n(5m increase) rules and long (subquery + burnrate) rules to different\nPrometheus/Thanos instances via label selectors.",
+                    "description": "RuleOutput configures labels on the generated PrometheusRule resources\nwhen performance_over_accuracy is enabled. This allows routing the short\n(5m increase + burnrate + alert) rules and long (subquery) rules to\ndifferent Prometheus/Thanos instances via label selectors.",
                     "properties": {
                       "enableDescriptionAsLabel": {
                         "description": "EnableDescriptionAsLabel configures whether the description should be added as\na label to the generated PrometheusRule resources. This allows the\ndescription to be used in visualization tools like Grafana and in alert\nnotifications, but can cause performance issues if the description is\nvery long. Use with caution.",
@@ -278,14 +278,14 @@
                         "additionalProperties": {
                           "type": "string"
                         },
-                        "description": "LongRulesLabels are merged into the labels of the PrometheusRule\ncontaining the long (subquery + burnrate + alert) rules.",
+                        "description": "LongRulesLabels are merged into the labels of the PrometheusRule\ncontaining the long (full-window subquery) recording rule.\nThis PrometheusRule is named \"{slo-name}-long\".",
                         "type": "object"
                       },
                       "shortRulesLabels": {
                         "additionalProperties": {
                           "type": "string"
                         },
-                        "description": "ShortRulesLabels are merged into the labels of the PrometheusRule\ncontaining the short (5m increase) recording rules.",
+                        "description": "ShortRulesLabels are merged into the labels of the PrometheusRule\ncontaining the short (5m increase + burnrate + alert) recording rules.\nThis PrometheusRule is named \"{slo-name}-short\".",
                         "type": "object"
                       }
                     },

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -105,8 +105,8 @@ type ServiceLevelObjectiveSpec struct {
 	// +optional
 	// RuleOutput configures labels on the generated PrometheusRule resources
 	// when performance_over_accuracy is enabled. This allows routing the short
-	// (5m increase) rules and long (subquery + burnrate) rules to different
-	// Prometheus/Thanos instances via label selectors.
+	// (5m increase + burnrate + alert) rules and long (subquery) rules to
+	// different Prometheus/Thanos instances via label selectors.
 	RuleOutput *RuleOutput `json:"ruleOutput,omitempty"`
 }
 
@@ -114,12 +114,14 @@ type ServiceLevelObjectiveSpec struct {
 type RuleOutput struct {
 	// +optional
 	// ShortRulesLabels are merged into the labels of the PrometheusRule
-	// containing the short (5m increase) recording rules.
+	// containing the short (5m increase + burnrate + alert) recording rules.
+	// This PrometheusRule is named "{slo-name}-short".
 	ShortRulesLabels map[string]string `json:"shortRulesLabels,omitempty"`
 
 	// +optional
 	// LongRulesLabels are merged into the labels of the PrometheusRule
-	// containing the long (subquery + burnrate + alert) rules.
+	// containing the long (full-window subquery) recording rule.
+	// This PrometheusRule is named "{slo-name}-long".
 	LongRulesLabels map[string]string `json:"longRulesLabels,omitempty"`
 
 	// +optional

--- a/kubernetes/controllers/servicelevelobjective.go
+++ b/kubernetes/controllers/servicelevelobjective.go
@@ -112,8 +112,12 @@ func (r *ServiceLevelObjectiveReconciler) reconcilePrometheusRule(ctx context.Co
 		return r.reconcileSplitPrometheusRules(ctx, logger, req, kubeObjective)
 	}
 
-	// Clean up stale increase rule if user toggled performance_over_accuracy from true to false.
-	r.cleanupStaleIncreaseRule(ctx, logger, req)
+	// Clean up stale split rules if user toggled performance_over_accuracy from true to false.
+	r.cleanupStalePrometheusRules(ctx, logger, req,
+		req.Name+"-short",
+		req.Name+"-long",
+		req.Name+"-increase", // legacy name from before the -short/-long split
+	)
 
 	newRule, err := makePrometheusRule(kubeObjective, r.GenericRules, r.EnablePrometheus3Migration, r.PyrraExternalURL)
 	if err != nil {
@@ -132,7 +136,7 @@ func (r *ServiceLevelObjectiveReconciler) reconcilePrometheusRule(ctx context.Co
 	return ctrl.Result{}, nil
 }
 
-func (r *ServiceLevelObjectiveReconciler) reconcileSplitPrometheusRules(ctx context.Context, logger kitlog.Logger, _ ctrl.Request, kubeObjective pyrrav1alpha1.ServiceLevelObjective) (ctrl.Result, error) {
+func (r *ServiceLevelObjectiveReconciler) reconcileSplitPrometheusRules(ctx context.Context, logger kitlog.Logger, req ctrl.Request, kubeObjective pyrrav1alpha1.ServiceLevelObjective) (ctrl.Result, error) {
 	shortRule, longRule, err := makeSplitPrometheusRules(kubeObjective, r.GenericRules, r.EnablePrometheus3Migration, r.PyrraExternalURL)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -145,6 +149,14 @@ func (r *ServiceLevelObjectiveReconciler) reconcileSplitPrometheusRules(ctx cont
 	if err := r.upsertPrometheusRule(ctx, logger, longRule); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// Clean up stale rules from previous configurations:
+	// - {name}: from when performance_over_accuracy was disabled
+	// - {name}-increase: legacy name from before the -short/-long split
+	r.cleanupStalePrometheusRules(ctx, logger, req,
+		req.Name,
+		req.Name+"-increase",
+	)
 
 	kubeObjective.Status.Type = "PrometheusRule"
 	if err := r.Status().Update(ctx, &kubeObjective); err != nil {
@@ -171,16 +183,18 @@ func (r *ServiceLevelObjectiveReconciler) upsertPrometheusRule(ctx context.Conte
 	return r.Update(ctx, newRule)
 }
 
-func (r *ServiceLevelObjectiveReconciler) cleanupStaleIncreaseRule(ctx context.Context, logger kitlog.Logger, req ctrl.Request) {
-	increaseRuleName := req.Name + "-increase"
-	var staleRule monitoringv1.PrometheusRule
-	if err := r.Get(ctx, client.ObjectKey{
-		Namespace: req.Namespace,
-		Name:      increaseRuleName,
-	}, &staleRule); err == nil {
-		level.Info(logger).Log("msg", "cleaning up stale increase rule", "name", increaseRuleName)
+func (r *ServiceLevelObjectiveReconciler) cleanupStalePrometheusRules(ctx context.Context, logger kitlog.Logger, req ctrl.Request, names ...string) {
+	for _, name := range names {
+		var staleRule monitoringv1.PrometheusRule
+		if err := r.Get(ctx, client.ObjectKey{
+			Namespace: req.Namespace,
+			Name:      name,
+		}, &staleRule); err != nil {
+			continue
+		}
+		level.Info(logger).Log("msg", "cleaning up stale prometheus rule", "name", name)
 		if err := r.Delete(ctx, &staleRule); err != nil {
-			level.Error(logger).Log("msg", "failed to delete stale increase rule", "name", increaseRuleName, "err", err)
+			level.Error(logger).Log("msg", "failed to delete stale prometheus rule", "name", name, "err", err)
 		}
 	}
 }
@@ -533,9 +547,10 @@ func makeSplitPrometheusRules(kubeObjective pyrrav1alpha1.ServiceLevelObjective,
 	}
 
 	shortRule := newPrometheusRule(kubeObjective, shortLabels, shortSpec)
-	shortRule.Name = kubeObjective.GetName() + "-increase"
+	shortRule.Name = kubeObjective.GetName() + "-short"
 
 	longRule := newPrometheusRule(kubeObjective, longLabels, longSpec)
+	longRule.Name = kubeObjective.GetName() + "-long"
 
 	return shortRule, longRule, nil
 }

--- a/kubernetes/controllers/servicelevelobjective_test.go
+++ b/kubernetes/controllers/servicelevelobjective_test.go
@@ -215,7 +215,7 @@ func Test_makeSplitPrometheusRules(t *testing.T) {
 			Kind:       monitoringv1.PrometheusRuleKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "http-increase",
+			Name: "http-short",
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: pyrrav1alpha1.GroupVersion.Version,
@@ -343,7 +343,7 @@ func Test_makeSplitPrometheusRules(t *testing.T) {
 			Kind:       monitoringv1.PrometheusRuleKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "http",
+			Name: "http-long",
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: pyrrav1alpha1.GroupVersion.Version,


### PR DESCRIPTION
## Summary

When `performanceOverAccuracy: true` is set, Pyrra splits the recording rules into two PrometheusRule resources. Previously these were named `{name}-increase` (containing the 5m increases, burnrates and alerts) and `{name}` (containing only the long-window subquery). The `-increase` suffix is misleading there, since the actual full-window increase recording rule lives in the no-suffix file.

This rename makes the split match the `ShortRulesLabels` / `LongRulesLabels` routing fields:

- `{name}-short` holds the 5m increases, burnrates and alerts. Typically routed to Prometheus.
- `{name}-long` holds the full-window subquery. Typically routed to ThanosRuler.

Toggling `performanceOverAccuracy` cleans up the stale rules, including the legacy `{name}-increase` name from the previous layout, so existing users won't end up with orphaned PrometheusRule resources.

The filesystem operator now also matches the Kubernetes controller and writes the burnrates with the short rules, aligning with #1816's intent of running alerts on the short interval.