### PR TITLE
slo: fix latency total increase double-counting denominator

### DIFF
--- a/slo/promql.go
+++ b/slo/promql.go
@@ -2,14 +2,14 @@ package slo
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 // QueryTotal returns a PromQL query to get the total amount of requests served during the window.
@@ -859,7 +859,7 @@ func groupingLabels(errorMatchers, totalMatchers []*labels.Matcher) []string {
 	// and we have to remove it for the latency SLOs.
 	delete(groupingLabels, labels.BucketLabel)
 
-	return maps.Keys(groupingLabels)
+	return slices.Collect(maps.Keys(groupingLabels))
 }
 
 func cloneMatchers(matchers []*labels.Matcher) []*labels.Matcher {

--- a/slo/rules.go
+++ b/slo/rules.go
@@ -1096,9 +1096,17 @@ func (o Objective) increaseRuleLatency(sloName string, opts GenerationOptions) (
 		}
 
 		subqueryName := increaseName(o.Indicator.Latency.Total.Name, model.Duration(5*time.Minute))
+		// The total (_count) and success (_bucket) short rules both record into
+		// the same :increase5m metric, distinguished only by the "le" label: the
+		// total series has no "le" while the success series carries the threshold
+		// bucket (e.g. le="60.0"). Match le="" so the total subquery selects only
+		// the count series; without it the sum also picks up the success bucket
+		// and doubles the denominator.
+		totalSubqueryMatchers := o.buildSubqueryMatchers(applyPrometheus3Migration(o.Indicator.Latency.Total.LabelMatchers, opts), subqueryName)
+		totalSubqueryMatchers = append(totalSubqueryMatchers, &labels.Matcher{Type: labels.MatchEqual, Name: "le", Value: ""})
 		objectiveReplacer{
 			metric:   subqueryName,
-			matchers: o.buildSubqueryMatchers(applyPrometheus3Migration(o.Indicator.Latency.Total.LabelMatchers, opts), subqueryName),
+			matchers: totalSubqueryMatchers,
 			grouping: grouping,
 			window:   time.Duration(o.Window),
 		}.replace(subExpr)

--- a/slo/rules.go
+++ b/slo/rules.go
@@ -3,7 +3,9 @@ package slo
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -13,8 +15,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 

--- a/slo/rules_test.go
+++ b/slo/rules_test.go
@@ -1650,7 +1650,7 @@ func TestObjective_IncreaseRules(t *testing.T) {
 				Labels: map[string]string{"slo": "monitoring-http-latency", "le": "1", "severity": "critical"},
 			}, {
 				Record: "http_request_duration_seconds:increase4w",
-				Expr:   intstr.FromString(`sum by (code, handler, job) (sum_over_time(http_request_duration_seconds:increase5m{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default"}[4w:5m]))`),
+				Expr:   intstr.FromString(`sum by (code, handler, job) (sum_over_time(http_request_duration_seconds:increase5m{code=~"2..",handler=~"/api.*",job="metrics-service-thanos-receive-default",le=""}[4w:5m]))`),
 				Labels: map[string]string{"slo": "monitoring-http-latency"},
 			}, {
 				Record: "http_request_duration_seconds:increase4w",


### PR DESCRIPTION
The total `:increaseNw` recording rule for latency SLOs with `performanceOverAccuracy` summed the `:increase5m` metric without an `le` matcher. Since the `_count` (total) and `_bucket` (success) short rules record into the same `:increase5m` name and are only distinguished by `le`, the `sum by (...)` collapsed both series into `total + success`, roughly doubling the denominator. Availability then sat near 50% for latency SLOs even when nearly every request was within the threshold. Matching `le=""` makes the total subquery select only the count series.