### PR TITLE
fix(ui): scope ALERTS query to objective and grouping labels

### DIFF
--- a/ui/src/components/AlertsTable.tsx
+++ b/ui/src/components/AlertsTable.tsx
@@ -66,9 +66,14 @@ const AlertsTable = ({
       .catch((err) => { console.log(err); })
   }, [client, objective, grouping])
 
+  const alertsSelector = [
+    ...Object.entries(objective.labels).map(([k, v]) => k === '__name__' ? `slo="${v}"` : `${k}="${v}"`),
+    ...Object.entries(grouping).map(([k, v]) => `${k}="${v}"`),
+  ].join(', ')
+
   const {response: alertsRangeResponse} = usePrometheusQueryRange(
     promClient,
-    `ALERTS{slo="${objective.labels.__name__}"}`,
+    `ALERTS{${alertsSelector}}`,
     from / 1000,
     to / 1000,
     step(from, to),


### PR DESCRIPTION
The `ALERTS{slo="..."}` query only filtered by SLO name, so alerts from ephemeral namespaces sharing the same SLO name (like smoke test environments) would bleed into the detail page. This scopes the query to all objective labels and grouping labels so only the alerts for the exact SLO instance are shown.

In this screenshot, the query should include `namespace=columnstore` and not show a firing alert.

<img width="3226" height="924" alt="image" src="https://github.com/user-attachments/assets/7b4568da-ac10-4d78-8b2f-62527f0fe608" />
