### PR TITLE
fix(kubernetes): reject non-vector-selector ratio metrics in webhook

### DIFF
--- a/kubernetes/api/v1alpha1/servicelevelobjective_types.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types.go
@@ -310,13 +310,19 @@ func (in *ServiceLevelObjective) validate() (admission.Warnings, error) {
 			warnings = append(warnings, "ratio errors metric should be different from ratio total metric")
 		}
 
-		_, err := parser.ParseExpr(ratio.Total.Metric)
+		totalExpr, err := parser.ParseExpr(ratio.Total.Metric)
 		if err != nil {
 			return warnings, fmt.Errorf("failed to parse ratio total metric: %w", err)
 		}
-		_, err = parser.ParseExpr(ratio.Errors.Metric)
+		if _, ok := totalExpr.(*parser.VectorSelector); !ok {
+			return warnings, fmt.Errorf("ratio total metric must be a vector selector, but got %T", totalExpr)
+		}
+		errorsExpr, err := parser.ParseExpr(ratio.Errors.Metric)
 		if err != nil {
 			return warnings, fmt.Errorf("failed to parse ratio error metric: %w", err)
+		}
+		if _, ok := errorsExpr.(*parser.VectorSelector); !ok {
+			return warnings, fmt.Errorf("ratio errors metric must be a vector selector, but got %T", errorsExpr)
 		}
 	}
 

--- a/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
+++ b/kubernetes/api/v1alpha1/servicelevelobjective_types_test.go
@@ -488,6 +488,32 @@ func TestServiceLevelObjective_Validate(t *testing.T) {
 			require.EqualError(t, err, "failed to parse ratio total metric: 1:9: parse error: unterminated quoted string")
 			require.Nil(t, warn)
 		})
+
+		t.Run("notVectorSelector", func(t *testing.T) {
+			totalAggregate := ratio()
+			totalAggregate.Spec.ServiceLevelIndicator.Ratio.Total.Metric = `sum(total{foo="bar"})`
+			warn, err := totalAggregate.ValidateCreate(ctx, totalAggregate)
+			require.EqualError(t, err, "ratio total metric must be a vector selector, but got *parser.AggregateExpr")
+			require.Nil(t, warn)
+
+			totalBinary := ratio()
+			totalBinary.Spec.ServiceLevelIndicator.Ratio.Total.Metric = `errors{foo="bar"} / total{foo="bar"}`
+			warn, err = totalBinary.ValidateCreate(ctx, totalBinary)
+			require.EqualError(t, err, "ratio total metric must be a vector selector, but got *parser.BinaryExpr")
+			require.Nil(t, warn)
+
+			errorsAggregate := ratio()
+			errorsAggregate.Spec.ServiceLevelIndicator.Ratio.Errors.Metric = `sum(errors{foo="bar"})`
+			warn, err = errorsAggregate.ValidateCreate(ctx, errorsAggregate)
+			require.EqualError(t, err, "ratio errors metric must be a vector selector, but got *parser.AggregateExpr")
+			require.Nil(t, warn)
+
+			errorsCall := ratio()
+			errorsCall.Spec.ServiceLevelIndicator.Ratio.Errors.Metric = `rate(errors{foo="bar"}[5m])`
+			warn, err = errorsCall.ValidateCreate(ctx, errorsCall)
+			require.EqualError(t, err, "ratio errors metric must be a vector selector, but got *parser.Call")
+			require.Nil(t, warn)
+		})
 	})
 
 	t.Run("latency", func(t *testing.T) {


### PR DESCRIPTION
## What / Why

Fixes #1387.

The ratio indicator requires its `total` and `errors` metrics to be plain **vector selectors**. `Internal()` type-asserts both to `*parser.VectorSelector` and otherwise returns `ratio total metric is not a VectorSelector` / `ratio error metric is not a VectorSelector`:

https://github.com/pyrra-dev/pyrra/blob/main/kubernetes/api/v1alpha1/servicelevelobjective_types.go#L464-L477

However, the validating webhook's `validate()` only *parsed* the ratio expressions without checking their type:

```go
_, err := parser.ParseExpr(ratio.Total.Metric)
if err != nil { ... }
_, err = parser.ParseExpr(ratio.Errors.Metric)
if err != nil { ... }
```

So an SLO whose ratio metric is an aggregation (`sum(...)`), a binary/arithmetic expression (`a / b`), a function call (`rate(...[5m])`), etc. **passes admission** and only fails later during reconciliation / objective retrieval. In the UI this surfaces as `Error loading objectives` / `ratio total metric is not a VectorSelector`, well after the resource was accepted.

This is the same class of gap that #1181 fixed for the panic path — the latency branch already validates the concrete type; the ratio branch did not.

## Change

Mirror the existing latency validation and assert both ratio metrics are `*parser.VectorSelector` in `validate()`, returning a clear admission error so the mistake is caught at `kubectl apply` time instead of silently later:

```go
totalExpr, err := parser.ParseExpr(ratio.Total.Metric)
if err != nil { ... }
if _, ok := totalExpr.(*parser.VectorSelector); !ok {
    return warnings, fmt.Errorf("ratio total metric must be a vector selector, but got %T", totalExpr)
}
errorsExpr, err := parser.ParseExpr(ratio.Errors.Metric)
if err != nil { ... }
if _, ok := errorsExpr.(*parser.VectorSelector); !ok {
    return warnings, fmt.Errorf("ratio errors metric must be a vector selector, but got %T", errorsExpr)
}
```

The wording (`must be a vector selector, but got %T`) matches the existing latency messages in the same function.

## Tests

Added a `notVectorSelector` subtest under `TestServiceLevelObjective_Validate/ratio` covering aggregation, binary and call expressions for both the total and errors metrics.

Local checks (all green):
- `go test -race ./kubernetes/...`
- `go vet ./kubernetes/...`
- `gofumpt -l` (no diff)

No generated artifacts change (validation logic only; no CRD/kubebuilder-marker changes).
