### PR TITLE
fix: replace deprecated h2c handler with http.Server.Protocols

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -24,8 +24,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
@@ -260,8 +258,9 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 		router.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 
 		server := http.Server{
-			Addr:    ":9444",
-			Handler: h2c.NewHandler(router, &http2.Server{}),
+			Addr:      ":9444",
+			Handler:   router,
+			Protocols: httpProtocols(),
 		}
 
 		gr.Add(func() error {

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -33,8 +33,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -210,8 +208,9 @@ func cmdKubernetes(
 		}))
 
 		server := http.Server{
-			Addr:    ":9444",
-			Handler: h2c.NewHandler(router, &http2.Server{}),
+			Addr:      ":9444",
+			Handler:   router,
+			Protocols: httpProtocols(),
 		}
 
 		gr.Add(func() error {

--- a/main.go
+++ b/main.go
@@ -37,8 +37,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/pyrra-dev/pyrra/mimir"
@@ -470,7 +468,8 @@ func cmdAPI(
 	{
 		httpServer := &http.Server{
 			Addr:      ":9099",
-			Handler:   h2c.NewHandler(r, &http2.Server{}),
+			Handler:   r,
+			Protocols: httpProtocols(),
 			TLSConfig: &tls.Config{},
 		}
 		gr.Add(
@@ -497,6 +496,16 @@ func cmdAPI(
 		return 2
 	}
 	return 0
+}
+
+// httpProtocols enables HTTP/1.1, HTTP/2 over TLS and unencrypted HTTP/2 (h2c),
+// which connect-go clients rely on when talking to these servers.
+func httpProtocols() *http.Protocols {
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetHTTP2(true)
+	protocols.SetUnencryptedHTTP2(true)
+	return protocols
 }
 
 func newBackendClientCache(client objectivesv1alpha1connect.ObjectiveBackendServiceClient) objectivesv1alpha1connect.ObjectiveBackendServiceClient {


### PR DESCRIPTION
`golang.org/x/net` v0.55.0 deprecated `http2/h2c`, so staticcheck SA1019 now fails on every dependency update that crosses that version. That is currently blocking #1882, #1872 and #1865.

go.mod is already on go 1.25, so `http.Server.Protocols` handles this natively and keeps the cleartext h2c that connect-go clients rely on.
