### PR TITLE
chore(kubernetes): regenerate CRDs with controller-gen v0.21.0

### DIFF
--- a/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
+++ b/config/crd/bases/pyrra.dev_servicelevelobjectives.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev

--- a/examples/kubernetes-namespaced/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/kubernetes-namespaced/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev

--- a/examples/kubernetes/manifests-webhook/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/kubernetes/manifests-webhook/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev

--- a/examples/kubernetes/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/kubernetes/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev

--- a/examples/openshift/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
+++ b/examples/openshift/manifests/setup/pyrra-slo-CustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: servicelevelobjectives.pyrra.dev
 spec:
   group: pyrra.dev

--- a/jsonnet/controller-gen/pyrra.dev_servicelevelobjectives.json
+++ b/jsonnet/controller-gen/pyrra.dev_servicelevelobjectives.json
@@ -3,7 +3,7 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.20.1"
+      "controller-gen.kubebuilder.io/version": "v0.21.0"
     },
     "name": "servicelevelobjectives.pyrra.dev"
   },


### PR DESCRIPTION
#1854 bumped the controller-gen pin to v0.21.0 but the generated CRDs still carry the v0.20.1 annotation, so `make generate` leaves the tree dirty and the generate check fails on every PR against main, for example #1897.

Only the `controller-gen.kubebuilder.io/version` annotation changes. Note that the Makefile prefers whatever `controller-gen` is on your PATH, so regenerating with an older local binary will flip it back.