### PR TITLE
feat(ui): add the Create SLO editor page

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -437,7 +438,26 @@ func cmdAPI(
 			}
 		}
 
+		// The UI routes /objectives itself (the detail page reads its expr from the
+		// query string) as well as everything below it, like /objectives/create.
+		// Serve the index for all of them so those pages survive a reload and can
+		// be linked to, rather than falling through to the file server's 404.
+		//
+		// The index references its assets relatively, so from a nested page the
+		// browser asks for /objectives/assets/…. Anything that looks like a file
+		// has to reach the file server, or the page loads HTML where it expects
+		// JavaScript and never boots.
 		r.Get("/objectives", func(w http.ResponseWriter, _ *http.Request) {
+			renderIndex(w)
+		})
+		r.Get("/objectives/*", func(w http.ResponseWriter, req *http.Request) {
+			if path.Ext(req.URL.Path) != "" {
+				http.StripPrefix(
+					strings.TrimSuffix(routePrefix, "/")+"/objectives",
+					http.FileServer(http.FS(build)),
+				).ServeHTTP(w, req)
+				return
+			}
 			renderIndex(w)
 		})
 		r.Handle("/*", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,7 @@ import {BrowserRouter, Route, Routes} from 'react-router-dom'
 import {NuqsAdapter} from 'nuqs/adapters/react-router/v6'
 import List from './pages/List'
 import Detail from './pages/Detail'
+import Create from './pages/Create'
 import Footer from './components/Footer'
 import {TooltipProvider} from '@/components/ui/tooltip'
 import {
@@ -46,6 +47,7 @@ const App = () => {
           <NuqsAdapter>
             <Routes>
               <Route path="/" element={<List />} />
+              <Route path="/objectives/create" element={<Create />} />
               <Route path="/objectives" element={<Detail />} />
             </Routes>
             <Footer version={VERSION} />

--- a/ui/src/components/ObjectiveLabels.tsx
+++ b/ui/src/components/ObjectiveLabels.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import {Badge} from '@/components/ui/badge'
+import {cn} from '@/lib/utils'
+import {type Labels, MetricName} from '../labels'
+
+interface ObjectiveLabelsProps {
+  labels: Labels
+  grouping?: Labels
+  className?: string
+}
+
+// Renders an objective's labels (and optional grouping labels) as secondary badges,
+// dropping the __name__ metric label. Shared by the detail page and the Create preview.
+const ObjectiveLabels = ({labels, grouping, className}: ObjectiveLabelsProps): React.JSX.Element => (
+  <>
+    {Object.entries({...labels, ...grouping})
+      .filter(([k]) => k !== MetricName)
+      .map(([k, v]) => (
+        <Badge key={k} variant="secondary" className={cn('mr-1 font-normal', className)}>
+          {k}={v}
+        </Badge>
+      ))}
+  </>
+)
+
+export default ObjectiveLabels

--- a/ui/src/components/create/DetailPreview.tsx
+++ b/ui/src/components/create/DetailPreview.tsx
@@ -1,0 +1,236 @@
+// Live preview of the SLO Detail page, rendered from a materialized Objective.
+//
+// Given an Objective produced by the backend preview (see preview.ts), this
+// composes the very same building blocks as the real Detail page — the three
+// tiles and the error-budget / requests / errors graphs — querying Prometheus
+// directly through the query strings the backend computed. The result looks and
+// behaves exactly like an already-stored SLO.
+//
+// Until the backend preview endpoint exists, `objective` is null and this shows
+// the idle / unavailable states instead.
+
+import React, {useMemo, useState, type JSX} from 'react'
+import {createClient} from '@connectrpc/connect'
+import {createConnectTransport} from '@connectrpc/connect-web'
+import type uPlot from 'uplot'
+import {LineChart, Play} from 'lucide-react'
+import {Badge} from '@/components/ui/badge'
+import {Spinner} from '@/components/ui/spinner'
+import {Button} from '@/components/ui/button'
+import {hasObjectiveType, ObjectiveType, latencyTarget} from '../../App'
+import {MetricName} from '../../labels'
+import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
+import {PrometheusService} from '../../proto/prometheus/v1/prometheus_pb'
+import {usePrometheusQuery, replaceInterval} from '../../prometheus'
+import Tiles from '../tiles/Tiles'
+import ObjectiveTile from '../tiles/ObjectiveTile'
+import AvailabilityTile from '../tiles/AvailabilityTile'
+import ErrorBudgetTile from '../tiles/ErrorBudgetTile'
+import ErrorBudgetGraph from '../graphs/ErrorBudgetGraph'
+import RequestsGraph from '../graphs/RequestsGraph'
+import ErrorsGraph from '../graphs/ErrorsGraph'
+import {type PreviewStatus} from './preview'
+
+interface DetailPreviewProps {
+  baseUrl: string
+  objective: Objective | null
+  status: PreviewStatus
+  stale: boolean
+  onRun: () => void
+}
+
+const noop = (): void => {}
+
+const EmptyState = ({onRun}: {onRun: () => void}): JSX.Element => (
+  <div className="flex min-h-[60vh] flex-col items-center justify-center gap-2.5 p-10 text-center text-muted-foreground">
+    <LineChart className="h-10 w-10 opacity-40" />
+    <p className="font-heading text-xl font-bold text-foreground">No preview yet</p>
+    <p className="max-w-80 text-sm leading-relaxed">
+      Configure the SLO and press <b>Preview</b> to render its Detail page, exactly as it would appear
+      once stored in Pyrra.
+    </p>
+    <Button variant="outline" onClick={onRun} className="mt-2">
+      <Play /> Preview
+    </Button>
+  </div>
+)
+
+const Message = ({title, children}: {title: string; children: React.ReactNode}): JSX.Element => (
+  <div className="flex min-h-[60vh] flex-col items-center justify-center gap-2.5 p-10 text-center text-muted-foreground">
+    <p className="font-heading text-xl font-bold text-foreground">{title}</p>
+    <p className="max-w-96 text-sm leading-relaxed">{children}</p>
+  </div>
+)
+
+const DetailPreview = ({baseUrl, objective, status, stale, onRun}: DetailPreviewProps): JSX.Element => {
+  const promClient = useMemo(
+    () => createClient(PrometheusService, createConnectTransport({baseUrl})),
+    [baseUrl],
+  )
+
+  // A fixed range captured once — a preview doesn't need live auto-refresh.
+  const [{from, to}] = useState(() => {
+    const now = Date.now()
+    return {from: now - 60 * 60 * 1000, to: now}
+  })
+
+  const countTotal = objective?.queries?.countTotal ?? ''
+  const countErrors = objective?.queries?.countErrors ?? ''
+  const queriesEnabled = objective !== null && countTotal !== ''
+
+  const {response: totalResponse, status: totalStatus} = usePrometheusQuery(
+    promClient,
+    countTotal,
+    to / 1000,
+    {enabled: queriesEnabled},
+  )
+  const {response: errorResponse, status: errorStatus} = usePrometheusQuery(
+    promClient,
+    countErrors,
+    to / 1000,
+    {enabled: queriesEnabled},
+  )
+
+  if (status === 'loading') {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-3 text-muted-foreground">
+        <Spinner />
+        <p>Materializing objective…</p>
+      </div>
+    )
+  }
+
+  if (status === 'unavailable') {
+    return (
+      <Message title="Live preview isn't wired up yet">
+        The backend <code className="font-mono">Preview</code> endpoint that materializes a draft SLO is
+        coming next. Meanwhile, switch to the <b>YAML</b> tab to see the exact config this form produces.
+      </Message>
+    )
+  }
+
+  if (status === 'error') {
+    return (
+      <Message title="Preview failed">
+        The SLO couldn't be materialized. Check the editor for invalid metrics or values and try again.
+      </Message>
+    )
+  }
+
+  if (objective === null) {
+    return <EmptyState onRun={onRun} />
+  }
+
+  const name = objective.labels[MetricName] ?? 'preview'
+  const objectiveType = hasObjectiveType(objective)
+  const objectiveTypeLatency =
+    objectiveType === ObjectiveType.Latency || objectiveType === ObjectiveType.LatencyNative
+
+  const loading = totalStatus === 'pending' || errorStatus === 'pending'
+  const success = totalStatus === 'success' && errorStatus === 'success'
+
+  let errors = 0
+  let total = 1
+  if (totalResponse?.options.case === 'vector' && errorResponse?.options.case === 'vector') {
+    if (errorResponse.options.value.samples.length > 0) {
+      errors = errorResponse.options.value.samples[0].value
+    }
+    if (totalResponse.options.value.samples.length > 0) {
+      total = totalResponse.options.value.samples[0].value
+    }
+  }
+
+  const labelBadges = Object.entries(objective.labels)
+    .filter((l) => l[0] !== MetricName)
+    .map((l) => (
+      <Badge key={l[0]} variant="secondary" className="mr-1 font-normal">
+        {l[0]}={l[1]}
+      </Badge>
+    ))
+
+  const uPlotCursor: uPlot.Cursor = {y: false, lock: true, sync: {key: 'create-preview'}}
+
+  return (
+    <div className={stale ? 'opacity-55 transition-opacity' : 'transition-opacity'}>
+      <div className="px-6 pt-7 pb-14">
+        <div className="mb-7">
+          <h3 className="mb-3">{name}</h3>
+          {labelBadges}
+          {objective.description !== '' && (
+            <p className="mt-3 max-w-prose text-sm leading-relaxed">{objective.description}</p>
+          )}
+        </div>
+
+        <div className="mb-7">
+          <Tiles>
+            <ObjectiveTile objective={objective} />
+            <AvailabilityTile
+              objective={objective}
+              loading={loading}
+              success={success}
+              errors={errors}
+              total={total}
+            />
+            <ErrorBudgetTile
+              objective={objective}
+              loading={loading}
+              success={success}
+              errors={errors}
+              total={total}
+            />
+          </Tiles>
+        </div>
+
+        {objective.queries?.graphErrorBudget !== undefined && (
+          <div className="mb-7">
+            <ErrorBudgetGraph
+              client={promClient}
+              query={objective.queries.graphErrorBudget}
+              from={from}
+              to={to}
+              uPlotCursor={uPlotCursor}
+              updateTimeRange={noop}
+              absolute={true}
+            />
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {objective.queries?.graphRequests !== undefined && (
+            <RequestsGraph
+              client={promClient}
+              query={replaceInterval(objective.queries.graphRequests, from, to)}
+              from={from}
+              to={to}
+              uPlotCursor={uPlotCursor}
+              type={objectiveType}
+              updateTimeRange={noop}
+              absolute={true}
+            />
+          )}
+          {objective.queries?.graphErrors !== undefined && (
+            <ErrorsGraph
+              client={promClient}
+              type={objectiveType}
+              query={replaceInterval(objective.queries.graphErrors, from, to)}
+              from={from}
+              to={to}
+              uPlotCursor={uPlotCursor}
+              updateTimeRange={noop}
+              absolute={true}
+            />
+          )}
+        </div>
+
+        {objectiveTypeLatency && (
+          <p className="mt-4 text-xs text-muted-foreground">
+            Latency target: {latencyTarget(objective) ?? '—'} ms · the duration graph and alerts table appear
+            on the stored SLO's Detail page.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default DetailPreview

--- a/ui/src/components/create/DetailPreview.tsx
+++ b/ui/src/components/create/DetailPreview.tsx
@@ -14,18 +14,15 @@ import {createClient} from '@connectrpc/connect'
 import {createConnectTransport} from '@connectrpc/connect-web'
 import type uPlot from 'uplot'
 import {LineChart, Play} from 'lucide-react'
-import {Badge} from '@/components/ui/badge'
 import {Spinner} from '@/components/ui/spinner'
 import {Button} from '@/components/ui/button'
 import {hasObjectiveType, ObjectiveType, latencyTarget} from '../../App'
 import {MetricName} from '../../labels'
 import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {PrometheusService} from '../../proto/prometheus/v1/prometheus_pb'
-import {usePrometheusQuery, replaceInterval} from '../../prometheus'
-import Tiles from '../tiles/Tiles'
-import ObjectiveTile from '../tiles/ObjectiveTile'
-import AvailabilityTile from '../tiles/AvailabilityTile'
-import ErrorBudgetTile from '../tiles/ErrorBudgetTile'
+import {usePrometheusQuery, replaceInterval, vectorErrorsTotal} from '../../prometheus'
+import ObjectiveTiles from '../tiles/ObjectiveTiles'
+import ObjectiveLabels from '../ObjectiveLabels'
 import ErrorBudgetGraph from '../graphs/ErrorBudgetGraph'
 import RequestsGraph from '../graphs/RequestsGraph'
 import ErrorsGraph from '../graphs/ErrorsGraph'
@@ -129,24 +126,7 @@ const DetailPreview = ({baseUrl, objective, status, stale, onRun}: DetailPreview
   const loading = totalStatus === 'pending' || errorStatus === 'pending'
   const success = totalStatus === 'success' && errorStatus === 'success'
 
-  let errors = 0
-  let total = 1
-  if (totalResponse?.options.case === 'vector' && errorResponse?.options.case === 'vector') {
-    if (errorResponse.options.value.samples.length > 0) {
-      errors = errorResponse.options.value.samples[0].value
-    }
-    if (totalResponse.options.value.samples.length > 0) {
-      total = totalResponse.options.value.samples[0].value
-    }
-  }
-
-  const labelBadges = Object.entries(objective.labels)
-    .filter((l) => l[0] !== MetricName)
-    .map((l) => (
-      <Badge key={l[0]} variant="secondary" className="mr-1 font-normal">
-        {l[0]}={l[1]}
-      </Badge>
-    ))
+  const {errors, total} = vectorErrorsTotal(totalResponse, errorResponse)
 
   const uPlotCursor: uPlot.Cursor = {y: false, lock: true, sync: {key: 'create-preview'}}
 
@@ -155,30 +135,20 @@ const DetailPreview = ({baseUrl, objective, status, stale, onRun}: DetailPreview
       <div className="px-6 pt-7 pb-14">
         <div className="mb-7">
           <h3 className="mb-3">{name}</h3>
-          {labelBadges}
+          <ObjectiveLabels labels={objective.labels} />
           {objective.description !== '' && (
             <p className="mt-3 max-w-prose text-sm leading-relaxed">{objective.description}</p>
           )}
         </div>
 
         <div className="mb-7">
-          <Tiles>
-            <ObjectiveTile objective={objective} />
-            <AvailabilityTile
-              objective={objective}
-              loading={loading}
-              success={success}
-              errors={errors}
-              total={total}
-            />
-            <ErrorBudgetTile
-              objective={objective}
-              loading={loading}
-              success={success}
-              errors={errors}
-              total={total}
-            />
-          </Tiles>
+          <ObjectiveTiles
+            objective={objective}
+            loading={loading}
+            success={success}
+            errors={errors}
+            total={total}
+          />
         </div>
 
         {objective.queries?.graphErrorBudget !== undefined && (

--- a/ui/src/components/create/config.ts
+++ b/ui/src/components/create/config.ts
@@ -1,0 +1,134 @@
+// Form model + YAML generation for the Create SLO editor.
+//
+// The model mirrors the pyrra.dev/v1alpha1 ServiceLevelObjective spec closely
+// enough that buildYaml() emits a config identical to what you'd commit to Git
+// or apply with kubectl. The same YAML is what the (future) preview endpoint
+// feeds back through Pyrra's own Go parsing to materialize a live Objective.
+
+export type SLIType = 'ratio' | 'latency' | 'latencyNative' | 'bool'
+
+export interface LabelRow {
+  k: string
+  v: string
+}
+
+export interface CreateConfig {
+  name: string
+  namespace: string
+  description: string
+  labels: LabelRow[]
+  target: string
+  window: string
+  sliType: SLIType
+  ratio: {errors: string; total: string; grouping: string[]}
+  latency: {success: string; total: string; grouping: string[]}
+  latencyNative: {latency: string; total: string; grouping: string[]}
+  bool: {metric: string; grouping: string[]}
+}
+
+export const DEFAULT_CONFIG: CreateConfig = {
+  name: 'prometheus-api-query',
+  namespace: '',
+  description: 'Pyrra serves the Prometheus API at high availability.',
+  labels: [
+    {k: 'prometheus', v: 'k8s'},
+    {k: 'role', v: 'alert-rules'},
+  ],
+  target: '99.0',
+  window: '7d',
+  sliType: 'ratio',
+  ratio: {
+    errors: 'prometheus_http_requests_total{handler=~"/api.*",code=~"5.."}',
+    total: 'prometheus_http_requests_total{handler=~"/api.*"}',
+    grouping: ['handler'],
+  },
+  latency: {
+    success: 'caddy_http_response_duration_seconds_bucket{job="caddy",handler="subroute",code!~"5..",le="0.05"}',
+    total: 'caddy_http_response_duration_seconds_count{job="caddy",handler="subroute",code!~"5.."}',
+    grouping: [],
+  },
+  latencyNative: {
+    latency: '200ms',
+    total: 'connect_server_requests_duration_seconds{job="pyrra",code="ok"}',
+    grouping: ['service', 'method'],
+  },
+  bool: {
+    metric: 'up{job="prometheus-k8s"}',
+    grouping: ['instance'],
+  },
+}
+
+const groupingFor = (cfg: CreateConfig): string[] => {
+  switch (cfg.sliType) {
+    case 'ratio':
+      return cfg.ratio.grouping
+    case 'latency':
+      return cfg.latency.grouping
+    case 'latencyNative':
+      return cfg.latencyNative.grouping
+    case 'bool':
+      return cfg.bool.grouping
+  }
+}
+
+const yamlValue = (v: string): string => (/[^a-zA-Z0-9_.-]/.test(v) ? `'${v}'` : v)
+
+// Renders the ServiceLevelObjective YAML for the given form config.
+export const buildYaml = (cfg: CreateConfig): string => {
+  const grouping = groupingFor(cfg)
+  const metaLabels = cfg.labels.filter((r) => r.k !== '')
+  const lines: string[] = []
+
+  lines.push('apiVersion: pyrra.dev/v1alpha1')
+  lines.push('kind: ServiceLevelObjective')
+  lines.push('metadata:')
+  lines.push(`  name: ${cfg.name !== '' ? cfg.name : 'unnamed-slo'}`)
+  if (cfg.namespace !== '') {
+    lines.push(`  namespace: ${cfg.namespace}`)
+  }
+  if (metaLabels.length > 0) {
+    lines.push('  labels:')
+    metaLabels.forEach((r) => lines.push(`    ${r.k}: ${yamlValue(r.v)}`))
+  }
+  lines.push('spec:')
+  lines.push(`  target: '${cfg.target}'`)
+  lines.push(`  window: ${cfg.window}`)
+  if (cfg.description !== '') {
+    lines.push(`  description: ${cfg.description}`)
+  }
+  lines.push('  indicator:')
+  switch (cfg.sliType) {
+    case 'ratio':
+      lines.push('    ratio:')
+      lines.push('      errors:')
+      lines.push(`        metric: ${cfg.ratio.errors}`)
+      lines.push('      total:')
+      lines.push(`        metric: ${cfg.ratio.total}`)
+      break
+    case 'latency':
+      lines.push('    latency:')
+      lines.push('      success:')
+      lines.push(`        metric: ${cfg.latency.success}`)
+      lines.push('      total:')
+      lines.push(`        metric: ${cfg.latency.total}`)
+      break
+    case 'latencyNative':
+      lines.push('    latencyNative:')
+      lines.push(`      latency: ${cfg.latencyNative.latency}`)
+      lines.push('      total:')
+      lines.push(`        metric: ${cfg.latencyNative.total}`)
+      break
+    case 'bool':
+      lines.push('    bool_gauge:')
+      lines.push(`      metric: ${cfg.bool.metric}`)
+      break
+  }
+  if (grouping.length > 0) {
+    lines.push('      grouping:')
+    grouping.forEach((g) => lines.push(`        - ${g}`))
+  }
+  return lines.join('\n')
+}
+
+export const yamlFilename = (cfg: CreateConfig): string =>
+  `${cfg.name !== '' ? cfg.name : 'slo'}.yaml`

--- a/ui/src/components/create/editorFields.tsx
+++ b/ui/src/components/create/editorFields.tsx
@@ -1,0 +1,338 @@
+// Editor field components for the Create SLO page:
+//   - Field          label + hint wrapper
+//   - MetricInput     PromQL vector-selector input with Prometheus-style typeahead
+//                     (metric names -> label names in {} -> values after an operator)
+//                     and selector validation.
+//   - GroupingInput   0..n label-name chips with label-name typeahead / free text.
+//   - LabelsEditor    0..n free-form key=value metadata rows.
+//   - WindowControl   free-text duration fused to the 4w/2w/1w/1d preset buttons.
+
+import React, {type ReactNode, useRef, useState} from 'react'
+import {Trash2, Plus} from 'lucide-react'
+import {ToggleGroup, ToggleGroupItem} from '@/components/ui/toggle-group'
+import {cn} from '@/lib/utils'
+import {PYRRA_ALL_LABELS, PYRRA_SELECTOR_RE, suggest, type Suggestion} from './metricsCatalog'
+
+export const inputBase =
+  'w-full rounded-md border border-input bg-background px-3 text-sm text-foreground outline-none transition-all placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50'
+
+interface FieldProps {
+  label: string
+  hint?: string
+  htmlFor?: string
+  children: ReactNode
+}
+
+export const Field = ({label, hint, htmlFor, children}: FieldProps): React.JSX.Element => (
+  <div className="mb-4 last:mb-0">
+    <label className="mb-1.5 block text-sm font-semibold text-foreground" htmlFor={htmlFor}>
+      {label}
+    </label>
+    {hint !== undefined && <p className="mb-2 text-xs leading-snug text-muted-foreground">{hint}</p>}
+    {children}
+  </div>
+)
+
+const typeaheadHead = 'px-2 pt-1.5 pb-1 font-mono text-[10px] font-semibold uppercase tracking-wider text-muted-foreground'
+
+interface TypeaheadProps {
+  mode: string
+  items: string[]
+  active: number
+  onPick: (item: string) => void
+  onHover: (i: number) => void
+}
+
+const Typeahead = ({mode, items, active, onPick, onHover}: TypeaheadProps): React.JSX.Element => (
+  <ul
+    role="listbox"
+    className="absolute left-0 right-0 top-[calc(100%+4px)] z-30 m-0 max-h-60 list-none overflow-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md">
+    <li className={typeaheadHead}>{mode}</li>
+    {items.map((it, i) => (
+      <li
+        key={it}
+        role="option"
+        aria-selected={i === active}
+        className={cn(
+          'cursor-pointer whitespace-nowrap rounded-sm px-2 py-1.5 font-mono text-[13px]',
+          i === active && 'bg-primary text-primary-foreground',
+        )}
+        onMouseDown={(e) => {
+          e.preventDefault()
+          onPick(it)
+        }}
+        onMouseEnter={() => { onHover(i); }}>
+        {it}
+      </li>
+    ))}
+  </ul>
+)
+
+interface MetricInputProps {
+  id?: string
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+}
+
+export const MetricInput = ({id, value, onChange, placeholder}: MetricInputProps): React.JSX.Element => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [open, setOpen] = useState(false)
+  const [sug, setSug] = useState<Suggestion>({mode: '', items: [], replaceStart: 0, replaceEnd: 0})
+  const [active, setActive] = useState(0)
+
+  const valid = PYRRA_SELECTOR_RE.test(value)
+
+  const refresh = (): void => {
+    const el = inputRef.current
+    if (el === null) return
+    const s = suggest(value, el.selectionStart ?? value.length)
+    setSug(s)
+    setActive(0)
+    setOpen(s.items.length > 0)
+  }
+
+  const apply = (item: string): void => {
+    const el = inputRef.current
+    const caret = el !== null ? el.selectionStart ?? value.length : value.length
+    const s = suggest(value, caret)
+    let insert = item
+    if (s.mode === 'value' && s.wrapQuotes === true) insert = `"${item}"`
+    const next = value.slice(0, s.replaceStart) + insert + value.slice(s.replaceEnd)
+    onChange(next)
+    setOpen(false)
+    requestAnimationFrame(() => {
+      if (inputRef.current !== null) {
+        const pos = s.replaceStart + insert.length
+        inputRef.current.focus()
+        inputRef.current.setSelectionRange(pos, pos)
+      }
+    })
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent): void => {
+    if (!open) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActive((a) => Math.min(a + 1, sug.items.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActive((a) => Math.max(a - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (sug.items[active] !== undefined) apply(sug.items[active])
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div className="relative">
+      <div className="relative">
+        <input
+          id={id}
+          ref={inputRef}
+          className={cn(inputBase, 'h-9 font-mono text-[13px]', !valid && 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive/30')}
+          value={value}
+          placeholder={placeholder}
+          spellCheck={false}
+          autoComplete="off"
+          onChange={(e) => {
+            onChange(e.target.value)
+            requestAnimationFrame(refresh)
+          }}
+          onKeyDown={onKeyDown}
+          onKeyUp={(e) => {
+            if (!['ArrowDown', 'ArrowUp', 'Enter', 'Escape'].includes(e.key)) refresh()
+          }}
+          onClick={refresh}
+          onFocus={refresh}
+          onBlur={() => setTimeout(() => { setOpen(false); }, 120)}
+        />
+        {open && (
+          <Typeahead
+            mode={sug.mode}
+            items={sug.items}
+            active={active}
+            onPick={apply}
+            onHover={setActive}
+          />
+        )}
+      </div>
+      {!valid && <p className="mt-1.5 text-xs text-destructive">Only vector-selector characters are allowed.</p>}
+    </div>
+  )
+}
+
+interface GroupingInputProps {
+  value: string[]
+  onChange: (v: string[]) => void
+}
+
+export const GroupingInput = ({value, onChange}: GroupingInputProps): React.JSX.Element => {
+  const [text, setText] = useState('')
+  const [open, setOpen] = useState(false)
+  const [active, setActive] = useState(0)
+
+  const suggestions = PYRRA_ALL_LABELS.filter(
+    (l) => l.toLowerCase().includes(text.toLowerCase()) && !value.includes(l),
+  ).slice(0, 8)
+
+  const add = (label?: string): void => {
+    const v = (label ?? text).replace(/[^a-zA-Z0-9_]/g, '')
+    if (v !== '' && !value.includes(v)) onChange([...value, v])
+    setText('')
+    setOpen(false)
+  }
+  const remove = (label: string): void => { onChange(value.filter((l) => l !== label)); }
+
+  const onKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault()
+      if (open && suggestions[active] !== undefined) add(suggestions[active])
+      else add()
+    } else if (e.key === 'Backspace' && text === '' && value.length > 0) {
+      remove(value[value.length - 1])
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setOpen(true)
+      setActive((a) => Math.min(a + 1, suggestions.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActive((a) => Math.max(a - 1, 0))
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-9 flex-wrap items-center gap-1.5 rounded-md border border-input bg-background px-2 py-1 focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50">
+      {value.map((l) => (
+        <span
+          key={l}
+          className="inline-flex h-6 items-center gap-1 rounded-full bg-secondary pl-2.5 pr-1 font-mono text-xs text-secondary-foreground">
+          {l}
+          <button
+            type="button"
+            className="inline-flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+            onClick={() => { remove(l); }}
+            aria-label={`Remove ${l}`}>
+            ✕
+          </button>
+        </span>
+      ))}
+      <div className="relative min-w-[120px] flex-1">
+        <input
+          className="h-6 w-full border-0 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+          value={text}
+          placeholder={value.length > 0 ? '' : 'group by label…'}
+          spellCheck={false}
+          autoComplete="off"
+          onChange={(e) => {
+            setText(e.target.value)
+            setActive(0)
+            setOpen(true)
+          }}
+          onKeyDown={onKeyDown}
+          onFocus={() => { setOpen(true); }}
+          onBlur={() => setTimeout(() => { setOpen(false); }, 120)}
+        />
+        {open && suggestions.length > 0 && (
+          <Typeahead mode="label" items={suggestions} active={active} onPick={add} onHover={setActive} />
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface LabelsEditorProps {
+  value: Array<{k: string; v: string}>
+  onChange: (v: Array<{k: string; v: string}>) => void
+}
+
+export const LabelsEditor = ({value, onChange}: LabelsEditorProps): React.JSX.Element => {
+  const update = (i: number, key: 'k' | 'v', val: string): void => {
+    onChange(value.map((row, idx) => (idx === i ? {...row, [key]: val} : row)))
+  }
+  const add = (): void => { onChange([...value, {k: '', v: ''}]); }
+  const remove = (i: number): void => { onChange(value.filter((_, idx) => idx !== i)); }
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      {value.map((row, i) => (
+        <div key={i} className="grid w-full grid-cols-[1fr_16px_1fr_32px] items-center gap-2">
+          <input
+            className={cn(inputBase, 'h-8')}
+            placeholder="key"
+            value={row.k}
+            spellCheck={false}
+            autoComplete="off"
+            onChange={(e) => { update(i, 'k', e.target.value.replace(/[^a-zA-Z0-9_./-]/g, '')); }}
+          />
+          <span className="text-center text-muted-foreground">=</span>
+          <input
+            className={cn(inputBase, 'h-8')}
+            placeholder="value"
+            value={row.v}
+            spellCheck={false}
+            autoComplete="off"
+            onChange={(e) => { update(i, 'v', e.target.value); }}
+          />
+          <button
+            type="button"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+            onClick={() => { remove(i); }}
+            aria-label="Remove label">
+            <Trash2 size={16} />
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        className="inline-flex h-[30px] items-center gap-1.5 rounded-md border border-dashed border-border px-2.5 text-sm font-medium text-muted-foreground hover:border-muted-foreground hover:text-foreground"
+        onClick={add}>
+        <Plus size={14} /> Add label
+      </button>
+    </div>
+  )
+}
+
+interface WindowControlProps {
+  value: string
+  onChange: (v: string) => void
+}
+
+export const WindowControl = ({value, onChange}: WindowControlProps): React.JSX.Element => {
+  const presets = ['4w', '2w', '1w', '1d']
+  const isPreset = presets.includes(value)
+  return (
+    <div className="inline-flex items-center">
+      <input
+        className="z-10 h-8 w-14 rounded-l-lg rounded-r-none border border-r-0 border-input bg-muted/50 px-2.5 font-mono text-[13px] font-medium text-foreground shadow-inner outline-none transition-all placeholder:font-sans placeholder:text-muted-foreground focus-visible:z-20 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        value={isPreset ? '' : value}
+        placeholder="2w"
+        aria-label="Custom window"
+        spellCheck={false}
+        autoComplete="off"
+        onChange={(e) => { onChange(e.target.value.replace(/[^a-zA-Z0-9]/g, '')); }}
+      />
+      <ToggleGroup
+        variant="outline"
+        value={isPreset ? [value] : []}
+        onValueChange={(val) => {
+          if (val.length > 0) onChange(val[val.length - 1])
+        }}>
+        {presets.map((w, i) => (
+          <ToggleGroupItem
+            key={w}
+            value={w}
+            variant="outline"
+            aria-label={w}
+            className={i === 0 ? 'rounded-l-none!' : undefined}>
+            {w}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  )
+}

--- a/ui/src/components/create/metricsCatalog.ts
+++ b/ui/src/components/create/metricsCatalog.ts
@@ -1,0 +1,126 @@
+// Prometheus-style metric catalog + autocomplete engine for the Create SLO editor.
+// Suggests metric names, then label names inside {}, then label values after an
+// operator — the same three contexts Prometheus' own typeahead handles. An SLI
+// metric field is a single vector selector, so there are no functions/aggregations.
+//
+// The catalog is static for now. It is shaped so a live source (Prometheus label
+// names/values via the PrometheusService) can replace it later without touching
+// the suggestion logic below.
+
+export type MetricCatalog = Record<string, Record<string, string[]>>
+
+export const PYRRA_CATALOG: MetricCatalog = {
+  prometheus_http_requests_total: {
+    handler: ['/api/v1/query', '/api/v1/query_range', '/api/v1/labels', '/metrics', '/graph', '/-/healthy'],
+    code: ['200', '400', '422', '499', '500', '503'],
+    job: ['prometheus-k8s', 'prometheus'],
+  },
+  caddy_http_response_duration_seconds_bucket: {
+    job: ['caddy'],
+    handler: ['subroute', 'file_server', 'reverse_proxy'],
+    code: ['200', '204', '301', '404', '500', '502'],
+    le: ['0.005', '0.01', '0.025', '0.05', '0.1', '0.25', '0.5', '1', '2.5', '5', '10'],
+  },
+  caddy_http_response_duration_seconds_count: {
+    job: ['caddy'],
+    handler: ['subroute', 'file_server', 'reverse_proxy'],
+    code: ['200', '204', '301', '404', '500', '502'],
+  },
+  connect_server_requests_duration_seconds: {
+    job: ['pyrra'],
+    service: ['objectives.v1alpha1.ObjectiveService', 'prometheus.v1.PrometheusService'],
+    method: ['List', 'GetStatus', 'GetAlerts', 'Query', 'QueryRange'],
+    code: ['ok', 'internal', 'unavailable', 'not_found'],
+  },
+  http_requests_total: {
+    job: ['gateway', 'checkout', 'grafana', 'api'],
+    namespace: ['production', 'monitoring', 'kube-system'],
+    code: ['200', '201', '301', '400', '404', '500', '502', '503'],
+    method: ['GET', 'POST', 'PUT', 'DELETE'],
+    handler: ['/', '/checkout', '/login', '/api/v1'],
+  },
+  apiserver_request_total: {
+    verb: ['GET', 'LIST', 'POST', 'PUT', 'PATCH', 'DELETE', 'WATCH'],
+    code: ['200', '201', '403', '404', '409', '500', '503'],
+    resource: ['pods', 'services', 'configmaps', 'secrets', 'deployments'],
+    namespace: ['monitoring', 'kube-system', 'default'],
+  },
+  coredns_dns_responses_total: {
+    job: ['coredns'],
+    rcode: ['NOERROR', 'NXDOMAIN', 'SERVFAIL', 'REFUSED'],
+    zone: ['.', 'cluster.local.'],
+  },
+}
+
+export const PYRRA_ALL_LABELS: string[] = (() => {
+  const s = new Set<string>()
+  Object.values(PYRRA_CATALOG).forEach((m) => { Object.keys(m).forEach((k) => s.add(k)); })
+  return [...s].sort((a, b) => a.localeCompare(b))
+})()
+
+// Characters legal inside a vector selector (metric name + label matchers).
+export const PYRRA_SELECTOR_RE = /^[a-zA-Z0-9_:{}[\]=!~"'`,.\s|/()*+-]*$/
+
+export const metricName = (text: string): string => {
+  const m = text.match(/^\s*([a-zA-Z_:][a-zA-Z0-9_:]*)/)
+  return m !== null ? m[1] : ''
+}
+
+export type SuggestMode = 'metric' | 'label' | 'value' | ''
+
+export interface Suggestion {
+  mode: SuggestMode
+  items: string[]
+  replaceStart: number
+  replaceEnd: number
+  wrapQuotes?: boolean
+}
+
+// Returns the suggestion context for the caret position within a selector.
+export const suggest = (text: string, caret: number, catalog: MetricCatalog = PYRRA_CATALOG): Suggestion => {
+  const before = text.slice(0, caret)
+  const braceOpen = before.lastIndexOf('{')
+  const braceClose = before.lastIndexOf('}')
+  const inBraces = braceOpen > braceClose
+
+  if (!inBraces) {
+    // metric-name context (before any brace)
+    const tok = (before.match(/[a-zA-Z0-9_:]*$/) ?? [''])[0]
+    const items = Object.keys(catalog)
+      .filter((n) => n.toLowerCase().includes(tok.toLowerCase()) && n !== tok)
+      .slice(0, 8)
+    return {mode: 'metric', items, replaceStart: caret - tok.length, replaceEnd: caret}
+  }
+
+  const metric = metricName(text)
+  const labels = catalog[metric] ?? {}
+  const segStart = Math.max(braceOpen, before.lastIndexOf(',')) + 1
+  const seg = before.slice(segStart)
+  const op = seg.match(/(=~|!=|!~|=)/)
+
+  if (op?.index !== undefined) {
+    // value context
+    const labelName = seg.slice(0, op.index).trim()
+    const rawVal = seg.slice(op.index + op[0].length)
+    const hasQuote = /^\s*"/.test(rawVal)
+    const valTok = rawVal.replace(/^\s*"?/, '')
+    const values = labels[labelName] ?? []
+    const items = values
+      .filter((v) => v.toLowerCase().includes(valTok.toLowerCase()) && v !== valTok)
+      .slice(0, 8)
+    return {
+      mode: 'value',
+      items,
+      replaceStart: caret - valTok.length,
+      replaceEnd: caret,
+      wrapQuotes: !hasQuote,
+    }
+  }
+
+  // label-name context
+  const labelTok = seg.trim()
+  const items = Object.keys(labels)
+    .filter((l) => l.toLowerCase().includes(labelTok.toLowerCase()) && l !== labelTok)
+    .slice(0, 8)
+  return {mode: 'label', items, replaceStart: caret - labelTok.length, replaceEnd: caret}
+}

--- a/ui/src/components/create/preview.ts
+++ b/ui/src/components/create/preview.ts
@@ -1,0 +1,29 @@
+// Backend seam for the live Create-SLO preview.
+//
+// previewObjective() materializes a draft SLO (as YAML) into a live Objective by
+// running it through Pyrra's own Go parsing on the backend, so the preview renders
+// exactly as a stored SLO would — same queries, same tiles, same graphs against
+// real Prometheus data.
+//
+// The backend `Preview` endpoint is not wired up yet. Until it lands this throws
+// PreviewUnavailableError and the editor falls back to the (fully live) YAML view.
+// When the endpoint exists, implement the call here and the DetailPreview lights up
+// with no further changes to the page.
+
+import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
+
+export type PreviewStatus = 'idle' | 'loading' | 'success' | 'unavailable' | 'error'
+
+export class PreviewUnavailableError extends Error {
+  constructor(message = 'preview backend not available yet') {
+    super(message)
+    this.name = 'PreviewUnavailableError'
+  }
+}
+
+export async function previewObjective(_baseUrl: string, _config: string): Promise<Objective> {
+  // TODO(backend): POST the YAML to the Preview endpoint, which parses it via
+  // ServiceLevelObjective.Internal() + FromInternal() and fills in the queries
+  // (the same path as ObjectiveService.List), then return the materialized Objective.
+  throw new PreviewUnavailableError()
+}

--- a/ui/src/components/tiles/ObjectiveTiles.tsx
+++ b/ui/src/components/tiles/ObjectiveTiles.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import Tiles from './Tiles'
+import ObjectiveTile from './ObjectiveTile'
+import AvailabilityTile from './AvailabilityTile'
+import ErrorBudgetTile from './ErrorBudgetTile'
+import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
+
+interface ObjectiveTilesProps {
+  objective: Objective
+  loading: boolean
+  success: boolean
+  errors: number | undefined
+  total: number | undefined
+}
+
+// The three headline tiles (Objective / Availability / Error Budget) shared by the
+// SLO detail page and the Create-SLO preview. Each caller wraps it in its own layout.
+const ObjectiveTiles = ({
+  objective,
+  loading,
+  success,
+  errors,
+  total,
+}: ObjectiveTilesProps): React.JSX.Element => (
+  <Tiles>
+    <ObjectiveTile objective={objective} />
+    <AvailabilityTile
+      objective={objective}
+      loading={loading}
+      success={success}
+      errors={errors}
+      total={total}
+    />
+    <ErrorBudgetTile
+      objective={objective}
+      loading={loading}
+      success={success}
+      errors={errors}
+      total={total}
+    />
+  </Tiles>
+)
+
+export default ObjectiveTiles

--- a/ui/src/pages/Create.tsx
+++ b/ui/src/pages/Create.tsx
@@ -1,0 +1,341 @@
+// Create SLO — split editor / live preview page.
+//
+// Left:  the SLO editor (metadata, labels, target, window, SLI-type tabs with a
+//        PromQL typeahead metric field + grouping).
+// Right: a live Preview of the Detail page, materialized by the backend from the
+//        same YAML this form produces — or the YAML config itself.
+//
+// The YAML view is always live. The Detail view is rendered from the backend
+// preview (see ../components/create/preview.ts); until that endpoint is wired it
+// shows an "unavailable" state and the YAML view carries the workflow.
+
+import {useMemo, useState, type JSX} from 'react'
+import {Link} from 'react-router-dom'
+import {Check, Copy, Download, Play, RefreshCw} from 'lucide-react'
+import {Button} from '@/components/ui/button'
+import {ToggleGroup, ToggleGroupItem} from '@/components/ui/toggle-group'
+import {cn} from '@/lib/utils'
+import {API_BASEPATH} from '../App'
+import Navbar from '../components/Navbar'
+import {Field, MetricInput, GroupingInput, LabelsEditor, WindowControl, inputBase} from '../components/create/editorFields'
+import {DEFAULT_CONFIG, buildYaml, yamlFilename, type CreateConfig, type SLIType} from '../components/create/config'
+import {previewObjective, PreviewUnavailableError, type PreviewStatus} from '../components/create/preview'
+import DetailPreview from '../components/create/DetailPreview'
+import {type Objective} from '../proto/objectives/v1alpha1/objectives_pb'
+
+const sliTabs: Array<{value: SLIType; label: string}> = [
+  {value: 'ratio', label: 'Ratio'},
+  {value: 'latency', label: 'Latency'},
+  {value: 'latencyNative', label: 'Latency (native)'},
+  {value: 'bool', label: 'Bool'},
+]
+
+const Create = (): JSX.Element => {
+  document.title = 'Create SLO - Pyrra'
+  const baseUrl = API_BASEPATH ?? 'http://localhost:9099'
+
+  const [cfg, setCfg] = useState<CreateConfig>(DEFAULT_CONFIG)
+  const [rightView, setRightView] = useState<'detail' | 'yaml'>('yaml')
+  const [preview, setPreview] = useState<{objective: Objective; snap: string} | null>(null)
+  const [previewStatus, setPreviewStatus] = useState<PreviewStatus>('idle')
+  const [copied, setCopied] = useState(false)
+
+  const set = (patch: Partial<CreateConfig>): void => { setCfg((c) => ({...c, ...patch})); }
+  const setInd = <K extends SLIType>(
+    ind: K,
+    patch: Partial<CreateConfig[K]>,
+  ): void => { setCfg((c) => ({...c, [ind]: {...c[ind], ...patch}})); }
+
+  const yaml = useMemo(() => buildYaml(cfg), [cfg])
+  const snapshot = useMemo(() => JSON.stringify(cfg), [cfg])
+  const stale = preview !== null && preview.snap !== snapshot
+
+  const runPreview = (): void => {
+    setPreviewStatus('loading')
+    setRightView('detail')
+    previewObjective(baseUrl, yaml)
+      .then((objective) => {
+        setPreview({objective, snap: snapshot})
+        setPreviewStatus('success')
+      })
+      .catch((err) => {
+        setPreviewStatus(err instanceof PreviewUnavailableError ? 'unavailable' : 'error')
+      })
+  }
+
+  const copyYaml = (): void => {
+    if (navigator.clipboard !== undefined) {
+      void navigator.clipboard.writeText(yaml)
+      setCopied(true)
+      setTimeout(() => { setCopied(false); }, 1500)
+    }
+  }
+
+  const downloadYaml = (): void => {
+    const blob = new Blob([`${yaml}\n`], {type: 'application/yaml'})
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = yamlFilename(cfg)
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const createSlo = (): void => {
+    setRightView('yaml')
+    copyYaml()
+    downloadYaml()
+  }
+
+  return (
+    <div className="flex flex-col lg:h-screen lg:overflow-hidden">
+      <Navbar>
+        <div>
+          <Link to="/">Objectives</Link> &gt; <span>Create SLO</span>
+        </div>
+      </Navbar>
+
+      <div className="grid grid-cols-1 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(420px,1fr)_1fr]">
+        {/* ---------------- EDITOR ---------------- */}
+        <div className="border-b border-border bg-background lg:min-h-0 lg:overflow-auto lg:border-b-0 lg:border-r">
+          <div className="mx-auto max-w-2xl px-8 pt-7 pb-16">
+            <h3 className="mb-6">Create SLO</h3>
+
+            <section className="border-border py-5">
+              <Field label="Name" htmlFor="slo-name" hint="Unique objective name. Lowercase letters, numbers and dashes.">
+                <input
+                  id="slo-name"
+                  className={cn(inputBase, 'h-9')}
+                  value={cfg.name}
+                  spellCheck={false}
+                  autoComplete="off"
+                  onChange={(e) => { set({name: e.target.value.replace(/[^a-zA-Z0-9-]/g, '')}); }}
+                />
+              </Field>
+
+              <Field label="Labels" hint="Free-form key=value pairs attached to the objective.">
+                <LabelsEditor value={cfg.labels} onChange={(labels) => { set({labels}); }} />
+              </Field>
+
+              <div className="grid grid-cols-1 gap-5 sm:grid-cols-[160px_1fr]">
+                <Field label="Target" htmlFor="slo-target" hint="As a percentage.">
+                  <div className="relative">
+                    <input
+                      id="slo-target"
+                      className={cn(inputBase, 'h-9 pr-7')}
+                      value={cfg.target}
+                      inputMode="decimal"
+                      onChange={(e) => { set({target: e.target.value.replace(/[^0-9.]/g, '')}); }}
+                    />
+                    <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                      %
+                    </span>
+                  </div>
+                </Field>
+                <Field label="Window" htmlFor="slo-window" hint="Pick a preset or type a custom duration.">
+                  <WindowControl value={cfg.window} onChange={(window) => { set({window}); }} />
+                </Field>
+              </div>
+
+              <Field label="Description" htmlFor="slo-desc" hint="Optional. Shown on the objective's detail page.">
+                <textarea
+                  id="slo-desc"
+                  className={cn(inputBase, 'min-h-16 resize-y py-2.5 leading-relaxed')}
+                  rows={2}
+                  value={cfg.description}
+                  onChange={(e) => { set({description: e.target.value}); }}
+                />
+              </Field>
+            </section>
+
+            <section className="border-t border-border py-5">
+              <h4 className="mb-3 text-lg">Service Level Indicator</h4>
+              <ToggleGroup
+                variant="outline"
+                className="mb-4 flex-wrap"
+                value={[cfg.sliType]}
+                onValueChange={(val) => {
+                  if (val.length > 0) set({sliType: val[val.length - 1] as SLIType})
+                }}>
+                {sliTabs.map((t) => (
+                  <ToggleGroupItem key={t.value} value={t.value} variant="outline" aria-label={t.label}>
+                    {t.label}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+
+              {cfg.sliType === 'ratio' && (
+                <>
+                  <Field label="Errors metric" hint="Vector selector counting failed events.">
+                    <MetricInput
+                      id="m-errors"
+                      value={cfg.ratio.errors}
+                      onChange={(v) => { setInd('ratio', {errors: v}); }}
+                      placeholder={'metric{code=~"5.."}'}
+                    />
+                  </Field>
+                  <Field label="Total metric" hint="Vector selector counting all events.">
+                    <MetricInput
+                      id="m-total"
+                      value={cfg.ratio.total}
+                      onChange={(v) => { setInd('ratio', {total: v}); }}
+                      placeholder="metric{}"
+                    />
+                  </Field>
+                  <Field label="Group by" hint="Split the SLO by these label names.">
+                    <GroupingInput value={cfg.ratio.grouping} onChange={(g) => { setInd('ratio', {grouping: g}); }} />
+                  </Field>
+                </>
+              )}
+
+              {cfg.sliType === 'latency' && (
+                <>
+                  <Field label="Success metric" hint="Histogram bucket of requests within the latency target (le=…).">
+                    <MetricInput
+                      id="m-success"
+                      value={cfg.latency.success}
+                      onChange={(v) => { setInd('latency', {success: v}); }}
+                      placeholder={'metric_bucket{le="0.05"}'}
+                    />
+                  </Field>
+                  <Field label="Total metric" hint="The _count series for the same requests.">
+                    <MetricInput
+                      id="m-ltotal"
+                      value={cfg.latency.total}
+                      onChange={(v) => { setInd('latency', {total: v}); }}
+                      placeholder="metric_count{}"
+                    />
+                  </Field>
+                  <Field label="Group by">
+                    <GroupingInput value={cfg.latency.grouping} onChange={(g) => { setInd('latency', {grouping: g}); }} />
+                  </Field>
+                </>
+              )}
+
+              {cfg.sliType === 'latencyNative' && (
+                <>
+                  <Field label="Latency target" hint="Native (exponential) histogram threshold, e.g. 200ms.">
+                    <input
+                      className={cn(inputBase, 'h-9 w-32 font-mono text-[13px]')}
+                      value={cfg.latencyNative.latency}
+                      spellCheck={false}
+                      autoComplete="off"
+                      onChange={(e) => { setInd('latencyNative', {latency: e.target.value}); }}
+                    />
+                  </Field>
+                  <Field label="Total metric" hint="Native histogram series.">
+                    <MetricInput
+                      id="m-ntotal"
+                      value={cfg.latencyNative.total}
+                      onChange={(v) => { setInd('latencyNative', {total: v}); }}
+                      placeholder="metric{}"
+                    />
+                  </Field>
+                  <Field label="Group by">
+                    <GroupingInput
+                      value={cfg.latencyNative.grouping}
+                      onChange={(g) => { setInd('latencyNative', {grouping: g}); }}
+                    />
+                  </Field>
+                </>
+              )}
+
+              {cfg.sliType === 'bool' && (
+                <>
+                  <Field label="Bool gauge metric" hint="A 0/1 gauge; target is the share of time it is 1.">
+                    <MetricInput
+                      id="m-bool"
+                      value={cfg.bool.metric}
+                      onChange={(v) => { setInd('bool', {metric: v}); }}
+                      placeholder={'up{job="…"}'}
+                    />
+                  </Field>
+                  <Field label="Group by">
+                    <GroupingInput value={cfg.bool.grouping} onChange={(g) => { setInd('bool', {grouping: g}); }} />
+                  </Field>
+                </>
+              )}
+            </section>
+
+            <div className="mt-6 flex justify-end gap-2.5 border-t border-border pt-5">
+              <Button
+                variant="outline"
+                onClick={runPreview}
+                className={cn((stale || preview === null) && 'ring-2 ring-primary/30')}>
+                <Play /> Preview
+              </Button>
+              <Button onClick={createSlo}>
+                <Check /> Create SLO
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {/* ---------------- PREVIEW ---------------- */}
+        <div className="bg-muted/35 lg:min-h-0 lg:overflow-auto">
+          <div className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-border bg-muted/35 px-5 py-3 backdrop-blur">
+            <div className="flex min-w-0 items-baseline gap-2.5">
+              <span className="font-mono text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                Preview
+              </span>
+              {preview !== null && (
+                <span className="truncate font-mono text-[13px] text-foreground">{preview.objective.labels.__name__ ?? cfg.name}</span>
+              )}
+            </div>
+            <div className="flex items-center gap-3">
+              {stale && (
+                <button
+                  className="inline-flex h-7 items-center gap-1.5 rounded-md border border-warning/50 bg-warning/15 px-2.5 text-xs font-medium text-warning-foreground"
+                  onClick={runPreview}>
+                  <RefreshCw size={13} /> Editor changed — re-run
+                </button>
+              )}
+              <ToggleGroup
+                variant="outline"
+                value={[rightView]}
+                onValueChange={(val) => {
+                  if (val.length > 0) setRightView(val[val.length - 1] as 'detail' | 'yaml')
+                }}>
+                <ToggleGroupItem value="detail" variant="outline" aria-label="Detail">
+                  Detail
+                </ToggleGroupItem>
+                <ToggleGroupItem value="yaml" variant="outline" aria-label="YAML">
+                  YAML
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+          </div>
+
+          {rightView === 'yaml' ? (
+            <div className="m-6 overflow-hidden rounded-md border border-border bg-popover">
+              <div className="flex items-center justify-between border-b border-border px-4 py-2">
+                <span className="font-mono text-xs text-muted-foreground">{yamlFilename(cfg)}</span>
+                <div className="flex gap-1">
+                  <Button size="sm" variant="ghost" onClick={copyYaml}>
+                    {copied ? <Check /> : <Copy />} {copied ? 'Copied' : 'Copy'}
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={downloadYaml}>
+                    <Download /> Download
+                  </Button>
+                </div>
+              </div>
+              <pre className="overflow-auto bg-transparent p-5 font-mono text-[13px] leading-relaxed">
+                <code>{yaml}</code>
+              </pre>
+            </div>
+          ) : (
+            <DetailPreview
+              baseUrl={baseUrl}
+              objective={preview?.objective ?? null}
+              status={previewStatus}
+              stale={stale}
+              onRun={runPreview}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Create

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -1,7 +1,6 @@
 import {Link} from 'react-router-dom'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {useQueryState, parseAsString} from 'nuqs'
-import {Badge} from '@/components/ui/badge'
 import {Spinner} from '@/components/ui/spinner'
 import {ToggleGroup, ToggleGroupItem} from '@/components/ui/toggle-group'
 import {cn} from '@/lib/utils'
@@ -19,15 +18,13 @@ import Toggle from '../components/Toggle'
 import DurationGraph from '../components/graphs/DurationGraph'
 import type uPlot from 'uplot'
 import {PrometheusService} from '../proto/prometheus/v1/prometheus_pb'
-import {replaceInterval, usePrometheusQuery} from '../prometheus'
+import {replaceInterval, usePrometheusQuery, vectorErrorsTotal} from '../prometheus'
 import {useObjectivesList} from '../objectives'
 import {type Objective} from '../proto/objectives/v1alpha1/objectives_pb'
 import {formatDuration, parseDuration} from '../duration'
 import {computeTimeRangePresets} from '../timeRangePresets'
-import ObjectiveTile from '../components/tiles/ObjectiveTile'
-import AvailabilityTile from '../components/tiles/AvailabilityTile'
-import ErrorBudgetTile from '../components/tiles/ErrorBudgetTile'
-import Tiles from '../components/tiles/Tiles'
+import ObjectiveTiles from '../components/tiles/ObjectiveTiles'
+import ObjectiveLabels from '../components/ObjectiveLabels'
 import {ChartArea, ChartLine, CornerDownLeft} from 'lucide-react'
 
 const Detail = () => {
@@ -197,25 +194,11 @@ const Detail = () => {
 
   const success: boolean = totalStatus === 'success' && errorStatus === 'success'
 
-  let errors: number = 0
-  let total: number = 1
-  if (totalResponse?.options.case === 'vector' && errorResponse?.options.case === 'vector') {
-    if (errorResponse.options.value.samples.length > 0) {
-      errors = errorResponse.options.value.samples[0].value
-    }
+  const {errors, total} = vectorErrorsTotal(totalResponse, errorResponse)
 
-    if (totalResponse.options.value.samples.length > 0) {
-      total = totalResponse.options.value.samples[0].value
-    }
-  }
-
-  const labelBadges = Object.entries({...objective.labels, ...groupingLabels})
-    .filter((l: [string, string]) => l[0] !== MetricName)
-    .map((l: [string, string]) => (
-      <Badge key={l[0]} variant="secondary" className="mr-1 font-normal">
-        {l[0]}={l[1]}
-      </Badge>
-    ))
+  const hasLabels = Object.keys({...objective.labels, ...groupingLabels}).some(
+    (k) => k !== MetricName,
+  )
 
   const uPlotCursor: uPlot.Cursor = {
     y: false,
@@ -238,12 +221,12 @@ const Detail = () => {
           <div className="mb-24 flex flex-wrap">
             <div className="w-full 3xl:w-10/12 3xl:mx-auto">
               <h3>{name}</h3>
-              {labelBadges}
+              <ObjectiveLabels labels={objective.labels} grouping={groupingLabels} />
             </div>
             {objective.description !== undefined && objective.description !== '' ? (
               <div
                 className="w-full md:w-1/2 3xl:w-5/12 3xl:ml-[8.33%]"
-                style={{marginTop: labelBadges.length > 0 ? 12 : 0}}>
+                style={{marginTop: hasLabels ? 12 : 0}}>
                 <p>{objective.description}</p>
               </div>
             ) : (
@@ -252,23 +235,13 @@ const Detail = () => {
           </div>
           <div className="mb-24 flex flex-wrap">
             <div className="w-full 3xl:w-10/12 3xl:mx-auto">
-              <Tiles>
-                <ObjectiveTile objective={objective} />
-                <AvailabilityTile
-                  objective={objective}
-                  loading={loading}
-                  success={success}
-                  errors={errors}
-                  total={total}
-                />
-                <ErrorBudgetTile
-                  objective={objective}
-                  loading={loading}
-                  success={success}
-                  errors={errors}
-                  total={total}
-                />
-              </Tiles>
+              <ObjectiveTiles
+                objective={objective}
+                loading={loading}
+                success={success}
+                errors={errors}
+                total={total}
+              />
             </div>
           </div>
           <div className="mb-24 flex flex-wrap">

--- a/ui/src/pages/List.tsx
+++ b/ui/src/pages/List.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useMemo, useReducer, useState} from 'react'
 import {API_BASEPATH, latencyTarget} from '../App'
-import {useNavigate} from 'react-router-dom'
+import {useNavigate, Link} from 'react-router-dom'
 import {useQueryState, parseAsString} from 'nuqs'
 import Navbar from '../components/Navbar'
 import {type Labels, labelsString, MetricName} from '../labels'
@@ -32,8 +32,9 @@ import {
 } from '@tanstack/react-table'
 import {type Duration} from '@bufbuild/protobuf/wkt'
 import {useObjectivesList} from '../objectives'
-import {ArrowDown, ArrowUp, ArrowUpDown, ChevronDown, Columns2, Search, TriangleAlert} from 'lucide-react'
+import {ArrowDown, ArrowUp, ArrowUpDown, ChevronDown, Columns2, Plus, Search, TriangleAlert} from 'lucide-react'
 import {Badge} from '@/components/ui/badge'
+import {buttonVariants} from '@/components/ui/button'
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip'
 import {Alert, AlertDescription, AlertTitle} from '@/components/ui/alert'
 import {Spinner} from '@/components/ui/spinner'
@@ -716,7 +717,10 @@ const List = () => {
               </Alert>
             )}
           </div>
-          <div className="my-2 order-1 md:w-1/2 lg:order-2 lg:w-auto text-right">
+          <div className="my-2 order-1 flex items-center justify-end gap-2 md:w-1/2 lg:order-2 lg:w-auto">
+            <Link to="/objectives/create" className={cn(buttonVariants(), 'no-underline')}>
+              <Plus /> Create SLO
+            </Link>
             <DropdownMenu>
               <DropdownMenuTrigger
                 className="inline-flex shrink-0 items-center justify-center rounded-md border border-border bg-background px-2.5 py-1 text-sm font-medium hover:bg-muted">

--- a/ui/src/prometheus.tsx
+++ b/ui/src/prometheus.tsx
@@ -85,3 +85,22 @@ export const replaceInterval = (query: string, from: number, to: number): string
 
   return query.replaceAll(/\[(1s)\]/g, `[${rateIntervalStr}]`)
 }
+
+// vectorErrorsTotal pulls the errors/total sample values out of two instant-vector
+// query responses. total defaults to 1 so callers can divide without guarding.
+export const vectorErrorsTotal = (
+  totalResponse: QueryResponse | null,
+  errorResponse: QueryResponse | null,
+): {errors: number; total: number} => {
+  let errors = 0
+  let total = 1
+  if (totalResponse?.options.case === 'vector' && errorResponse?.options.case === 'vector') {
+    if (errorResponse.options.value.samples.length > 0) {
+      errors = errorResponse.options.value.samples[0].value
+    }
+    if (totalResponse.options.value.samples.length > 0) {
+      total = totalResponse.options.value.samples[0].value
+    }
+  }
+  return {errors, total}
+}


### PR DESCRIPTION
The editor writes the YAML you would otherwise hand-write, with a live view of it next to the form. The preview pane is inert until the Preview RPC lands in the PR above this one, so what is here is the form, the YAML view and the routing.

Paths below /objectives now render the UI too. Without that the new page returns a bare 404 on reload or when linked to directly.
