### PR TITLE
refactor(ui): extract the detail view into composable parts

### DIFF
--- a/ui/src/components/detail/ObjectiveDetail.tsx
+++ b/ui/src/components/detail/ObjectiveDetail.tsx
@@ -1,0 +1,317 @@
+// The SLO detail view, as a set of parts both consumers compose themselves.
+//
+// The stored-SLO page (pages/Detail.tsx) and the Create editor's live preview
+// (components/create/DetailPreview.tsx) render the same objective in the same
+// way, but not the same *set* of things: only the stored page has a time range
+// to control, alerting rules to evaluate, or a config to show. That used to be
+// two parallel implementations of the same markup, which drifted.
+//
+// So instead of one component with flags for what to leave out, each page
+// composes the parts it actually has. Everything the parts share — the
+// objective, the clients, the time range — comes from the context; anything
+// only one part needs is a prop.
+
+import React, {createContext, use, type JSX, type ReactNode} from 'react'
+import {type Client} from '@connectrpc/connect'
+import type uPlot from 'uplot'
+import {cn} from '@/lib/utils'
+import {latencyTarget, ObjectiveType} from '../../App'
+import {type Labels, labelsString, MetricName} from '../../labels'
+import {
+  type Objective,
+  type ObjectiveService,
+} from '../../proto/objectives/v1alpha1/objectives_pb'
+import {type PrometheusService} from '../../proto/prometheus/v1/prometheus_pb'
+import {replaceInterval, usePrometheusQuery, vectorErrorsTotal} from '../../prometheus'
+import {useGraphDuration, usePreviewGraphDuration} from '../../objectives'
+import ObjectiveTiles from '../tiles/ObjectiveTiles'
+import ObjectiveLabels from '../ObjectiveLabels'
+import ErrorBudgetGraph from '../graphs/ErrorBudgetGraph'
+import RequestsGraph from '../graphs/RequestsGraph'
+import ErrorsGraph from '../graphs/ErrorsGraph'
+import DurationGraph from '../graphs/DurationGraph'
+import AlertsTable from '../AlertsTable'
+
+export interface ObjectiveDetailValue {
+  // Guaranteed non-null with labels defined — both consumers hold their spinner
+  // and empty states until it is.
+  objective: Objective
+  objectiveType: ObjectiveType
+  promClient: Client<typeof PrometheusService>
+  // The grouping label set this view is scoped to, empty when unscoped.
+  grouping: Labels
+  from: number
+  to: number
+  absolute: boolean
+  // Carries the page's cursor sync key. Required rather than defaulted: two
+  // views sharing a key would drag each other's crosshairs around.
+  uPlotCursor: uPlot.Cursor
+  updateTimeRange: (min: number, max: number, absolute: boolean) => void
+}
+
+const ObjectiveDetailContext = createContext<ObjectiveDetailValue | null>(null)
+
+const useObjectiveDetail = (): ObjectiveDetailValue => {
+  const value = use(ObjectiveDetailContext)
+  if (value === null) {
+    throw new Error('ObjectiveDetail parts must be rendered inside <ObjectiveDetail.Provider>')
+  }
+  return value
+}
+
+const Provider = ({
+  value,
+  children,
+}: {
+  value: ObjectiveDetailValue
+  children: ReactNode
+}): JSX.Element => <ObjectiveDetailContext value={value}>{children}</ObjectiveDetailContext>
+
+const Header = (): JSX.Element => {
+  const {objective, grouping} = useObjectiveDetail()
+
+  const name = objective.labels[MetricName]
+  const hasLabels = Object.keys({...objective.labels, ...grouping}).some((k) => k !== MetricName)
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full 3xl:w-10/12 3xl:mx-auto">
+        <h3>{name}</h3>
+        <ObjectiveLabels labels={objective.labels} grouping={grouping} />
+      </div>
+      {objective.description !== undefined && objective.description !== '' ? (
+        <div
+          className="w-full md:w-1/2 3xl:w-5/12 3xl:ml-[8.33%]"
+          style={{marginTop: hasLabels ? 12 : 0}}>
+          <p>{objective.description}</p>
+        </div>
+      ) : (
+        <></>
+      )}
+    </div>
+  )
+}
+
+const Tiles = (): JSX.Element => {
+  const {objective, promClient, to} = useObjectiveDetail()
+
+  const countTotal = objective.queries?.countTotal ?? ''
+  const countErrors = objective.queries?.countErrors ?? ''
+
+  const {response: totalResponse, status: totalStatus} = usePrometheusQuery(
+    promClient,
+    countTotal,
+    to / 1000,
+    {enabled: countTotal !== ''},
+  )
+
+  const {response: errorResponse, status: errorStatus} = usePrometheusQuery(
+    promClient,
+    countErrors,
+    to / 1000,
+    {enabled: countTotal !== ''},
+  )
+
+  const loading: boolean = totalStatus === 'pending' || errorStatus === 'pending'
+  const success: boolean = totalStatus === 'success' && errorStatus === 'success'
+
+  const {errors, total} = vectorErrorsTotal(totalResponse, errorResponse)
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full 3xl:w-10/12 3xl:mx-auto">
+        <ObjectiveTiles
+          objective={objective}
+          loading={loading}
+          success={success}
+          errors={errors}
+          total={total}
+        />
+      </div>
+    </div>
+  )
+}
+
+const ErrorBudget = (): JSX.Element => {
+  const {objective, promClient, from, to, uPlotCursor, updateTimeRange, absolute} =
+    useObjectiveDetail()
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full">
+        {objective.queries?.graphErrorBudget !== undefined ? (
+          <ErrorBudgetGraph
+            client={promClient}
+            query={objective.queries.graphErrorBudget}
+            from={from}
+            to={to}
+            uPlotCursor={uPlotCursor}
+            updateTimeRange={updateTimeRange}
+            absolute={absolute}
+          />
+        ) : (
+          <></>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// GraphRow renders the requests and errors graphs side by side. Latency
+// objectives pass a Duration part as children, which takes the third column.
+const GraphRow = ({children}: {children?: ReactNode}): JSX.Element => {
+  const {objective, objectiveType, promClient, from, to, uPlotCursor, updateTimeRange, absolute} =
+    useObjectiveDetail()
+
+  const latency =
+    objectiveType === ObjectiveType.Latency || objectiveType === ObjectiveType.LatencyNative
+  const column = cn('w-full px-3', latency ? '3xl:w-1/3' : 'md:w-1/2')
+
+  return (
+    <div className="mb-24 flex flex-wrap -mx-3">
+      <div className={column}>
+        {objective.queries?.graphRequests !== undefined ? (
+          <RequestsGraph
+            client={promClient}
+            query={replaceInterval(objective.queries.graphRequests, from, to)}
+            from={from}
+            to={to}
+            uPlotCursor={uPlotCursor}
+            type={objectiveType}
+            updateTimeRange={updateTimeRange}
+            absolute={absolute}
+          />
+        ) : (
+          <></>
+        )}
+      </div>
+      <div className={column}>
+        {objective.queries?.graphErrors !== undefined ? (
+          <ErrorsGraph
+            client={promClient}
+            type={objectiveType}
+            query={replaceInterval(objective.queries.graphErrors, from, to)}
+            from={from}
+            to={to}
+            uPlotCursor={uPlotCursor}
+            updateTimeRange={updateTimeRange}
+            absolute={absolute}
+          />
+        ) : (
+          <></>
+        )}
+      </div>
+      {React.Children.map(children, (child) => (
+        <div className={column}>{child}</div>
+      ))}
+    </div>
+  )
+}
+
+// Duration and PreviewDuration differ only in where the percentiles come from:
+// a stored SLO is looked up by expr, a draft one is materialized from its YAML.
+// Two named parts rather than one part with an optional config, so the call
+// site says which it is.
+const Duration = ({
+  client,
+  expr,
+}: {
+  client: Client<typeof ObjectiveService>
+  expr: string
+}): JSX.Element => {
+  const {objective, grouping, from, to, uPlotCursor, updateTimeRange} = useObjectiveDetail()
+  const {timeseries, status} = useGraphDuration(client, expr, labelsString(grouping), from, to)
+
+  return (
+    <DurationGraph
+      timeseries={timeseries}
+      loading={status === 'pending'}
+      from={from}
+      to={to}
+      uPlotCursor={uPlotCursor}
+      updateTimeRange={updateTimeRange}
+      target={objective.target}
+      latency={latencyTarget(objective)}
+    />
+  )
+}
+
+const PreviewDuration = ({
+  client,
+  config,
+}: {
+  client: Client<typeof ObjectiveService>
+  config: string
+}): JSX.Element => {
+  const {objective, grouping, from, to, uPlotCursor, updateTimeRange} = useObjectiveDetail()
+  const {timeseries, status} = usePreviewGraphDuration(
+    client,
+    config,
+    labelsString(grouping),
+    from,
+    to,
+  )
+
+  return (
+    <DurationGraph
+      timeseries={timeseries}
+      loading={status === 'pending'}
+      from={from}
+      to={to}
+      uPlotCursor={uPlotCursor}
+      updateTimeRange={updateTimeRange}
+      target={objective.target}
+      latency={latencyTarget(objective)}
+    />
+  )
+}
+
+const Alerts = ({client}: {client: Client<typeof ObjectiveService>}): JSX.Element => {
+  const {objective, promClient, grouping, from, to, uPlotCursor} = useObjectiveDetail()
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full">
+        <h4>Multi Burn Rate Alerts</h4>
+        <AlertsTable
+          client={client}
+          promClient={promClient}
+          objective={objective}
+          grouping={grouping}
+          from={from}
+          to={to}
+          uPlotCursor={uPlotCursor}
+        />
+      </div>
+    </div>
+  )
+}
+
+const Config = (): JSX.Element => {
+  const {objective} = useObjectiveDetail()
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full">
+        <h4>Config</h4>
+        <pre className="rounded bg-muted p-5 overflow-auto max-w-full">
+          <code>{objective.config}</code>
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+const ObjectiveDetail = {
+  Provider,
+  Header,
+  Tiles,
+  ErrorBudget,
+  GraphRow,
+  Duration,
+  PreviewDuration,
+  Alerts,
+  Config,
+}
+
+export default ObjectiveDetail

--- a/ui/src/components/detail/TimeRangeControls.tsx
+++ b/ui/src/components/detail/TimeRangeControls.tsx
@@ -1,0 +1,107 @@
+// The detail page's time range bar: presets, a custom range, auto-reload and
+// the absolute/relative scale switch.
+//
+// Deliberately not part of the ObjectiveDetail compound components — the Create
+// editor's preview renders a fixed range and has nothing to control here.
+
+import React, {type JSX, useState} from 'react'
+import {ChartArea, ChartLine, CornerDownLeft} from 'lucide-react'
+import {ToggleGroup, ToggleGroupItem} from '@/components/ui/toggle-group'
+import {cn} from '@/lib/utils'
+import Toggle from '../Toggle'
+import {formatDuration, parseDuration} from '../../duration'
+
+interface TimeRangeControlsProps {
+  timeRanges: number[]
+  from: number
+  to: number
+  interval: number
+  autoReload: boolean
+  setAutoReload: (autoReload: boolean) => void
+  absolute: boolean
+  setAbsolute: (absolute: boolean) => void
+  // Selects a range of the given duration, ending now.
+  onSelectRange: (duration: number) => void
+}
+
+const TimeRangeControls = ({
+  timeRanges,
+  from,
+  to,
+  interval,
+  autoReload,
+  setAutoReload,
+  absolute,
+  setAbsolute,
+  onSelectRange,
+}: TimeRangeControlsProps): JSX.Element => {
+  const [customRange, setCustomRange] = useState('')
+  const [customRangeError, setCustomRangeError] = useState(false)
+
+  const handleCustomRangeSubmit = () => {
+    const ms = parseDuration(customRange)
+    if (ms !== null && ms > 0) {
+      setCustomRangeError(false)
+      onSelectRange(ms)
+    } else if (customRange !== '') {
+      setCustomRangeError(true)
+    }
+  }
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full text-center py-8 bg-[linear-gradient(0deg,transparent_45%,var(--muted)_50%,transparent_55%)]">
+        <div className="mx-auto flex flex-col items-center gap-5 bg-background sm:w-2/3 md:w-1/2 xl:flex-row xl:justify-center">
+          <div className="flex gap-5 justify-center">
+            <div className="flex items-center">
+              <div className="relative">
+                <input
+                  type="text"
+                  value={customRange}
+                  onChange={(e) => {
+                    setCustomRange(e.target.value)
+                    setCustomRangeError(false)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleCustomRangeSubmit()
+                  }}
+                  onBlur={handleCustomRangeSubmit}
+                  placeholder={formatDuration(timeRanges[0] * 2)}
+                  className={cn(
+                    'h-8 w-14 rounded-l-lg rounded-r-none border border-r-0 border-input bg-muted/50 shadow-inner pl-2 pr-5 text-sm font-medium outline-none transition-all placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:z-10',
+                    customRangeError && 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20'
+                  )}
+                />
+                {customRange !== '' && <CornerDownLeft size={11} className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" />}
+              </div>
+              <ToggleGroup variant="outline" value={[String(to - from)]} onValueChange={(val) => { if (val.length > 0) { setCustomRange(''); setCustomRangeError(false); onSelectRange(Number(val[val.length - 1])) } }}>
+                {timeRanges.map((t: number, i: number) => (
+                  <ToggleGroupItem key={t} value={String(t)} variant="outline" aria-label={formatDuration(t)} className={i === 0 ? 'rounded-l-none!' : undefined}>
+                    {formatDuration(t)}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </div>
+            <Toggle
+              checked={autoReload}
+              onChange={() => { setAutoReload(!autoReload) }}
+              onText={formatDuration(interval)}
+            />
+          </div>
+          <ToggleGroup variant="outline" value={[absolute ? 'absolute' : 'relative']} onValueChange={(val) => { if (val.length > 0) setAbsolute(val[val.length - 1] === 'absolute') }}>
+            <ToggleGroupItem value="absolute" variant="outline" aria-label="Absolute scale">
+              <ChartArea size={16} color={absolute ? 'white' : 'currentColor'} />
+              <span className="ml-2">Absolute</span>
+            </ToggleGroupItem>
+            <ToggleGroupItem value="relative" variant="outline" aria-label="Relative scale">
+              <ChartLine size={16} color={!absolute ? 'white' : 'currentColor'} />
+              <span className="ml-2">Relative</span>
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TimeRangeControls

--- a/ui/src/components/graphs/DurationGraph.tsx
+++ b/ui/src/components/graphs/DurationGraph.tsx
@@ -1,7 +1,6 @@
 import React, {type JSX, useLayoutEffect, useMemo, useRef, useState} from 'react'
 import {Spinner} from '@/components/ui/spinner'
 import UplotReact from 'uplot-react'
-import {type AlignedData} from 'uplot';
 import type uPlot from 'uplot'
 import {EXTERNAL_URL} from '../../App'
 import {ExternalLink} from 'lucide-react'

--- a/ui/src/components/graphs/DurationGraph.tsx
+++ b/ui/src/components/graphs/DurationGraph.tsx
@@ -1,31 +1,24 @@
-import React, {type JSX, useEffect, useLayoutEffect, useRef, useState} from 'react'
+import React, {type JSX, useLayoutEffect, useMemo, useRef, useState} from 'react'
 import {Spinner} from '@/components/ui/spinner'
 import UplotReact from 'uplot-react'
 import {type AlignedData} from 'uplot';
 import type uPlot from 'uplot'
 import {EXTERNAL_URL} from '../../App'
 import {ExternalLink} from 'lucide-react'
-import {type Labels, labelsString, parseLabelValue} from '../../labels'
+import {parseLabelValue} from '../../labels'
 import {colorful, greys} from './colors'
 import {seriesGaps} from './gaps'
-import {type Client} from '@connectrpc/connect'
-import {
-  type GraphDurationResponse,
-  type ObjectiveService,
-  type Series,
-  type Timeseries,
-} from '../../proto/objectives/v1alpha1/objectives_pb'
-import {timestampFromDate} from '@bufbuild/protobuf/wkt'
+import {type Timeseries} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {selectTimeRange} from './selectTimeRange'
 import {formatDuration} from '../../duration'
 import {buildExternalHRef, externalName} from '../../external'
 import {useGraphTooltip, formatAxisDates} from './useGraphTooltip'
 import GraphTooltip from './GraphTooltip'
+import {durationAlignedData} from './durationData'
 
 interface DurationGraphProps {
-  client: Client<typeof ObjectiveService>
-  labels: Labels
-  grouping: Labels
+  timeseries: Timeseries[]
+  loading: boolean
   from: number
   to: number
   uPlotCursor: uPlot.Cursor
@@ -35,9 +28,8 @@ interface DurationGraphProps {
 }
 
 const DurationGraph = ({
-  client,
-  labels,
-  grouping,
+  timeseries,
+  loading,
   from,
   to,
   uPlotCursor,
@@ -49,11 +41,13 @@ const DurationGraph = ({
 
   const {tooltipRef, initHook, setCursorHook} = useGraphTooltip(150)
 
-  const [durations, setDurations] = useState<AlignedData>()
-  const [durationQueries, setDurationQueries] = useState<string[]>([])
-  const [durationLabels, setDurationLabels] = useState<string[]>([])
-  const [durationsLoading, setDurationsLoading] = useState<boolean>(true)
   const [width, setWidth] = useState<number>(500)
+
+  const {
+    data: durations,
+    labels: durationLabels,
+    queries: durationQueries,
+  } = useMemo(() => durationAlignedData(timeseries, latency), [timeseries, latency])
 
   const setWidthFromContainer = () => {
     if (targetRef.current !== undefined && targetRef.current !== null) {
@@ -66,59 +60,12 @@ const DurationGraph = ({
   // Set width on every window resize
   window.addEventListener('resize', setWidthFromContainer)
 
-  useEffect(() => {
-    setDurationsLoading(true)
-    client
-      .graphDuration({
-        expr: labelsString(labels),
-        grouping: labelsString(grouping),
-        start: timestampFromDate(new Date(from)),
-        end: timestampFromDate(new Date(to)),
-      })
-      .then((resp: GraphDurationResponse) => {
-        let durationTimestamps: number[] = []
-        const durationData: number[][] = []
-        const durationLabels: string[] = []
-        const durationQueries: string[] = []
-
-        // The first series is a straight line (same latency target value for all timestamps)
-        // showing the objective.
-        if (latency !== undefined) {
-          durationData.push(Array(resp.timeseries[0].series[0].values.length).fill(latency / 1000) as number[])
-          durationLabels.push('{quantile="target"}')
-        }
-
-        resp.timeseries.forEach((timeseries: Timeseries, i: number) => {
-          const [x, ...series] = timeseries.series
-          if (i === 0) {
-            durationTimestamps = x.values
-          }
-
-          series.forEach((s: Series) => {
-            durationData.push(s.values)
-          })
-
-          durationLabels.push(...timeseries.labels)
-          durationQueries.push(timeseries.query)
-        })
-        setDurations([durationTimestamps, ...durationData])
-        setDurationLabels(durationLabels)
-        setDurationQueries(durationQueries)
-      })
-      .catch(() => {
-        setDurations(undefined)
-      })
-      .finally(() => {
-        setDurationsLoading(false)
-      })
-  }, [client, labels, grouping, from, to, latency])
-
   return (
     <>
       <div style={{display: 'flex', alignItems: 'baseline', justifyContent: 'space-between'}}>
         <h4 className="graphs-headline">
           Duration
-          {durationsLoading ? (
+          {loading ? (
             <Spinner
               className="ml-4 mb-2 h-4 w-4 border-1"
             />

--- a/ui/src/components/graphs/durationData.test.ts
+++ b/ui/src/components/graphs/durationData.test.ts
@@ -1,0 +1,52 @@
+import {describe, expect, it} from 'vitest'
+import {durationAlignedData} from './durationData'
+import {type Timeseries} from '../../proto/objectives/v1alpha1/objectives_pb'
+
+// The proto messages carry $typeName fields we don't care about here.
+const timeseries = (labels: string[], query: string, series: number[][]): Timeseries =>
+  ({labels, query, series: series.map((values) => ({values}))}) as unknown as Timeseries
+
+describe('durationAlignedData', () => {
+  const p99 = timeseries(
+    ['{quantile="p99"}'],
+    'histogram_quantile(0.99, foo)',
+    [
+      [0, 1, 2], // x
+      [0.1, 0.2, 0.3],
+    ],
+  )
+
+  it('aligns a single percentile', () => {
+    const {data, labels, queries} = durationAlignedData([p99], undefined)
+
+    expect(data).toEqual([
+      [0, 1, 2],
+      [0.1, 0.2, 0.3],
+    ])
+    expect(labels).toEqual(['{quantile="p99"}'])
+    expect(queries).toEqual(['histogram_quantile(0.99, foo)'])
+  })
+
+  it('prefixes a flat target line when a latency target is set', () => {
+    const {data, labels} = durationAlignedData([p99], 200)
+
+    // 200ms becomes 0.2s, held flat across every timestamp.
+    expect(data).toEqual([
+      [0, 1, 2],
+      [0.2, 0.2, 0.2],
+      [0.1, 0.2, 0.3],
+    ])
+    expect(labels).toEqual(['{quantile="target"}', '{quantile="p99"}'])
+  })
+
+  it('returns no data when the objective has no series', () => {
+    // A draft SLO pointed at a metric that doesn't exist yet: the graph has to
+    // render empty rather than throw on timeseries[0].series[0].
+    expect(durationAlignedData([], 200)).toEqual({data: undefined, labels: [], queries: []})
+    expect(durationAlignedData([timeseries([], 'q', [])], 200)).toEqual({
+      data: undefined,
+      labels: [],
+      queries: [],
+    })
+  })
+})

--- a/ui/src/components/graphs/durationData.ts
+++ b/ui/src/components/graphs/durationData.ts
@@ -1,0 +1,50 @@
+import {type AlignedData} from 'uplot'
+import {type Series, type Timeseries} from '../../proto/objectives/v1alpha1/objectives_pb'
+
+export interface DurationAlignedData {
+  data: AlignedData | undefined
+  labels: string[]
+  queries: string[]
+}
+
+// durationAlignedData folds the per-percentile timeseries into the single
+// x-then-y array uPlot wants, optionally prefixing the flat line that marks the
+// objective's latency target.
+export const durationAlignedData = (
+  timeseries: Timeseries[],
+  latency: number | undefined,
+): DurationAlignedData => {
+  // A draft SLO pointed at a metric that doesn't exist (or a typo mid-edit)
+  // comes back without any series at all.
+  if (timeseries.length === 0 || timeseries[0].series.length === 0) {
+    return {data: undefined, labels: [], queries: []}
+  }
+
+  let timestamps: number[] = []
+  const data: number[][] = []
+  const labels: string[] = []
+  const queries: string[] = []
+
+  // The first series is a straight line (same latency target value for all timestamps)
+  // showing the objective.
+  if (latency !== undefined) {
+    data.push(Array(timeseries[0].series[0].values.length).fill(latency / 1000) as number[])
+    labels.push('{quantile="target"}')
+  }
+
+  timeseries.forEach((ts: Timeseries, i: number) => {
+    const [x, ...series] = ts.series
+    if (i === 0) {
+      timestamps = x.values
+    }
+
+    series.forEach((s: Series) => {
+      data.push(s.values)
+    })
+
+    labels.push(...ts.labels)
+    queries.push(ts.query)
+  })
+
+  return {data: [timestamps, ...data], labels, queries}
+}

--- a/ui/src/objectives.tsx
+++ b/ui/src/objectives.tsx
@@ -1,6 +1,6 @@
 import {type ConnectError, type Client} from '@connectrpc/connect'
 import {type QueryStatus} from '@tanstack/react-query'
-import {type GetStatusResponse, type ListResponse, type ObjectiveService} from './proto/objectives/v1alpha1/objectives_pb'
+import {type GetStatusResponse, type ListResponse, type ObjectiveService, type Timeseries} from './proto/objectives/v1alpha1/objectives_pb'
 import {timestampFromDate} from '@bufbuild/protobuf/wkt'
 import {type QueryOptions, useConnectQuery} from './query'
 
@@ -50,4 +50,62 @@ export const useObjectivesStatus = (
   })
 
   return {response: data ?? null, error: error as ConnectError, status}
+}
+
+export interface DurationTimeseriesResponse {
+  timeseries: Timeseries[]
+  error: ConnectError
+  status: QueryStatus
+}
+
+// useGraphDuration fetches the duration percentiles of a stored SLO, looked up
+// by the same expr the list and detail views use.
+export const useGraphDuration = (
+  client: Client<typeof ObjectiveService>,
+  expr: string,
+  grouping: string,
+  from: number,
+  to: number,
+  options?: QueryOptions,
+): DurationTimeseriesResponse => {
+  const {data, error, status} = useConnectQuery({
+    key: ['graphDuration', expr, grouping, from, to],
+    func: async () => {
+      return await client.graphDuration({
+        expr,
+        grouping,
+        start: timestampFromDate(new Date(from)),
+        end: timestampFromDate(new Date(to)),
+      })
+    },
+    options,
+  })
+
+  return {timeseries: data?.timeseries ?? [], error: error as ConnectError, status}
+}
+
+// usePreviewGraphDuration fetches the same percentiles for a draft SLO that
+// isn't stored yet, so the Create editor's preview can render the graph too.
+export const usePreviewGraphDuration = (
+  client: Client<typeof ObjectiveService>,
+  config: string,
+  grouping: string,
+  from: number,
+  to: number,
+  options?: QueryOptions,
+): DurationTimeseriesResponse => {
+  const {data, error, status} = useConnectQuery({
+    key: ['previewGraphDuration', config, grouping, from, to],
+    func: async () => {
+      return await client.previewGraphDuration({
+        config,
+        grouping,
+        start: timestampFromDate(new Date(from)),
+        end: timestampFromDate(new Date(to)),
+      })
+    },
+    options,
+  })
+
+  return {timeseries: data?.timeseries ?? [], error: error as ConnectError, status}
 }

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -2,30 +2,28 @@ import {Link} from 'react-router-dom'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {useQueryState, parseAsString} from 'nuqs'
 import {Spinner} from '@/components/ui/spinner'
-import {ToggleGroup, ToggleGroupItem} from '@/components/ui/toggle-group'
-import {cn} from '@/lib/utils'
-import {API_BASEPATH, hasObjectiveType, latencyTarget, ObjectiveType} from '../App'
+import {API_BASEPATH, hasObjectiveType, ObjectiveType} from '../App'
 import Navbar from '../components/Navbar'
 import {MetricName, parseLabels} from '../labels'
-import ErrorBudgetGraph from '../components/graphs/ErrorBudgetGraph'
-import RequestsGraph from '../components/graphs/RequestsGraph'
-import ErrorsGraph from '../components/graphs/ErrorsGraph'
 import {createConnectTransport} from '@connectrpc/connect-web'
 import {createClient} from '@connectrpc/connect'
 import {ObjectiveService} from '../proto/objectives/v1alpha1/objectives_pb'
-import AlertsTable from '../components/AlertsTable'
-import Toggle from '../components/Toggle'
-import DurationGraph from '../components/graphs/DurationGraph'
 import type uPlot from 'uplot'
 import {PrometheusService} from '../proto/prometheus/v1/prometheus_pb'
-import {replaceInterval, usePrometheusQuery, vectorErrorsTotal} from '../prometheus'
-import {useGraphDuration, useObjectivesList} from '../objectives'
+import {useObjectivesList} from '../objectives'
 import {type Objective} from '../proto/objectives/v1alpha1/objectives_pb'
 import {formatDuration, parseDuration} from '../duration'
 import {computeTimeRangePresets} from '../timeRangePresets'
-import ObjectiveTiles from '../components/tiles/ObjectiveTiles'
-import ObjectiveLabels from '../components/ObjectiveLabels'
-import {ChartArea, ChartLine, CornerDownLeft} from 'lucide-react'
+import ObjectiveDetail, {type ObjectiveDetailValue} from '../components/detail/ObjectiveDetail'
+import TimeRangeControls from '../components/detail/TimeRangeControls'
+
+const uPlotCursor: uPlot.Cursor = {
+  y: false,
+  lock: true,
+  sync: {
+    key: 'detail',
+  },
+}
 
 const Detail = () => {
   const baseUrl = API_BASEPATH ?? 'http://localhost:9099'
@@ -43,7 +41,7 @@ const Detail = () => {
   const [fromParam, setFromParam] = useQueryState('from', parseAsString)
   const [toParam, setToParam] = useQueryState('to', parseAsString)
 
-  const {from, to, groupingLabels, name, labels} = useMemo(() => {
+  const {from, to, groupingLabels, name} = useMemo(() => {
     const labels = parseLabels(expr)
     const groupingLabels = parseLabels(groupingParam)
     const name: string = labels[MetricName]
@@ -69,50 +67,19 @@ const Detail = () => {
 
     document.title = `${name} - Pyrra`
 
-    return {from, to, groupingLabels, name, labels}
+    return {from, to, groupingLabels, name}
   }, [expr, groupingParam, fromParam, toParam])
 
   const [autoReload, setAutoReload] = useState<boolean>(true)
   const [absolute, setAbsolute] = useState<boolean>(true)
-  const [customRange, setCustomRange] = useState('')
-  const [customRangeError, setCustomRangeError] = useState(false)
 
-  const {
-    response: objectiveResponse,
-    error: objectiveError,
-    status: objectiveStatus,
-  } = useObjectivesList(client, expr, groupingParam)
-
-  const objective: Objective | null = objectiveResponse?.objectives[0] ?? null
-
-  const {response: totalResponse, status: totalStatus} = usePrometheusQuery(
-    promClient,
-    objective?.queries?.countTotal ?? '',
-    to / 1000,
-    {enabled: objectiveStatus === 'success' && objective?.queries?.countTotal !== undefined},
-  )
-
-  const {response: errorResponse, status: errorStatus} = usePrometheusQuery(
-    promClient,
-    objective?.queries?.countErrors ?? '',
-    to / 1000,
-    {enabled: objectiveStatus === 'success' && objective?.queries?.countTotal !== undefined},
-  )
-
-  // Only latency objectives have a duration graph. The check has to happen up
-  // here rather than next to the graph, because hooks can't be conditional.
-  const latencyObjective =
-    objective !== null &&
-    [ObjectiveType.Latency, ObjectiveType.LatencyNative].includes(hasObjectiveType(objective))
-
-  const {timeseries: durationTimeseries, status: durationStatus} = useGraphDuration(
+  const {response: objectiveResponse, error: objectiveError} = useObjectivesList(
     client,
     expr,
     groupingParam,
-    from,
-    to,
-    {enabled: latencyObjective},
   )
+
+  const objective: Objective | null = objectiveResponse?.objectives[0] ?? null
 
   const updateTimeRange = useCallback(
     (from: number, to: number, absolute: boolean) => {
@@ -128,11 +95,14 @@ const Detail = () => {
     [setFromParam, setToParam],
   )
 
-  const updateTimeRangeSelect = (min: number, max: number, absolute: boolean) => {
-    // when selecting time ranges with the mouse we want to disable the auto refresh
-    setAutoReload(false)
-    updateTimeRange(min, max, absolute)
-  }
+  const updateTimeRangeSelect = useCallback(
+    (min: number, max: number, absolute: boolean) => {
+      // when selecting time ranges with the mouse we want to disable the auto refresh
+      setAutoReload(false)
+      updateTimeRange(min, max, absolute)
+    },
+    [updateTimeRange],
+  )
 
   const duration = to - from
   const interval = intervalFromDuration(duration)
@@ -151,21 +121,39 @@ const Detail = () => {
     }
   }, [updateTimeRange, autoReload, duration, interval])
 
-  const handleTimeRangeClick = (t: number) => () => {
+  const selectRange = (t: number) => {
     const to = Date.now()
     const from = to - t
     updateTimeRange(from, to, false)
   }
 
-  const handleCustomRangeSubmit = () => {
-    const ms = parseDuration(customRange)
-    if (ms !== null && ms > 0) {
-      setCustomRangeError(false)
-      handleTimeRangeClick(ms)()
-    } else if (customRange !== '') {
-      setCustomRangeError(true)
+  const objectiveType = objective !== null ? hasObjectiveType(objective) : ObjectiveType.Ratio
+
+  const detail = useMemo<ObjectiveDetailValue | null>(() => {
+    if (objective === null || objective.labels === undefined) {
+      return null
     }
-  }
+    return {
+      objective,
+      objectiveType,
+      promClient,
+      grouping: groupingLabels,
+      from,
+      to,
+      absolute,
+      uPlotCursor,
+      updateTimeRange: updateTimeRangeSelect,
+    }
+  }, [
+    objective,
+    objectiveType,
+    promClient,
+    groupingLabels,
+    from,
+    to,
+    absolute,
+    updateTimeRangeSelect,
+  ])
 
   if (objectiveError !== null) {
     return (
@@ -192,36 +180,15 @@ const Detail = () => {
     )
   }
 
-  if (objective.labels === undefined) {
+  if (detail === null) {
     return <></>
   }
 
   const windowMs = Number(objective.window?.seconds ?? 0) * 1000
   const timeRanges = computeTimeRangePresets(windowMs > 0 ? windowMs : 28 * 24 * 3600 * 1000)
 
-  const objectiveType = hasObjectiveType(objective)
   const objectiveTypeLatency =
     objectiveType === ObjectiveType.Latency || objectiveType === ObjectiveType.LatencyNative
-
-  const loading: boolean =
-    totalStatus === 'pending' ||
-    errorStatus === 'pending'
-
-  const success: boolean = totalStatus === 'success' && errorStatus === 'success'
-
-  const {errors, total} = vectorErrorsTotal(totalResponse, errorResponse)
-
-  const hasLabels = Object.keys({...objective.labels, ...groupingLabels}).some(
-    (k) => k !== MetricName,
-  )
-
-  const uPlotCursor: uPlot.Cursor = {
-    y: false,
-    lock: true,
-    sync: {
-      key: 'detail',
-    },
-  }
 
   return (
     <>
@@ -233,171 +200,27 @@ const Detail = () => {
 
       <div className="mt-[100px]">
         <div className="container-responsive">
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full 3xl:w-10/12 3xl:mx-auto">
-              <h3>{name}</h3>
-              <ObjectiveLabels labels={objective.labels} grouping={groupingLabels} />
-            </div>
-            {objective.description !== undefined && objective.description !== '' ? (
-              <div
-                className="w-full md:w-1/2 3xl:w-5/12 3xl:ml-[8.33%]"
-                style={{marginTop: hasLabels ? 12 : 0}}>
-                <p>{objective.description}</p>
-              </div>
-            ) : (
-              <></>
-            )}
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full 3xl:w-10/12 3xl:mx-auto">
-              <ObjectiveTiles
-                objective={objective}
-                loading={loading}
-                success={success}
-                errors={errors}
-                total={total}
-              />
-            </div>
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full text-center py-8 bg-[linear-gradient(0deg,transparent_45%,var(--muted)_50%,transparent_55%)]">
-              <div className="mx-auto flex flex-col items-center gap-5 bg-background sm:w-2/3 md:w-1/2 xl:flex-row xl:justify-center">
-                <div className="flex gap-5 justify-center">
-                  <div className="flex items-center">
-                    <div className="relative">
-                      <input
-                        type="text"
-                        value={customRange}
-                        onChange={(e) => {
-                          setCustomRange(e.target.value)
-                          setCustomRangeError(false)
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter') handleCustomRangeSubmit()
-                        }}
-                        onBlur={handleCustomRangeSubmit}
-                        placeholder={formatDuration(timeRanges[0] * 2)}
-                        className={cn(
-                          'h-8 w-14 rounded-l-lg rounded-r-none border border-r-0 border-input bg-muted/50 shadow-inner pl-2 pr-5 text-sm font-medium outline-none transition-all placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:z-10',
-                          customRangeError && 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20'
-                        )}
-                      />
-                      {customRange !== '' && <CornerDownLeft size={11} className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" />}
-                    </div>
-                    <ToggleGroup variant="outline" value={[String(to - from)]} onValueChange={(val) => { if (val.length > 0) { setCustomRange(''); setCustomRangeError(false); handleTimeRangeClick(Number(val[val.length - 1]))() } }}>
-                      {timeRanges.map((t: number, i: number) => (
-                        <ToggleGroupItem key={t} value={String(t)} variant="outline" aria-label={formatDuration(t)} className={i === 0 ? 'rounded-l-none!' : undefined}>
-                          {formatDuration(t)}
-                        </ToggleGroupItem>
-                      ))}
-                    </ToggleGroup>
-                  </div>
-                  <Toggle
-                    checked={autoReload}
-                    onChange={() => { setAutoReload(!autoReload) }}
-                    onText={formatDuration(interval)}
-                  />
-                </div>
-                <ToggleGroup variant="outline" value={[absolute ? 'absolute' : 'relative']} onValueChange={(val) => { if (val.length > 0) setAbsolute(val[val.length - 1] === 'absolute') }}>
-                  <ToggleGroupItem value="absolute" variant="outline" aria-label="Absolute scale">
-                    <ChartArea size={16} color={absolute ? 'white' : 'currentColor'} />
-                    <span className="ml-2">Absolute</span>
-                  </ToggleGroupItem>
-                  <ToggleGroupItem value="relative" variant="outline" aria-label="Relative scale">
-                    <ChartLine size={16} color={!absolute ? 'white' : 'currentColor'} />
-                    <span className="ml-2">Relative</span>
-                  </ToggleGroupItem>
-                </ToggleGroup>
-              </div>
-            </div>
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full">
-              {objective.queries?.graphErrorBudget !== undefined ? (
-                <ErrorBudgetGraph
-                  client={promClient}
-                  query={objective.queries.graphErrorBudget}
-                  from={from}
-                  to={to}
-                  uPlotCursor={uPlotCursor}
-                  updateTimeRange={updateTimeRangeSelect}
-                  absolute={absolute}
-                />
-              ) : (
-                <></>
-              )}
-            </div>
-          </div>
-          <div className="mb-24 flex flex-wrap -mx-3">
-            <div className={cn('w-full px-3', objectiveTypeLatency ? '3xl:w-1/3' : 'md:w-1/2')}>
-              {objective.queries?.graphRequests !== undefined ? (
-                <RequestsGraph
-                  client={promClient}
-                  query={replaceInterval(objective.queries.graphRequests, from, to)}
-                  from={from}
-                  to={to}
-                  uPlotCursor={uPlotCursor}
-                  type={objectiveType}
-                  updateTimeRange={updateTimeRangeSelect}
-                  absolute={absolute}
-                />
-              ) : (
-                <></>
-              )}
-            </div>
-            <div className={cn('w-full px-3', objectiveTypeLatency ? '3xl:w-1/3' : 'md:w-1/2')}>
-              {objective.queries?.graphErrors !== undefined ? (
-                <ErrorsGraph
-                  client={promClient}
-                  type={objectiveType}
-                  query={replaceInterval(objective.queries.graphErrors, from, to)}
-                  from={from}
-                  to={to}
-                  uPlotCursor={uPlotCursor}
-                  updateTimeRange={updateTimeRangeSelect}
-                  absolute={absolute}
-                />
-              ) : (
-                <></>
-              )}
-            </div>
-            {objectiveTypeLatency && (
-              <div className="w-full px-3 3xl:w-1/3">
-                <DurationGraph
-                  timeseries={durationTimeseries}
-                  loading={durationStatus === 'pending'}
-                  from={from}
-                  to={to}
-                  uPlotCursor={uPlotCursor}
-                  updateTimeRange={updateTimeRangeSelect}
-                  target={objective.target}
-                  latency={latencyTarget(objective)}
-                />
-              </div>
-            )}
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full">
-              <h4>Multi Burn Rate Alerts</h4>
-              <AlertsTable
-                client={client}
-                promClient={promClient}
-                objective={objective}
-                grouping={groupingLabels}
-                from={from}
-                to={to}
-                uPlotCursor={uPlotCursor}
-              />
-            </div>
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full">
-              <h4>Config</h4>
-              <pre className="rounded bg-muted p-5 overflow-auto max-w-full">
-                <code>{objective.config}</code>
-              </pre>
-            </div>
-          </div>
+          <ObjectiveDetail.Provider value={detail}>
+            <ObjectiveDetail.Header />
+            <ObjectiveDetail.Tiles />
+            <TimeRangeControls
+              timeRanges={timeRanges}
+              from={from}
+              to={to}
+              interval={interval}
+              autoReload={autoReload}
+              setAutoReload={setAutoReload}
+              absolute={absolute}
+              setAbsolute={setAbsolute}
+              onSelectRange={selectRange}
+            />
+            <ObjectiveDetail.ErrorBudget />
+            <ObjectiveDetail.GraphRow>
+              {objectiveTypeLatency && <ObjectiveDetail.Duration client={client} expr={expr} />}
+            </ObjectiveDetail.GraphRow>
+            <ObjectiveDetail.Alerts client={client} />
+            <ObjectiveDetail.Config />
+          </ObjectiveDetail.Provider>
         </div>
       </div>
     </>

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -19,7 +19,7 @@ import DurationGraph from '../components/graphs/DurationGraph'
 import type uPlot from 'uplot'
 import {PrometheusService} from '../proto/prometheus/v1/prometheus_pb'
 import {replaceInterval, usePrometheusQuery, vectorErrorsTotal} from '../prometheus'
-import {useObjectivesList} from '../objectives'
+import {useGraphDuration, useObjectivesList} from '../objectives'
 import {type Objective} from '../proto/objectives/v1alpha1/objectives_pb'
 import {formatDuration, parseDuration} from '../duration'
 import {computeTimeRangePresets} from '../timeRangePresets'
@@ -97,6 +97,21 @@ const Detail = () => {
     objective?.queries?.countErrors ?? '',
     to / 1000,
     {enabled: objectiveStatus === 'success' && objective?.queries?.countTotal !== undefined},
+  )
+
+  // Only latency objectives have a duration graph. The check has to happen up
+  // here rather than next to the graph, because hooks can't be conditional.
+  const latencyObjective =
+    objective !== null &&
+    [ObjectiveType.Latency, ObjectiveType.LatencyNative].includes(hasObjectiveType(objective))
+
+  const {timeseries: durationTimeseries, status: durationStatus} = useGraphDuration(
+    client,
+    expr,
+    groupingParam,
+    from,
+    to,
+    {enabled: latencyObjective},
   )
 
   const updateTimeRange = useCallback(
@@ -349,9 +364,8 @@ const Detail = () => {
             {objectiveTypeLatency && (
               <div className="w-full px-3 3xl:w-1/3">
                 <DurationGraph
-                  client={client}
-                  labels={labels}
-                  grouping={groupingLabels}
+                  timeseries={durationTimeseries}
+                  loading={durationStatus === 'pending'}
                   from={from}
                   to={to}
                   uPlotCursor={uPlotCursor}

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -130,7 +130,7 @@ const Detail = () => {
   const objectiveType = objective !== null ? hasObjectiveType(objective) : ObjectiveType.Ratio
 
   const detail = useMemo<ObjectiveDetailValue | null>(() => {
-    if (objective === null || objective.labels === undefined) {
+    if (objective?.labels === undefined) {
       return null
     }
     return {


### PR DESCRIPTION
The detail page and the Create preview render the same objective but not the same set of things, and both had grown their own copy of the markup. Each page now composes the parts it actually has, rather than one component carrying flags for what to leave out.

No behaviour change on the detail page.
