### PR TITLE
feat(ui): render the real detail view in the Create SLO preview

### DIFF
--- a/main.go
+++ b/main.go
@@ -1812,9 +1812,12 @@ func (s *objectiveServer) PreviewGraphDuration(ctx context.Context, req *connect
 }
 
 // graphRange resolves a request's start/end, defaulting to the last hour when
-// either end is unset.
+// they're unset or nonsensical. Note an absent timestamp arrives as the Unix
+// epoch rather than the zero time, so IsZero alone doesn't catch it — and a
+// start that isn't before end would divide the range into a zero-width step,
+// which Prometheus rejects.
 func graphRange(start, end time.Time) (time.Time, time.Time) {
-	if start.IsZero() || end.IsZero() {
+	if start.IsZero() || end.IsZero() || start.Unix() <= 0 || !end.After(start) {
 		end = time.Now()
 		start = end.Add(-1 * time.Hour)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -687,6 +687,35 @@ spec:
 	}
 }
 
+func TestGraphRange(t *testing.T) {
+	start := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	t.Run("passes a valid range through", func(t *testing.T) {
+		gotStart, gotEnd := graphRange(start, end)
+		require.Equal(t, start, gotStart)
+		require.Equal(t, end, gotEnd)
+	})
+
+	// An absent protobuf timestamp arrives as the Unix epoch, not the zero time,
+	// so both need to fall back or the step ends up zero and Prometheus 400s.
+	for _, tc := range []struct {
+		name       string
+		start, end time.Time
+	}{
+		{name: "zero", start: time.Time{}, end: time.Time{}},
+		{name: "unix epoch", start: time.Unix(0, 0), end: time.Unix(0, 0)},
+		{name: "end before start", start: end, end: start},
+		{name: "empty range", start: start, end: start},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStart, gotEnd := graphRange(tc.start, tc.end)
+			require.Equal(t, time.Hour, gotEnd.Sub(gotStart))
+			require.WithinDuration(t, time.Now(), gotEnd, time.Minute)
+		})
+	}
+}
+
 func TestObjectiveServerPreviewGraphDurationErrors(t *testing.T) {
 	t.Run("invalid config", func(t *testing.T) {
 		server, _ := newDurationServer(t, durationMatrix())

--- a/ui/src/components/create/DetailPreview.tsx
+++ b/ui/src/components/create/DetailPreview.tsx
@@ -2,15 +2,17 @@
 //
 // This is the same detail view a stored SLO gets — it composes the parts from
 // components/detail/ObjectiveDetail rather than reimplementing them, so the two
-// can't drift. What it leaves out is what a draft SLO genuinely can't have: a
-// time range to control (the preview pins one hour), and the alerts table,
-// which needs alerting rules that only exist once the SLO is deployed.
+// can't drift. The one thing it leaves out is the alerts table, which needs
+// alerting rules that only exist once the SLO is deployed.
+//
+// The time range lives in local state rather than the URL: the draft isn't
+// addressable, so there's nothing to put a range on.
 //
 // Everything around the view — the idle, loading and error states, the grouping
 // chooser's back button, the dimming while the editor is ahead of the preview —
 // lives here.
 
-import React, {useMemo, useState, type JSX} from 'react'
+import React, {useCallback, useMemo, useState, type JSX} from 'react'
 import {createClient} from '@connectrpc/connect'
 import {createConnectTransport} from '@connectrpc/connect-web'
 import type uPlot from 'uplot'
@@ -22,6 +24,9 @@ import {type Labels} from '../../labels'
 import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {PrometheusService} from '../../proto/prometheus/v1/prometheus_pb'
 import ObjectiveDetail, {type ObjectiveDetailValue} from '../detail/ObjectiveDetail'
+import TimeRangeControls from '../detail/TimeRangeControls'
+import {useAutoReload} from '../detail/useAutoReload'
+import {intervalFromDuration, previewTimeRangePresets} from '../../timeRangePresets'
 import {objectiveClient, type PreviewStatus} from './preview'
 
 interface DetailPreviewProps {
@@ -40,8 +45,6 @@ interface DetailPreviewProps {
   // this Detail view is one chosen label set of a chooser).
   onBack?: () => void
 }
-
-const noop = (): void => {}
 
 // A different sync key from the detail page's, so hovering the preview can't
 // drag the crosshair on a detail page rendered elsewhere.
@@ -84,11 +87,35 @@ const DetailPreview = ({
   )
   const client = useMemo(() => objectiveClient(baseUrl), [baseUrl])
 
-  // A fixed range captured once — a preview doesn't need live auto-refresh.
-  const [{from, to}] = useState(() => {
+  const [{from, to}, setRange] = useState(() => {
     const now = Date.now()
     return {from: now - 60 * 60 * 1000, to: now}
   })
+  const [autoReload, setAutoReload] = useState(false)
+  const [absolute, setAbsolute] = useState(true)
+
+  const updateTimeRange = useCallback((from: number, to: number) => {
+    setRange({from, to})
+  }, [])
+
+  // Dragging a selection on a graph picks an explicit window, so stop sliding it.
+  const updateTimeRangeSelect = useCallback(
+    (min: number, max: number) => {
+      setAutoReload(false)
+      updateTimeRange(min, max)
+    },
+    [updateTimeRange],
+  )
+
+  const selectRange = useCallback((duration: number) => {
+    const to = Date.now()
+    setRange({from: to - duration, to})
+  }, [])
+
+  const duration = to - from
+  const interval = intervalFromDuration(duration)
+
+  useAutoReload(autoReload, duration, interval, updateTimeRange)
 
   const detail = useMemo<ObjectiveDetailValue | null>(() => {
     if (objective === null) {
@@ -101,11 +128,11 @@ const DetailPreview = ({
       grouping: grouping ?? {},
       from,
       to,
-      absolute: true,
+      absolute,
       uPlotCursor,
-      updateTimeRange: noop,
+      updateTimeRange: updateTimeRangeSelect,
     }
-  }, [objective, promClient, grouping, from, to])
+  }, [objective, promClient, grouping, from, to, absolute, updateTimeRangeSelect])
 
   if (status === 'loading') {
     return (
@@ -141,6 +168,9 @@ const DetailPreview = ({
     detail.objectiveType === ObjectiveType.Latency ||
     detail.objectiveType === ObjectiveType.LatencyNative
 
+  const timeRanges = previewTimeRangePresets(Number(detail.objective.window?.seconds ?? 0) * 1000)
+
+
   return (
     <div className={stale ? 'opacity-55 transition-opacity' : 'transition-opacity'}>
       <div className="px-6 pt-7 pb-14">
@@ -154,6 +184,17 @@ const DetailPreview = ({
         <ObjectiveDetail.Provider value={detail}>
           <ObjectiveDetail.Header />
           <ObjectiveDetail.Tiles />
+          <TimeRangeControls
+            timeRanges={timeRanges}
+            from={from}
+            to={to}
+            interval={interval}
+            autoReload={autoReload}
+            setAutoReload={setAutoReload}
+            absolute={absolute}
+            setAbsolute={setAbsolute}
+            onSelectRange={selectRange}
+          />
           <ObjectiveDetail.ErrorBudget />
           <ObjectiveDetail.GraphRow>
             {latency && <ObjectiveDetail.PreviewDuration client={client} config={config} />}

--- a/ui/src/components/create/DetailPreview.tsx
+++ b/ui/src/components/create/DetailPreview.tsx
@@ -1,13 +1,14 @@
 // Live preview of the SLO Detail page, rendered from a materialized Objective.
 //
-// Given an Objective produced by the backend preview (see preview.ts), this
-// composes the very same building blocks as the real Detail page — the three
-// tiles and the error-budget / requests / errors graphs — querying Prometheus
-// directly through the query strings the backend computed. The result looks and
-// behaves exactly like an already-stored SLO.
+// This is the same detail view a stored SLO gets — it composes the parts from
+// components/detail/ObjectiveDetail rather than reimplementing them, so the two
+// can't drift. What it leaves out is what a draft SLO genuinely can't have: a
+// time range to control (the preview pins one hour), and the alerts table,
+// which needs alerting rules that only exist once the SLO is deployed.
 //
-// Until the backend preview endpoint exists, `objective` is null and this shows
-// the idle / unavailable states instead.
+// Everything around the view — the idle, loading and error states, the grouping
+// chooser's back button, the dimming while the editor is ahead of the preview —
+// lives here.
 
 import React, {useMemo, useState, type JSX} from 'react'
 import {createClient} from '@connectrpc/connect'
@@ -16,17 +17,12 @@ import type uPlot from 'uplot'
 import {ArrowLeft, LineChart, Play} from 'lucide-react'
 import {Spinner} from '@/components/ui/spinner'
 import {Button} from '@/components/ui/button'
-import {hasObjectiveType, ObjectiveType, latencyTarget} from '../../App'
-import {type Labels, MetricName} from '../../labels'
+import {hasObjectiveType, ObjectiveType} from '../../App'
+import {type Labels} from '../../labels'
 import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {PrometheusService} from '../../proto/prometheus/v1/prometheus_pb'
-import {usePrometheusQuery, replaceInterval, vectorErrorsTotal} from '../../prometheus'
-import ObjectiveTiles from '../tiles/ObjectiveTiles'
-import ObjectiveLabels from '../ObjectiveLabels'
-import ErrorBudgetGraph from '../graphs/ErrorBudgetGraph'
-import RequestsGraph from '../graphs/RequestsGraph'
-import ErrorsGraph from '../graphs/ErrorsGraph'
-import {type PreviewStatus} from './preview'
+import ObjectiveDetail, {type ObjectiveDetailValue} from '../detail/ObjectiveDetail'
+import {objectiveClient, type PreviewStatus} from './preview'
 
 interface DetailPreviewProps {
   baseUrl: string
@@ -34,6 +30,9 @@ interface DetailPreviewProps {
   status: PreviewStatus
   stale: boolean
   onRun: () => void
+  // The YAML that produced `objective`. The duration graph is computed from the
+  // same draft, since there is no stored SLO to look up.
+  config: string
   // The grouping label set this preview is scoped to, shown as pills next to the
   // objective's labels. Undefined for an ungrouped (overall) preview.
   grouping?: Labels
@@ -43,6 +42,10 @@ interface DetailPreviewProps {
 }
 
 const noop = (): void => {}
+
+// A different sync key from the detail page's, so hovering the preview can't
+// drag the crosshair on a detail page rendered elsewhere.
+const uPlotCursor: uPlot.Cursor = {y: false, lock: true, sync: {key: 'create-preview'}}
 
 const EmptyState = ({onRun}: {onRun: () => void}): JSX.Element => (
   <div className="flex min-h-[60vh] flex-col items-center justify-center gap-2.5 p-10 text-center text-muted-foreground">
@@ -65,11 +68,21 @@ const Message = ({title, children}: {title: string; children: React.ReactNode}):
   </div>
 )
 
-const DetailPreview = ({baseUrl, objective, status, stale, onRun, grouping, onBack}: DetailPreviewProps): JSX.Element => {
+const DetailPreview = ({
+  baseUrl,
+  objective,
+  status,
+  stale,
+  onRun,
+  config,
+  grouping,
+  onBack,
+}: DetailPreviewProps): JSX.Element => {
   const promClient = useMemo(
     () => createClient(PrometheusService, createConnectTransport({baseUrl})),
     [baseUrl],
   )
+  const client = useMemo(() => objectiveClient(baseUrl), [baseUrl])
 
   // A fixed range captured once — a preview doesn't need live auto-refresh.
   const [{from, to}] = useState(() => {
@@ -77,22 +90,22 @@ const DetailPreview = ({baseUrl, objective, status, stale, onRun, grouping, onBa
     return {from: now - 60 * 60 * 1000, to: now}
   })
 
-  const countTotal = objective?.queries?.countTotal ?? ''
-  const countErrors = objective?.queries?.countErrors ?? ''
-  const queriesEnabled = objective !== null && countTotal !== ''
-
-  const {response: totalResponse, status: totalStatus} = usePrometheusQuery(
-    promClient,
-    countTotal,
-    to / 1000,
-    {enabled: queriesEnabled},
-  )
-  const {response: errorResponse, status: errorStatus} = usePrometheusQuery(
-    promClient,
-    countErrors,
-    to / 1000,
-    {enabled: queriesEnabled},
-  )
+  const detail = useMemo<ObjectiveDetailValue | null>(() => {
+    if (objective === null) {
+      return null
+    }
+    return {
+      objective,
+      objectiveType: hasObjectiveType(objective),
+      promClient,
+      grouping: grouping ?? {},
+      from,
+      to,
+      absolute: true,
+      uPlotCursor,
+      updateTimeRange: noop,
+    }
+  }, [objective, promClient, grouping, from, to])
 
   if (status === 'loading') {
     return (
@@ -120,21 +133,13 @@ const DetailPreview = ({baseUrl, objective, status, stale, onRun, grouping, onBa
     )
   }
 
-  if (objective === null) {
+  if (detail === null) {
     return <EmptyState onRun={onRun} />
   }
 
-  const name = objective.labels[MetricName] ?? 'preview'
-  const objectiveType = hasObjectiveType(objective)
-  const objectiveTypeLatency =
-    objectiveType === ObjectiveType.Latency || objectiveType === ObjectiveType.LatencyNative
-
-  const loading = totalStatus === 'pending' || errorStatus === 'pending'
-  const success = totalStatus === 'success' && errorStatus === 'success'
-
-  const {errors, total} = vectorErrorsTotal(totalResponse, errorResponse)
-
-  const uPlotCursor: uPlot.Cursor = {y: false, lock: true, sync: {key: 'create-preview'}}
+  const latency =
+    detail.objectiveType === ObjectiveType.Latency ||
+    detail.objectiveType === ObjectiveType.LatencyNative
 
   return (
     <div className={stale ? 'opacity-55 transition-opacity' : 'transition-opacity'}>
@@ -146,71 +151,14 @@ const DetailPreview = ({baseUrl, objective, status, stale, onRun, grouping, onBa
             <ArrowLeft size={15} /> Groupings
           </button>
         )}
-        <div className="mb-7">
-          <h3 className="mb-3">{name}</h3>
-          <ObjectiveLabels labels={objective.labels} grouping={grouping} />
-          {objective.description !== '' && (
-            <p className="mt-3 max-w-prose text-sm leading-relaxed">{objective.description}</p>
-          )}
-        </div>
-
-        <div className="mb-7">
-          <ObjectiveTiles
-            objective={objective}
-            loading={loading}
-            success={success}
-            errors={errors}
-            total={total}
-          />
-        </div>
-
-        {objective.queries?.graphErrorBudget !== undefined && (
-          <div className="mb-7">
-            <ErrorBudgetGraph
-              client={promClient}
-              query={objective.queries.graphErrorBudget}
-              from={from}
-              to={to}
-              uPlotCursor={uPlotCursor}
-              updateTimeRange={noop}
-              absolute={true}
-            />
-          </div>
-        )}
-
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          {objective.queries?.graphRequests !== undefined && (
-            <RequestsGraph
-              client={promClient}
-              query={replaceInterval(objective.queries.graphRequests, from, to)}
-              from={from}
-              to={to}
-              uPlotCursor={uPlotCursor}
-              type={objectiveType}
-              updateTimeRange={noop}
-              absolute={true}
-            />
-          )}
-          {objective.queries?.graphErrors !== undefined && (
-            <ErrorsGraph
-              client={promClient}
-              type={objectiveType}
-              query={replaceInterval(objective.queries.graphErrors, from, to)}
-              from={from}
-              to={to}
-              uPlotCursor={uPlotCursor}
-              updateTimeRange={noop}
-              absolute={true}
-            />
-          )}
-        </div>
-
-        {objectiveTypeLatency && (
-          <p className="mt-4 text-xs text-muted-foreground">
-            Latency target: {latencyTarget(objective) ?? '—'} ms · the duration graph and alerts table appear
-            on the stored SLO's Detail page.
-          </p>
-        )}
+        <ObjectiveDetail.Provider value={detail}>
+          <ObjectiveDetail.Header />
+          <ObjectiveDetail.Tiles />
+          <ObjectiveDetail.ErrorBudget />
+          <ObjectiveDetail.GraphRow>
+            {latency && <ObjectiveDetail.PreviewDuration client={client} config={config} />}
+          </ObjectiveDetail.GraphRow>
+        </ObjectiveDetail.Provider>
       </div>
     </div>
   )

--- a/ui/src/components/create/config.ts
+++ b/ui/src/components/create/config.ts
@@ -33,6 +33,9 @@ export const DEFAULT_CONFIG: CreateConfig = {
   labels: [
     {k: 'prometheus', v: 'k8s'},
     {k: 'role', v: 'alert-rules'},
+    // Only pyrra.dev/-prefixed labels become part of the objective itself, so
+    // this is the one that shows up on the detail page.
+    {k: 'pyrra.dev/team', v: 'platform'},
   ],
   target: '99.0',
   window: '7d',

--- a/ui/src/components/create/preview.ts
+++ b/ui/src/components/create/preview.ts
@@ -5,7 +5,7 @@
 // parsing on the backend, so the preview renders exactly as a stored SLO would —
 // same queries, same tiles, same graphs against real Prometheus data.
 
-import {Code, ConnectError, createClient} from '@connectrpc/connect'
+import {type Client, Code, ConnectError, createClient} from '@connectrpc/connect'
 import {createConnectTransport} from '@connectrpc/connect-web'
 import {ObjectiveService, type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
 
@@ -18,10 +18,13 @@ export class PreviewUnavailableError extends Error {
   }
 }
 
+export const objectiveClient = (baseUrl: string): Client<typeof ObjectiveService> =>
+  createClient(ObjectiveService, createConnectTransport({baseUrl}))
+
 // grouping optionally scopes the preview to a single grouping label set (e.g.
 // {handler="/api"}); empty previews the objective grouped by its grouping labels.
 export async function previewObjective(baseUrl: string, config: string, grouping = ''): Promise<Objective> {
-  const client = createClient(ObjectiveService, createConnectTransport({baseUrl}))
+  const client = objectiveClient(baseUrl)
   try {
     const response = await client.preview({config, grouping})
     if (response.objective === undefined) {

--- a/ui/src/components/detail/useAutoReload.ts
+++ b/ui/src/components/detail/useAutoReload.ts
@@ -1,0 +1,26 @@
+import {useEffect} from 'react'
+
+// useAutoReload slides the time range forward on a timer, keeping its length and
+// pinning the end to now. Shared by the detail page and the Create preview,
+// which differ only in where they keep the range.
+export const useAutoReload = (
+  enabled: boolean,
+  duration: number,
+  interval: number,
+  updateTimeRange: (from: number, to: number, absolute: boolean) => void,
+): void => {
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    const id = setInterval(() => {
+      const to = Date.now()
+      updateTimeRange(to - duration, to, false)
+    }, interval)
+
+    return () => {
+      clearInterval(id)
+    }
+  }, [enabled, duration, interval, updateTimeRange])
+}

--- a/ui/src/pages/Create.tsx
+++ b/ui/src/pages/Create.tsx
@@ -183,7 +183,9 @@ const Create = (): JSX.Element => {
                 />
               </Field>
 
-              <Field label="Labels" hint="Free-form key=value pairs attached to the objective.">
+              <Field
+                label="Labels"
+                hint="Metadata labels on the resource. Prefix a key with pyrra.dev/ to make it part of the objective — those show up on its detail page and are propagated to the generated rules. Unprefixed keys (like prometheus or role) only select which Prometheus picks up the PrometheusRule.">
                 <LabelsEditor value={cfg.labels} onChange={(labels) => { set({labels}); }} />
               </Field>
 
@@ -429,6 +431,7 @@ const Create = (): JSX.Element => {
               status={previewStatus}
               stale={stale}
               onRun={runPreview}
+              config={previewYaml}
               grouping={selectedGrouping ?? undefined}
               onBack={groupingObjective !== null ? backToGroupings : undefined}
             />

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -1,5 +1,5 @@
 import {Link} from 'react-router-dom'
-import React, {useCallback, useEffect, useMemo, useState} from 'react'
+import React, {useCallback, useMemo, useState} from 'react'
 import {useQueryState, parseAsString} from 'nuqs'
 import {Spinner} from '@/components/ui/spinner'
 import {API_BASEPATH, hasObjectiveType, ObjectiveType} from '../App'

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -13,9 +13,10 @@ import {PrometheusService} from '../proto/prometheus/v1/prometheus_pb'
 import {useObjectivesList} from '../objectives'
 import {type Objective} from '../proto/objectives/v1alpha1/objectives_pb'
 import {formatDuration, parseDuration} from '../duration'
-import {computeTimeRangePresets} from '../timeRangePresets'
+import {computeTimeRangePresets, intervalFromDuration} from '../timeRangePresets'
 import ObjectiveDetail, {type ObjectiveDetailValue} from '../components/detail/ObjectiveDetail'
 import TimeRangeControls from '../components/detail/TimeRangeControls'
+import {useAutoReload} from '../components/detail/useAutoReload'
 
 const uPlotCursor: uPlot.Cursor = {
   y: false,
@@ -107,19 +108,7 @@ const Detail = () => {
   const duration = to - from
   const interval = intervalFromDuration(duration)
 
-  useEffect(() => {
-    if (autoReload) {
-      const id = setInterval(() => {
-        const newTo = Date.now()
-        const newFrom = newTo - duration
-        updateTimeRange(newFrom, newTo, false)
-      }, interval)
-
-      return () => {
-        clearInterval(id)
-      }
-    }
-  }, [updateTimeRange, autoReload, duration, interval])
+  useAutoReload(autoReload, duration, interval, updateTimeRange)
 
   const selectRange = (t: number) => {
     const to = Date.now()
@@ -225,27 +214,6 @@ const Detail = () => {
       </div>
     </>
   )
-}
-
-const intervalFromDuration = (duration: number): number => {
-  // map some preset duration to nicer looking intervals
-  switch (duration) {
-    case 60 * 60 * 1000: // 1h => 10s
-      return 10 * 1000
-    case 12 * 60 * 60 * 1000: // 12h => 30s
-      return 30 * 1000
-    case 24 * 60 * 60 * 1000: // 12h => 30s
-      return 90 * 1000
-  }
-
-  if (duration < 10 * 1000 * 1000) {
-    return 10 * 1000
-  }
-  if (duration < 10 * 60 * 1000 * 1000) {
-    return Math.floor(duration / 1000 / 1000) * 1000 // round to seconds
-  }
-
-  return Math.floor(duration / 60 / 1000 / 1000) * 60 * 1000
 }
 
 export default Detail

--- a/ui/src/timeRangePresets.test.ts
+++ b/ui/src/timeRangePresets.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {computeTimeRangePresets} from './timeRangePresets'
+import {computeTimeRangePresets, previewTimeRangePresets} from './timeRangePresets'
 
 const ms = {
   h: 3600 * 1000,
@@ -61,5 +61,48 @@ describe('computeTimeRangePresets', () => {
   it('handles very large window (1y = 365d)', () => {
     const result = computeTimeRangePresets(365 * ms.d)
     expect(result).toEqual([365 * ms.d, 4 * ms.w, 1 * ms.w, 1 * ms.d, 12 * ms.h, 1 * ms.h])
+  })
+})
+
+describe('previewTimeRangePresets', () => {
+  const standard = [4 * ms.w, 1 * ms.w, 1 * ms.d, 12 * ms.h, 1 * ms.h]
+
+  it('keeps the standard set when the window is already one of them', () => {
+    expect(previewTimeRangePresets(1 * ms.w)).toEqual(standard)
+    expect(previewTimeRangePresets(4 * ms.w)).toEqual(standard)
+    expect(previewTimeRangePresets(1 * ms.d)).toEqual(standard)
+  })
+
+  it('slots an unlisted window in by length', () => {
+    expect(previewTimeRangePresets(2 * ms.w)).toEqual([
+      4 * ms.w,
+      2 * ms.w,
+      1 * ms.w,
+      1 * ms.d,
+      12 * ms.h,
+      1 * ms.h,
+    ])
+    expect(previewTimeRangePresets(6 * ms.h)).toEqual([
+      4 * ms.w,
+      1 * ms.w,
+      1 * ms.d,
+      12 * ms.h,
+      6 * ms.h,
+      1 * ms.h,
+    ])
+  })
+
+  it('keeps windows longer than every standard preset at the front', () => {
+    expect(previewTimeRangePresets(8 * ms.w)).toEqual([8 * ms.w, ...standard])
+  })
+
+  // Unlike the detail page, presets longer than the window are kept — the
+  // window is still being edited, so the buttons shouldn't move around.
+  it('does not drop presets longer than the window', () => {
+    expect(previewTimeRangePresets(12 * ms.h)).toEqual(standard)
+  })
+
+  it('falls back to the standard set for a missing window', () => {
+    expect(previewTimeRangePresets(0)).toEqual(standard)
   })
 })

--- a/ui/src/timeRangePresets.ts
+++ b/ui/src/timeRangePresets.ts
@@ -3,7 +3,7 @@ const DAY = 24 * HOUR
 const WEEK = 7 * DAY
 
 // Standard presets in descending order, matching the current hardcoded values in Detail.tsx.
-const STANDARD_PRESETS: number[] = [
+export const STANDARD_PRESETS: number[] = [
   4 * WEEK, // 4w
   1 * WEEK, // 1w
   1 * DAY, // 1d
@@ -25,4 +25,48 @@ export const computeTimeRangePresets = (windowMs: number): number[] => {
   // element of STANDARD_PRESETS that equals windowMs – we skip those via the
   // strict-less-than filter above and just prepend the window.
   return [windowMs, ...smaller]
+}
+
+/**
+ * Time range presets for the Create SLO preview: always the standard set, plus
+ * the objective's own window when that isn't one of them, slotted in by length.
+ *
+ * Unlike the detail page this doesn't drop the presets longer than the window.
+ * The window is a field you're still editing, and buttons rearranging under the
+ * cursor as you type is worse than occasionally offering a range longer than
+ * the window itself.
+ */
+export const previewTimeRangePresets = (windowMs: number): number[] => {
+  if (windowMs <= 0 || STANDARD_PRESETS.includes(windowMs)) {
+    return STANDARD_PRESETS
+  }
+
+  return [...STANDARD_PRESETS, windowMs].sort((a, b) => b - a)
+}
+
+/**
+ * How often a time range of the given length should auto-refresh, in ms.
+ *
+ * The presets get hand-picked intervals; anything else is refreshed at roughly
+ * a thousandth of its length, which is about one interval per pixel of graph.
+ */
+export const intervalFromDuration = (duration: number): number => {
+  // map some preset duration to nicer looking intervals
+  switch (duration) {
+    case 60 * 60 * 1000: // 1h => 10s
+      return 10 * 1000
+    case 12 * 60 * 60 * 1000: // 12h => 30s
+      return 30 * 1000
+    case 24 * 60 * 60 * 1000: // 12h => 30s
+      return 90 * 1000
+  }
+
+  if (duration < 10 * 1000 * 1000) {
+    return 10 * 1000
+  }
+  if (duration < 10 * 60 * 1000 * 1000) {
+    return Math.floor(duration / 1000 / 1000) * 1000 // round to seconds
+  }
+
+  return Math.floor(duration / 60 / 1000 / 1000) * 60 * 1000
 }


### PR DESCRIPTION
The preview composes the same parts the detail page does now, so it picks up the duration graph and the time range picker, and stops drifting from the page it is imitating.

The alerts table stays out. It reflects the state of alerting rules that only exist once the SLO is deployed, so there is nothing for it to show beforehand.
