### PR TITLE
feat(ui): recompute the error budget as you change the target

### DIFF
--- a/main.go
+++ b/main.go
@@ -1812,9 +1812,12 @@ func (s *objectiveServer) PreviewGraphDuration(ctx context.Context, req *connect
 }
 
 // graphRange resolves a request's start/end, defaulting to the last hour when
-// either end is unset.
+// they're unset or nonsensical. Note an absent timestamp arrives as the Unix
+// epoch rather than the zero time, so IsZero alone doesn't catch it — and a
+// start that isn't before end would divide the range into a zero-width step,
+// which Prometheus rejects.
 func graphRange(start, end time.Time) (time.Time, time.Time) {
-	if start.IsZero() || end.IsZero() {
+	if start.IsZero() || end.IsZero() || start.Unix() <= 0 || !end.After(start) {
 		end = time.Now()
 		start = end.Add(-1 * time.Hour)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -687,6 +687,35 @@ spec:
 	}
 }
 
+func TestGraphRange(t *testing.T) {
+	start := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	t.Run("passes a valid range through", func(t *testing.T) {
+		gotStart, gotEnd := graphRange(start, end)
+		require.Equal(t, start, gotStart)
+		require.Equal(t, end, gotEnd)
+	})
+
+	// An absent protobuf timestamp arrives as the Unix epoch, not the zero time,
+	// so both need to fall back or the step ends up zero and Prometheus 400s.
+	for _, tc := range []struct {
+		name       string
+		start, end time.Time
+	}{
+		{name: "zero", start: time.Time{}, end: time.Time{}},
+		{name: "unix epoch", start: time.Unix(0, 0), end: time.Unix(0, 0)},
+		{name: "end before start", start: end, end: start},
+		{name: "empty range", start: start, end: start},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStart, gotEnd := graphRange(tc.start, tc.end)
+			require.Equal(t, time.Hour, gotEnd.Sub(gotStart))
+			require.WithinDuration(t, time.Now(), gotEnd, time.Minute)
+		})
+	}
+}
+
 func TestObjectiveServerPreviewGraphDurationErrors(t *testing.T) {
 	t.Run("invalid config", func(t *testing.T) {
 		server, _ := newDurationServer(t, durationMatrix())

--- a/ui/src/components/create/DetailPreview.tsx
+++ b/ui/src/components/create/DetailPreview.tsx
@@ -2,15 +2,17 @@
 //
 // This is the same detail view a stored SLO gets — it composes the parts from
 // components/detail/ObjectiveDetail rather than reimplementing them, so the two
-// can't drift. What it leaves out is what a draft SLO genuinely can't have: a
-// time range to control (the preview pins one hour), and the alerts table,
-// which needs alerting rules that only exist once the SLO is deployed.
+// can't drift. The one thing it leaves out is the alerts table, which needs
+// alerting rules that only exist once the SLO is deployed.
+//
+// The time range lives in local state rather than the URL: the draft isn't
+// addressable, so there's nothing to put a range on.
 //
 // Everything around the view — the idle, loading and error states, the grouping
 // chooser's back button, the dimming while the editor is ahead of the preview —
 // lives here.
 
-import React, {useMemo, useState, type JSX} from 'react'
+import React, {useCallback, useMemo, useState, type JSX} from 'react'
 import {createClient} from '@connectrpc/connect'
 import {createConnectTransport} from '@connectrpc/connect-web'
 import type uPlot from 'uplot'
@@ -22,6 +24,9 @@ import {type Labels} from '../../labels'
 import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {PrometheusService} from '../../proto/prometheus/v1/prometheus_pb'
 import ObjectiveDetail, {type ObjectiveDetailValue} from '../detail/ObjectiveDetail'
+import TimeRangeControls from '../detail/TimeRangeControls'
+import {useAutoReload} from '../detail/useAutoReload'
+import {intervalFromDuration, previewTimeRangePresets} from '../../timeRangePresets'
 import {objectiveClient, type PreviewStatus} from './preview'
 
 interface DetailPreviewProps {
@@ -40,8 +45,6 @@ interface DetailPreviewProps {
   // this Detail view is one chosen label set of a chooser).
   onBack?: () => void
 }
-
-const noop = (): void => {}
 
 // A different sync key from the detail page's, so hovering the preview can't
 // drag the crosshair on a detail page rendered elsewhere.
@@ -84,11 +87,35 @@ const DetailPreview = ({
   )
   const client = useMemo(() => objectiveClient(baseUrl), [baseUrl])
 
-  // A fixed range captured once — a preview doesn't need live auto-refresh.
-  const [{from, to}] = useState(() => {
+  const [{from, to}, setRange] = useState(() => {
     const now = Date.now()
     return {from: now - 60 * 60 * 1000, to: now}
   })
+  const [autoReload, setAutoReload] = useState(false)
+  const [absolute, setAbsolute] = useState(true)
+
+  const updateTimeRange = useCallback((from: number, to: number) => {
+    setRange({from, to})
+  }, [])
+
+  // Dragging a selection on a graph picks an explicit window, so stop sliding it.
+  const updateTimeRangeSelect = useCallback(
+    (min: number, max: number) => {
+      setAutoReload(false)
+      updateTimeRange(min, max)
+    },
+    [updateTimeRange],
+  )
+
+  const selectRange = useCallback((duration: number) => {
+    const to = Date.now()
+    setRange({from: to - duration, to})
+  }, [])
+
+  const duration = to - from
+  const interval = intervalFromDuration(duration)
+
+  useAutoReload(autoReload, duration, interval, updateTimeRange)
 
   const detail = useMemo<ObjectiveDetailValue | null>(() => {
     if (objective === null) {
@@ -101,11 +128,11 @@ const DetailPreview = ({
       grouping: grouping ?? {},
       from,
       to,
-      absolute: true,
+      absolute,
       uPlotCursor,
-      updateTimeRange: noop,
+      updateTimeRange: updateTimeRangeSelect,
     }
-  }, [objective, promClient, grouping, from, to])
+  }, [objective, promClient, grouping, from, to, absolute, updateTimeRangeSelect])
 
   if (status === 'loading') {
     return (
@@ -141,6 +168,9 @@ const DetailPreview = ({
     detail.objectiveType === ObjectiveType.Latency ||
     detail.objectiveType === ObjectiveType.LatencyNative
 
+  const timeRanges = previewTimeRangePresets(Number(detail.objective.window?.seconds ?? 0) * 1000)
+
+
   return (
     <div className={stale ? 'opacity-55 transition-opacity' : 'transition-opacity'}>
       <div className="px-6 pt-7 pb-14">
@@ -154,6 +184,17 @@ const DetailPreview = ({
         <ObjectiveDetail.Provider value={detail}>
           <ObjectiveDetail.Header />
           <ObjectiveDetail.Tiles />
+          <TimeRangeControls
+            timeRanges={timeRanges}
+            from={from}
+            to={to}
+            interval={interval}
+            autoReload={autoReload}
+            setAutoReload={setAutoReload}
+            absolute={absolute}
+            setAbsolute={setAbsolute}
+            onSelectRange={selectRange}
+          />
           <ObjectiveDetail.ErrorBudget />
           <ObjectiveDetail.GraphRow>
             {latency && <ObjectiveDetail.PreviewDuration client={client} config={config} />}

--- a/ui/src/components/create/DetailPreview.tsx
+++ b/ui/src/components/create/DetailPreview.tsx
@@ -1,13 +1,14 @@
 // Live preview of the SLO Detail page, rendered from a materialized Objective.
 //
-// Given an Objective produced by the backend preview (see preview.ts), this
-// composes the very same building blocks as the real Detail page — the three
-// tiles and the error-budget / requests / errors graphs — querying Prometheus
-// directly through the query strings the backend computed. The result looks and
-// behaves exactly like an already-stored SLO.
+// This is the same detail view a stored SLO gets — it composes the parts from
+// components/detail/ObjectiveDetail rather than reimplementing them, so the two
+// can't drift. What it leaves out is what a draft SLO genuinely can't have: a
+// time range to control (the preview pins one hour), and the alerts table,
+// which needs alerting rules that only exist once the SLO is deployed.
 //
-// Until the backend preview endpoint exists, `objective` is null and this shows
-// the idle / unavailable states instead.
+// Everything around the view — the idle, loading and error states, the grouping
+// chooser's back button, the dimming while the editor is ahead of the preview —
+// lives here.
 
 import React, {useMemo, useState, type JSX} from 'react'
 import {createClient} from '@connectrpc/connect'
@@ -16,17 +17,12 @@ import type uPlot from 'uplot'
 import {ArrowLeft, LineChart, Play} from 'lucide-react'
 import {Spinner} from '@/components/ui/spinner'
 import {Button} from '@/components/ui/button'
-import {hasObjectiveType, ObjectiveType, latencyTarget} from '../../App'
-import {type Labels, MetricName} from '../../labels'
+import {hasObjectiveType, ObjectiveType} from '../../App'
+import {type Labels} from '../../labels'
 import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {PrometheusService} from '../../proto/prometheus/v1/prometheus_pb'
-import {usePrometheusQuery, replaceInterval, vectorErrorsTotal} from '../../prometheus'
-import ObjectiveTiles from '../tiles/ObjectiveTiles'
-import ObjectiveLabels from '../ObjectiveLabels'
-import ErrorBudgetGraph from '../graphs/ErrorBudgetGraph'
-import RequestsGraph from '../graphs/RequestsGraph'
-import ErrorsGraph from '../graphs/ErrorsGraph'
-import {type PreviewStatus} from './preview'
+import ObjectiveDetail, {type ObjectiveDetailValue} from '../detail/ObjectiveDetail'
+import {objectiveClient, type PreviewStatus} from './preview'
 
 interface DetailPreviewProps {
   baseUrl: string
@@ -34,6 +30,9 @@ interface DetailPreviewProps {
   status: PreviewStatus
   stale: boolean
   onRun: () => void
+  // The YAML that produced `objective`. The duration graph is computed from the
+  // same draft, since there is no stored SLO to look up.
+  config: string
   // The grouping label set this preview is scoped to, shown as pills next to the
   // objective's labels. Undefined for an ungrouped (overall) preview.
   grouping?: Labels
@@ -43,6 +42,10 @@ interface DetailPreviewProps {
 }
 
 const noop = (): void => {}
+
+// A different sync key from the detail page's, so hovering the preview can't
+// drag the crosshair on a detail page rendered elsewhere.
+const uPlotCursor: uPlot.Cursor = {y: false, lock: true, sync: {key: 'create-preview'}}
 
 const EmptyState = ({onRun}: {onRun: () => void}): JSX.Element => (
   <div className="flex min-h-[60vh] flex-col items-center justify-center gap-2.5 p-10 text-center text-muted-foreground">
@@ -65,11 +68,21 @@ const Message = ({title, children}: {title: string; children: React.ReactNode}):
   </div>
 )
 
-const DetailPreview = ({baseUrl, objective, status, stale, onRun, grouping, onBack}: DetailPreviewProps): JSX.Element => {
+const DetailPreview = ({
+  baseUrl,
+  objective,
+  status,
+  stale,
+  onRun,
+  config,
+  grouping,
+  onBack,
+}: DetailPreviewProps): JSX.Element => {
   const promClient = useMemo(
     () => createClient(PrometheusService, createConnectTransport({baseUrl})),
     [baseUrl],
   )
+  const client = useMemo(() => objectiveClient(baseUrl), [baseUrl])
 
   // A fixed range captured once — a preview doesn't need live auto-refresh.
   const [{from, to}] = useState(() => {
@@ -77,22 +90,22 @@ const DetailPreview = ({baseUrl, objective, status, stale, onRun, grouping, onBa
     return {from: now - 60 * 60 * 1000, to: now}
   })
 
-  const countTotal = objective?.queries?.countTotal ?? ''
-  const countErrors = objective?.queries?.countErrors ?? ''
-  const queriesEnabled = objective !== null && countTotal !== ''
-
-  const {response: totalResponse, status: totalStatus} = usePrometheusQuery(
-    promClient,
-    countTotal,
-    to / 1000,
-    {enabled: queriesEnabled},
-  )
-  const {response: errorResponse, status: errorStatus} = usePrometheusQuery(
-    promClient,
-    countErrors,
-    to / 1000,
-    {enabled: queriesEnabled},
-  )
+  const detail = useMemo<ObjectiveDetailValue | null>(() => {
+    if (objective === null) {
+      return null
+    }
+    return {
+      objective,
+      objectiveType: hasObjectiveType(objective),
+      promClient,
+      grouping: grouping ?? {},
+      from,
+      to,
+      absolute: true,
+      uPlotCursor,
+      updateTimeRange: noop,
+    }
+  }, [objective, promClient, grouping, from, to])
 
   if (status === 'loading') {
     return (
@@ -120,21 +133,13 @@ const DetailPreview = ({baseUrl, objective, status, stale, onRun, grouping, onBa
     )
   }
 
-  if (objective === null) {
+  if (detail === null) {
     return <EmptyState onRun={onRun} />
   }
 
-  const name = objective.labels[MetricName] ?? 'preview'
-  const objectiveType = hasObjectiveType(objective)
-  const objectiveTypeLatency =
-    objectiveType === ObjectiveType.Latency || objectiveType === ObjectiveType.LatencyNative
-
-  const loading = totalStatus === 'pending' || errorStatus === 'pending'
-  const success = totalStatus === 'success' && errorStatus === 'success'
-
-  const {errors, total} = vectorErrorsTotal(totalResponse, errorResponse)
-
-  const uPlotCursor: uPlot.Cursor = {y: false, lock: true, sync: {key: 'create-preview'}}
+  const latency =
+    detail.objectiveType === ObjectiveType.Latency ||
+    detail.objectiveType === ObjectiveType.LatencyNative
 
   return (
     <div className={stale ? 'opacity-55 transition-opacity' : 'transition-opacity'}>
@@ -146,71 +151,14 @@ const DetailPreview = ({baseUrl, objective, status, stale, onRun, grouping, onBa
             <ArrowLeft size={15} /> Groupings
           </button>
         )}
-        <div className="mb-7">
-          <h3 className="mb-3">{name}</h3>
-          <ObjectiveLabels labels={objective.labels} grouping={grouping} />
-          {objective.description !== '' && (
-            <p className="mt-3 max-w-prose text-sm leading-relaxed">{objective.description}</p>
-          )}
-        </div>
-
-        <div className="mb-7">
-          <ObjectiveTiles
-            objective={objective}
-            loading={loading}
-            success={success}
-            errors={errors}
-            total={total}
-          />
-        </div>
-
-        {objective.queries?.graphErrorBudget !== undefined && (
-          <div className="mb-7">
-            <ErrorBudgetGraph
-              client={promClient}
-              query={objective.queries.graphErrorBudget}
-              from={from}
-              to={to}
-              uPlotCursor={uPlotCursor}
-              updateTimeRange={noop}
-              absolute={true}
-            />
-          </div>
-        )}
-
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          {objective.queries?.graphRequests !== undefined && (
-            <RequestsGraph
-              client={promClient}
-              query={replaceInterval(objective.queries.graphRequests, from, to)}
-              from={from}
-              to={to}
-              uPlotCursor={uPlotCursor}
-              type={objectiveType}
-              updateTimeRange={noop}
-              absolute={true}
-            />
-          )}
-          {objective.queries?.graphErrors !== undefined && (
-            <ErrorsGraph
-              client={promClient}
-              type={objectiveType}
-              query={replaceInterval(objective.queries.graphErrors, from, to)}
-              from={from}
-              to={to}
-              uPlotCursor={uPlotCursor}
-              updateTimeRange={noop}
-              absolute={true}
-            />
-          )}
-        </div>
-
-        {objectiveTypeLatency && (
-          <p className="mt-4 text-xs text-muted-foreground">
-            Latency target: {latencyTarget(objective) ?? '—'} ms · the duration graph and alerts table appear
-            on the stored SLO's Detail page.
-          </p>
-        )}
+        <ObjectiveDetail.Provider value={detail}>
+          <ObjectiveDetail.Header />
+          <ObjectiveDetail.Tiles />
+          <ObjectiveDetail.ErrorBudget />
+          <ObjectiveDetail.GraphRow>
+            {latency && <ObjectiveDetail.PreviewDuration client={client} config={config} />}
+          </ObjectiveDetail.GraphRow>
+        </ObjectiveDetail.Provider>
       </div>
     </div>
   )

--- a/ui/src/components/create/DetailPreview.tsx
+++ b/ui/src/components/create/DetailPreview.tsx
@@ -38,6 +38,11 @@ interface DetailPreviewProps {
   // The YAML that produced `objective`. The duration graph is computed from the
   // same draft, since there is no stored SLO to look up.
   config: string
+  // The target currently in the editor, as a fraction. Availability and error
+  // budget are pure functions of it and of the error/total counts, which don't
+  // depend on the target at all — so moving it recomputes the tiles and the
+  // error budget graph immediately, without materializing the draft again.
+  target?: number
   // The grouping label set this preview is scoped to, shown as pills next to the
   // objective's labels. Undefined for an ungrouped (overall) preview.
   grouping?: Labels
@@ -78,6 +83,7 @@ const DetailPreview = ({
   stale,
   onRun,
   config,
+  target,
   grouping,
   onBack,
 }: DetailPreviewProps): JSX.Element => {
@@ -122,7 +128,7 @@ const DetailPreview = ({
       return null
     }
     return {
-      objective,
+      objective: target !== undefined ? {...objective, target} : objective,
       objectiveType: hasObjectiveType(objective),
       promClient,
       grouping: grouping ?? {},
@@ -132,7 +138,7 @@ const DetailPreview = ({
       uPlotCursor,
       updateTimeRange: updateTimeRangeSelect,
     }
-  }, [objective, promClient, grouping, from, to, absolute, updateTimeRangeSelect])
+  }, [objective, target, promClient, grouping, from, to, absolute, updateTimeRangeSelect])
 
   if (status === 'loading') {
     return (
@@ -195,7 +201,7 @@ const DetailPreview = ({
             setAbsolute={setAbsolute}
             onSelectRange={selectRange}
           />
-          <ObjectiveDetail.ErrorBudget />
+          <ObjectiveDetail.ErrorBudget queryTarget={objective?.target} />
           <ObjectiveDetail.GraphRow>
             {latency && <ObjectiveDetail.PreviewDuration client={client} config={config} />}
           </ObjectiveDetail.GraphRow>

--- a/ui/src/components/create/config.ts
+++ b/ui/src/components/create/config.ts
@@ -33,6 +33,9 @@ export const DEFAULT_CONFIG: CreateConfig = {
   labels: [
     {k: 'prometheus', v: 'k8s'},
     {k: 'role', v: 'alert-rules'},
+    // Only pyrra.dev/-prefixed labels become part of the objective itself, so
+    // this is the one that shows up on the detail page.
+    {k: 'pyrra.dev/team', v: 'platform'},
   ],
   target: '99.0',
   window: '7d',

--- a/ui/src/components/create/preview.ts
+++ b/ui/src/components/create/preview.ts
@@ -5,7 +5,7 @@
 // parsing on the backend, so the preview renders exactly as a stored SLO would —
 // same queries, same tiles, same graphs against real Prometheus data.
 
-import {Code, ConnectError, createClient} from '@connectrpc/connect'
+import {type Client, Code, ConnectError, createClient} from '@connectrpc/connect'
 import {createConnectTransport} from '@connectrpc/connect-web'
 import {ObjectiveService, type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
 
@@ -18,10 +18,13 @@ export class PreviewUnavailableError extends Error {
   }
 }
 
+export const objectiveClient = (baseUrl: string): Client<typeof ObjectiveService> =>
+  createClient(ObjectiveService, createConnectTransport({baseUrl}))
+
 // grouping optionally scopes the preview to a single grouping label set (e.g.
 // {handler="/api"}); empty previews the objective grouped by its grouping labels.
 export async function previewObjective(baseUrl: string, config: string, grouping = ''): Promise<Objective> {
-  const client = createClient(ObjectiveService, createConnectTransport({baseUrl}))
+  const client = objectiveClient(baseUrl)
   try {
     const response = await client.preview({config, grouping})
     if (response.objective === undefined) {

--- a/ui/src/components/detail/ObjectiveDetail.tsx
+++ b/ui/src/components/detail/ObjectiveDetail.tsx
@@ -140,6 +140,11 @@ const ErrorBudget = ({queryTarget}: {queryTarget?: number}): JSX.Element => {
   const {objective, promClient, from, to, uPlotCursor, updateTimeRange, absolute} =
     useObjectiveDetail()
 
+  // A 100% target has no error budget, so there's no percentage of one to plot.
+  if (objective.target >= 1) {
+    return <></>
+  }
+
   return (
     <div className="mb-24 flex flex-wrap">
       <div className="w-full">

--- a/ui/src/components/detail/ObjectiveDetail.tsx
+++ b/ui/src/components/detail/ObjectiveDetail.tsx
@@ -132,7 +132,11 @@ const Tiles = (): JSX.Element => {
   )
 }
 
-const ErrorBudget = (): JSX.Element => {
+// queryTarget is the target the graphErrorBudget query was built with. The
+// Create editor passes it so a target changed since then re-derives the series
+// locally instead of waiting for a new preview; the detail page's target can't
+// move out from under its query, so it doesn't.
+const ErrorBudget = ({queryTarget}: {queryTarget?: number}): JSX.Element => {
   const {objective, promClient, from, to, uPlotCursor, updateTimeRange, absolute} =
     useObjectiveDetail()
 
@@ -148,6 +152,11 @@ const ErrorBudget = (): JSX.Element => {
             uPlotCursor={uPlotCursor}
             updateTimeRange={updateTimeRange}
             absolute={absolute}
+            rescale={
+              queryTarget !== undefined && queryTarget !== objective.target
+                ? {from: queryTarget, to: objective.target}
+                : undefined
+            }
           />
         ) : (
           <></>

--- a/ui/src/components/detail/ObjectiveDetail.tsx
+++ b/ui/src/components/detail/ObjectiveDetail.tsx
@@ -1,0 +1,317 @@
+// The SLO detail view, as a set of parts both consumers compose themselves.
+//
+// The stored-SLO page (pages/Detail.tsx) and the Create editor's live preview
+// (components/create/DetailPreview.tsx) render the same objective in the same
+// way, but not the same *set* of things: only the stored page has a time range
+// to control, alerting rules to evaluate, or a config to show. That used to be
+// two parallel implementations of the same markup, which drifted.
+//
+// So instead of one component with flags for what to leave out, each page
+// composes the parts it actually has. Everything the parts share — the
+// objective, the clients, the time range — comes from the context; anything
+// only one part needs is a prop.
+
+import React, {createContext, use, type JSX, type ReactNode} from 'react'
+import {type Client} from '@connectrpc/connect'
+import type uPlot from 'uplot'
+import {cn} from '@/lib/utils'
+import {latencyTarget, ObjectiveType} from '../../App'
+import {type Labels, labelsString, MetricName} from '../../labels'
+import {
+  type Objective,
+  type ObjectiveService,
+} from '../../proto/objectives/v1alpha1/objectives_pb'
+import {type PrometheusService} from '../../proto/prometheus/v1/prometheus_pb'
+import {replaceInterval, usePrometheusQuery, vectorErrorsTotal} from '../../prometheus'
+import {useGraphDuration, usePreviewGraphDuration} from '../../objectives'
+import ObjectiveTiles from '../tiles/ObjectiveTiles'
+import ObjectiveLabels from '../ObjectiveLabels'
+import ErrorBudgetGraph from '../graphs/ErrorBudgetGraph'
+import RequestsGraph from '../graphs/RequestsGraph'
+import ErrorsGraph from '../graphs/ErrorsGraph'
+import DurationGraph from '../graphs/DurationGraph'
+import AlertsTable from '../AlertsTable'
+
+export interface ObjectiveDetailValue {
+  // Guaranteed non-null with labels defined — both consumers hold their spinner
+  // and empty states until it is.
+  objective: Objective
+  objectiveType: ObjectiveType
+  promClient: Client<typeof PrometheusService>
+  // The grouping label set this view is scoped to, empty when unscoped.
+  grouping: Labels
+  from: number
+  to: number
+  absolute: boolean
+  // Carries the page's cursor sync key. Required rather than defaulted: two
+  // views sharing a key would drag each other's crosshairs around.
+  uPlotCursor: uPlot.Cursor
+  updateTimeRange: (min: number, max: number, absolute: boolean) => void
+}
+
+const ObjectiveDetailContext = createContext<ObjectiveDetailValue | null>(null)
+
+const useObjectiveDetail = (): ObjectiveDetailValue => {
+  const value = use(ObjectiveDetailContext)
+  if (value === null) {
+    throw new Error('ObjectiveDetail parts must be rendered inside <ObjectiveDetail.Provider>')
+  }
+  return value
+}
+
+const Provider = ({
+  value,
+  children,
+}: {
+  value: ObjectiveDetailValue
+  children: ReactNode
+}): JSX.Element => <ObjectiveDetailContext value={value}>{children}</ObjectiveDetailContext>
+
+const Header = (): JSX.Element => {
+  const {objective, grouping} = useObjectiveDetail()
+
+  const name = objective.labels[MetricName]
+  const hasLabels = Object.keys({...objective.labels, ...grouping}).some((k) => k !== MetricName)
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full 3xl:w-10/12 3xl:mx-auto">
+        <h3>{name}</h3>
+        <ObjectiveLabels labels={objective.labels} grouping={grouping} />
+      </div>
+      {objective.description !== undefined && objective.description !== '' ? (
+        <div
+          className="w-full md:w-1/2 3xl:w-5/12 3xl:ml-[8.33%]"
+          style={{marginTop: hasLabels ? 12 : 0}}>
+          <p>{objective.description}</p>
+        </div>
+      ) : (
+        <></>
+      )}
+    </div>
+  )
+}
+
+const Tiles = (): JSX.Element => {
+  const {objective, promClient, to} = useObjectiveDetail()
+
+  const countTotal = objective.queries?.countTotal ?? ''
+  const countErrors = objective.queries?.countErrors ?? ''
+
+  const {response: totalResponse, status: totalStatus} = usePrometheusQuery(
+    promClient,
+    countTotal,
+    to / 1000,
+    {enabled: countTotal !== ''},
+  )
+
+  const {response: errorResponse, status: errorStatus} = usePrometheusQuery(
+    promClient,
+    countErrors,
+    to / 1000,
+    {enabled: countTotal !== ''},
+  )
+
+  const loading: boolean = totalStatus === 'pending' || errorStatus === 'pending'
+  const success: boolean = totalStatus === 'success' && errorStatus === 'success'
+
+  const {errors, total} = vectorErrorsTotal(totalResponse, errorResponse)
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full 3xl:w-10/12 3xl:mx-auto">
+        <ObjectiveTiles
+          objective={objective}
+          loading={loading}
+          success={success}
+          errors={errors}
+          total={total}
+        />
+      </div>
+    </div>
+  )
+}
+
+const ErrorBudget = (): JSX.Element => {
+  const {objective, promClient, from, to, uPlotCursor, updateTimeRange, absolute} =
+    useObjectiveDetail()
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full">
+        {objective.queries?.graphErrorBudget !== undefined ? (
+          <ErrorBudgetGraph
+            client={promClient}
+            query={objective.queries.graphErrorBudget}
+            from={from}
+            to={to}
+            uPlotCursor={uPlotCursor}
+            updateTimeRange={updateTimeRange}
+            absolute={absolute}
+          />
+        ) : (
+          <></>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// GraphRow renders the requests and errors graphs side by side. Latency
+// objectives pass a Duration part as children, which takes the third column.
+const GraphRow = ({children}: {children?: ReactNode}): JSX.Element => {
+  const {objective, objectiveType, promClient, from, to, uPlotCursor, updateTimeRange, absolute} =
+    useObjectiveDetail()
+
+  const latency =
+    objectiveType === ObjectiveType.Latency || objectiveType === ObjectiveType.LatencyNative
+  const column = cn('w-full px-3', latency ? '3xl:w-1/3' : 'md:w-1/2')
+
+  return (
+    <div className="mb-24 flex flex-wrap -mx-3">
+      <div className={column}>
+        {objective.queries?.graphRequests !== undefined ? (
+          <RequestsGraph
+            client={promClient}
+            query={replaceInterval(objective.queries.graphRequests, from, to)}
+            from={from}
+            to={to}
+            uPlotCursor={uPlotCursor}
+            type={objectiveType}
+            updateTimeRange={updateTimeRange}
+            absolute={absolute}
+          />
+        ) : (
+          <></>
+        )}
+      </div>
+      <div className={column}>
+        {objective.queries?.graphErrors !== undefined ? (
+          <ErrorsGraph
+            client={promClient}
+            type={objectiveType}
+            query={replaceInterval(objective.queries.graphErrors, from, to)}
+            from={from}
+            to={to}
+            uPlotCursor={uPlotCursor}
+            updateTimeRange={updateTimeRange}
+            absolute={absolute}
+          />
+        ) : (
+          <></>
+        )}
+      </div>
+      {React.Children.map(children, (child) => (
+        <div className={column}>{child}</div>
+      ))}
+    </div>
+  )
+}
+
+// Duration and PreviewDuration differ only in where the percentiles come from:
+// a stored SLO is looked up by expr, a draft one is materialized from its YAML.
+// Two named parts rather than one part with an optional config, so the call
+// site says which it is.
+const Duration = ({
+  client,
+  expr,
+}: {
+  client: Client<typeof ObjectiveService>
+  expr: string
+}): JSX.Element => {
+  const {objective, grouping, from, to, uPlotCursor, updateTimeRange} = useObjectiveDetail()
+  const {timeseries, status} = useGraphDuration(client, expr, labelsString(grouping), from, to)
+
+  return (
+    <DurationGraph
+      timeseries={timeseries}
+      loading={status === 'pending'}
+      from={from}
+      to={to}
+      uPlotCursor={uPlotCursor}
+      updateTimeRange={updateTimeRange}
+      target={objective.target}
+      latency={latencyTarget(objective)}
+    />
+  )
+}
+
+const PreviewDuration = ({
+  client,
+  config,
+}: {
+  client: Client<typeof ObjectiveService>
+  config: string
+}): JSX.Element => {
+  const {objective, grouping, from, to, uPlotCursor, updateTimeRange} = useObjectiveDetail()
+  const {timeseries, status} = usePreviewGraphDuration(
+    client,
+    config,
+    labelsString(grouping),
+    from,
+    to,
+  )
+
+  return (
+    <DurationGraph
+      timeseries={timeseries}
+      loading={status === 'pending'}
+      from={from}
+      to={to}
+      uPlotCursor={uPlotCursor}
+      updateTimeRange={updateTimeRange}
+      target={objective.target}
+      latency={latencyTarget(objective)}
+    />
+  )
+}
+
+const Alerts = ({client}: {client: Client<typeof ObjectiveService>}): JSX.Element => {
+  const {objective, promClient, grouping, from, to, uPlotCursor} = useObjectiveDetail()
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full">
+        <h4>Multi Burn Rate Alerts</h4>
+        <AlertsTable
+          client={client}
+          promClient={promClient}
+          objective={objective}
+          grouping={grouping}
+          from={from}
+          to={to}
+          uPlotCursor={uPlotCursor}
+        />
+      </div>
+    </div>
+  )
+}
+
+const Config = (): JSX.Element => {
+  const {objective} = useObjectiveDetail()
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full">
+        <h4>Config</h4>
+        <pre className="rounded bg-muted p-5 overflow-auto max-w-full">
+          <code>{objective.config}</code>
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+const ObjectiveDetail = {
+  Provider,
+  Header,
+  Tiles,
+  ErrorBudget,
+  GraphRow,
+  Duration,
+  PreviewDuration,
+  Alerts,
+  Config,
+}
+
+export default ObjectiveDetail

--- a/ui/src/components/detail/TimeRangeControls.tsx
+++ b/ui/src/components/detail/TimeRangeControls.tsx
@@ -1,0 +1,107 @@
+// The detail page's time range bar: presets, a custom range, auto-reload and
+// the absolute/relative scale switch.
+//
+// Deliberately not part of the ObjectiveDetail compound components — the Create
+// editor's preview renders a fixed range and has nothing to control here.
+
+import React, {type JSX, useState} from 'react'
+import {ChartArea, ChartLine, CornerDownLeft} from 'lucide-react'
+import {ToggleGroup, ToggleGroupItem} from '@/components/ui/toggle-group'
+import {cn} from '@/lib/utils'
+import Toggle from '../Toggle'
+import {formatDuration, parseDuration} from '../../duration'
+
+interface TimeRangeControlsProps {
+  timeRanges: number[]
+  from: number
+  to: number
+  interval: number
+  autoReload: boolean
+  setAutoReload: (autoReload: boolean) => void
+  absolute: boolean
+  setAbsolute: (absolute: boolean) => void
+  // Selects a range of the given duration, ending now.
+  onSelectRange: (duration: number) => void
+}
+
+const TimeRangeControls = ({
+  timeRanges,
+  from,
+  to,
+  interval,
+  autoReload,
+  setAutoReload,
+  absolute,
+  setAbsolute,
+  onSelectRange,
+}: TimeRangeControlsProps): JSX.Element => {
+  const [customRange, setCustomRange] = useState('')
+  const [customRangeError, setCustomRangeError] = useState(false)
+
+  const handleCustomRangeSubmit = () => {
+    const ms = parseDuration(customRange)
+    if (ms !== null && ms > 0) {
+      setCustomRangeError(false)
+      onSelectRange(ms)
+    } else if (customRange !== '') {
+      setCustomRangeError(true)
+    }
+  }
+
+  return (
+    <div className="mb-24 flex flex-wrap">
+      <div className="w-full text-center py-8 bg-[linear-gradient(0deg,transparent_45%,var(--muted)_50%,transparent_55%)]">
+        <div className="mx-auto flex flex-col items-center gap-5 bg-background sm:w-2/3 md:w-1/2 xl:flex-row xl:justify-center">
+          <div className="flex gap-5 justify-center">
+            <div className="flex items-center">
+              <div className="relative">
+                <input
+                  type="text"
+                  value={customRange}
+                  onChange={(e) => {
+                    setCustomRange(e.target.value)
+                    setCustomRangeError(false)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleCustomRangeSubmit()
+                  }}
+                  onBlur={handleCustomRangeSubmit}
+                  placeholder={formatDuration(timeRanges[0] * 2)}
+                  className={cn(
+                    'h-8 w-14 rounded-l-lg rounded-r-none border border-r-0 border-input bg-muted/50 shadow-inner pl-2 pr-5 text-sm font-medium outline-none transition-all placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:z-10',
+                    customRangeError && 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20'
+                  )}
+                />
+                {customRange !== '' && <CornerDownLeft size={11} className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" />}
+              </div>
+              <ToggleGroup variant="outline" value={[String(to - from)]} onValueChange={(val) => { if (val.length > 0) { setCustomRange(''); setCustomRangeError(false); onSelectRange(Number(val[val.length - 1])) } }}>
+                {timeRanges.map((t: number, i: number) => (
+                  <ToggleGroupItem key={t} value={String(t)} variant="outline" aria-label={formatDuration(t)} className={i === 0 ? 'rounded-l-none!' : undefined}>
+                    {formatDuration(t)}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </div>
+            <Toggle
+              checked={autoReload}
+              onChange={() => { setAutoReload(!autoReload) }}
+              onText={formatDuration(interval)}
+            />
+          </div>
+          <ToggleGroup variant="outline" value={[absolute ? 'absolute' : 'relative']} onValueChange={(val) => { if (val.length > 0) setAbsolute(val[val.length - 1] === 'absolute') }}>
+            <ToggleGroupItem value="absolute" variant="outline" aria-label="Absolute scale">
+              <ChartArea size={16} color={absolute ? 'white' : 'currentColor'} />
+              <span className="ml-2">Absolute</span>
+            </ToggleGroupItem>
+            <ToggleGroupItem value="relative" variant="outline" aria-label="Relative scale">
+              <ChartLine size={16} color={!absolute ? 'white' : 'currentColor'} />
+              <span className="ml-2">Relative</span>
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TimeRangeControls

--- a/ui/src/components/detail/useAutoReload.ts
+++ b/ui/src/components/detail/useAutoReload.ts
@@ -1,0 +1,26 @@
+import {useEffect} from 'react'
+
+// useAutoReload slides the time range forward on a timer, keeping its length and
+// pinning the end to now. Shared by the detail page and the Create preview,
+// which differ only in where they keep the range.
+export const useAutoReload = (
+  enabled: boolean,
+  duration: number,
+  interval: number,
+  updateTimeRange: (from: number, to: number, absolute: boolean) => void,
+): void => {
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    const id = setInterval(() => {
+      const to = Date.now()
+      updateTimeRange(to - duration, to, false)
+    }, interval)
+
+    return () => {
+      clearInterval(id)
+    }
+  }, [enabled, duration, interval, updateTimeRange])
+}

--- a/ui/src/components/graphs/DurationGraph.tsx
+++ b/ui/src/components/graphs/DurationGraph.tsx
@@ -1,31 +1,24 @@
-import React, {type JSX, useEffect, useLayoutEffect, useRef, useState} from 'react'
+import React, {type JSX, useLayoutEffect, useMemo, useRef, useState} from 'react'
 import {Spinner} from '@/components/ui/spinner'
 import UplotReact from 'uplot-react'
 import {type AlignedData} from 'uplot';
 import type uPlot from 'uplot'
 import {EXTERNAL_URL} from '../../App'
 import {ExternalLink} from 'lucide-react'
-import {type Labels, labelsString, parseLabelValue} from '../../labels'
+import {parseLabelValue} from '../../labels'
 import {colorful, greys} from './colors'
 import {seriesGaps} from './gaps'
-import {type Client} from '@connectrpc/connect'
-import {
-  type GraphDurationResponse,
-  type ObjectiveService,
-  type Series,
-  type Timeseries,
-} from '../../proto/objectives/v1alpha1/objectives_pb'
-import {timestampFromDate} from '@bufbuild/protobuf/wkt'
+import {type Timeseries} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {selectTimeRange} from './selectTimeRange'
 import {formatDuration} from '../../duration'
 import {buildExternalHRef, externalName} from '../../external'
 import {useGraphTooltip, formatAxisDates} from './useGraphTooltip'
 import GraphTooltip from './GraphTooltip'
+import {durationAlignedData} from './durationData'
 
 interface DurationGraphProps {
-  client: Client<typeof ObjectiveService>
-  labels: Labels
-  grouping: Labels
+  timeseries: Timeseries[]
+  loading: boolean
   from: number
   to: number
   uPlotCursor: uPlot.Cursor
@@ -35,9 +28,8 @@ interface DurationGraphProps {
 }
 
 const DurationGraph = ({
-  client,
-  labels,
-  grouping,
+  timeseries,
+  loading,
   from,
   to,
   uPlotCursor,
@@ -49,11 +41,13 @@ const DurationGraph = ({
 
   const {tooltipRef, initHook, setCursorHook} = useGraphTooltip(150)
 
-  const [durations, setDurations] = useState<AlignedData>()
-  const [durationQueries, setDurationQueries] = useState<string[]>([])
-  const [durationLabels, setDurationLabels] = useState<string[]>([])
-  const [durationsLoading, setDurationsLoading] = useState<boolean>(true)
   const [width, setWidth] = useState<number>(500)
+
+  const {
+    data: durations,
+    labels: durationLabels,
+    queries: durationQueries,
+  } = useMemo(() => durationAlignedData(timeseries, latency), [timeseries, latency])
 
   const setWidthFromContainer = () => {
     if (targetRef.current !== undefined && targetRef.current !== null) {
@@ -66,59 +60,12 @@ const DurationGraph = ({
   // Set width on every window resize
   window.addEventListener('resize', setWidthFromContainer)
 
-  useEffect(() => {
-    setDurationsLoading(true)
-    client
-      .graphDuration({
-        expr: labelsString(labels),
-        grouping: labelsString(grouping),
-        start: timestampFromDate(new Date(from)),
-        end: timestampFromDate(new Date(to)),
-      })
-      .then((resp: GraphDurationResponse) => {
-        let durationTimestamps: number[] = []
-        const durationData: number[][] = []
-        const durationLabels: string[] = []
-        const durationQueries: string[] = []
-
-        // The first series is a straight line (same latency target value for all timestamps)
-        // showing the objective.
-        if (latency !== undefined) {
-          durationData.push(Array(resp.timeseries[0].series[0].values.length).fill(latency / 1000) as number[])
-          durationLabels.push('{quantile="target"}')
-        }
-
-        resp.timeseries.forEach((timeseries: Timeseries, i: number) => {
-          const [x, ...series] = timeseries.series
-          if (i === 0) {
-            durationTimestamps = x.values
-          }
-
-          series.forEach((s: Series) => {
-            durationData.push(s.values)
-          })
-
-          durationLabels.push(...timeseries.labels)
-          durationQueries.push(timeseries.query)
-        })
-        setDurations([durationTimestamps, ...durationData])
-        setDurationLabels(durationLabels)
-        setDurationQueries(durationQueries)
-      })
-      .catch(() => {
-        setDurations(undefined)
-      })
-      .finally(() => {
-        setDurationsLoading(false)
-      })
-  }, [client, labels, grouping, from, to, latency])
-
   return (
     <>
       <div style={{display: 'flex', alignItems: 'baseline', justifyContent: 'space-between'}}>
         <h4 className="graphs-headline">
           Duration
-          {durationsLoading ? (
+          {loading ? (
             <Spinner
               className="ml-4 mb-2 h-4 w-4 border-1"
             />

--- a/ui/src/components/graphs/ErrorBudgetGraph.tsx
+++ b/ui/src/components/graphs/ErrorBudgetGraph.tsx
@@ -14,6 +14,7 @@ import {type PrometheusService, type SamplePair, type SampleStream} from '../../
 import {usePrometheusQueryRange} from '../../prometheus'
 import {selectTimeRange} from './selectTimeRange'
 import {buildExternalHRef, externalName} from '../../external'
+import {rescaleErrorBudget} from './errorBudget'
 
 interface ErrorBudgetGraphProps {
   client: Client<typeof PrometheusService>
@@ -23,6 +24,9 @@ interface ErrorBudgetGraphProps {
   uPlotCursor: uPlot.Cursor
   updateTimeRange: (min: number, max: number, absolute: boolean) => void
   absolute: boolean
+  // When the objective's target has moved since the query was built, re-derives
+  // the series for the new target instead of re-querying. See errorBudget.ts.
+  rescale?: {from: number; to: number}
 }
 
 const ErrorBudgetGraph = ({
@@ -33,6 +37,7 @@ const ErrorBudgetGraph = ({
   uPlotCursor,
   updateTimeRange,
   absolute = false,
+  rescale,
 }: ErrorBudgetGraphProps): JSX.Element => {
   const targetRef = useRef<HTMLDivElement>(null)
 
@@ -72,7 +77,9 @@ const ErrorBudgetGraph = ({
       response.options.value.samples.forEach((s: SampleStream) => {
         s.values.forEach((sp: SamplePair) => {
           times.push(Number(sp.time))
-          values.push(sp.value * 100)
+          const value =
+            rescale !== undefined ? rescaleErrorBudget(sp.value, rescale.from, rescale.to) : sp.value
+          values.push(value * 100)
         })
       })
       samples = [times, values]

--- a/ui/src/components/graphs/durationData.test.ts
+++ b/ui/src/components/graphs/durationData.test.ts
@@ -1,0 +1,52 @@
+import {describe, expect, it} from 'vitest'
+import {durationAlignedData} from './durationData'
+import {type Timeseries} from '../../proto/objectives/v1alpha1/objectives_pb'
+
+// The proto messages carry $typeName fields we don't care about here.
+const timeseries = (labels: string[], query: string, series: number[][]): Timeseries =>
+  ({labels, query, series: series.map((values) => ({values}))}) as unknown as Timeseries
+
+describe('durationAlignedData', () => {
+  const p99 = timeseries(
+    ['{quantile="p99"}'],
+    'histogram_quantile(0.99, foo)',
+    [
+      [0, 1, 2], // x
+      [0.1, 0.2, 0.3],
+    ],
+  )
+
+  it('aligns a single percentile', () => {
+    const {data, labels, queries} = durationAlignedData([p99], undefined)
+
+    expect(data).toEqual([
+      [0, 1, 2],
+      [0.1, 0.2, 0.3],
+    ])
+    expect(labels).toEqual(['{quantile="p99"}'])
+    expect(queries).toEqual(['histogram_quantile(0.99, foo)'])
+  })
+
+  it('prefixes a flat target line when a latency target is set', () => {
+    const {data, labels} = durationAlignedData([p99], 200)
+
+    // 200ms becomes 0.2s, held flat across every timestamp.
+    expect(data).toEqual([
+      [0, 1, 2],
+      [0.2, 0.2, 0.2],
+      [0.1, 0.2, 0.3],
+    ])
+    expect(labels).toEqual(['{quantile="target"}', '{quantile="p99"}'])
+  })
+
+  it('returns no data when the objective has no series', () => {
+    // A draft SLO pointed at a metric that doesn't exist yet: the graph has to
+    // render empty rather than throw on timeseries[0].series[0].
+    expect(durationAlignedData([], 200)).toEqual({data: undefined, labels: [], queries: []})
+    expect(durationAlignedData([timeseries([], 'q', [])], 200)).toEqual({
+      data: undefined,
+      labels: [],
+      queries: [],
+    })
+  })
+})

--- a/ui/src/components/graphs/durationData.ts
+++ b/ui/src/components/graphs/durationData.ts
@@ -1,0 +1,50 @@
+import {type AlignedData} from 'uplot'
+import {type Series, type Timeseries} from '../../proto/objectives/v1alpha1/objectives_pb'
+
+export interface DurationAlignedData {
+  data: AlignedData | undefined
+  labels: string[]
+  queries: string[]
+}
+
+// durationAlignedData folds the per-percentile timeseries into the single
+// x-then-y array uPlot wants, optionally prefixing the flat line that marks the
+// objective's latency target.
+export const durationAlignedData = (
+  timeseries: Timeseries[],
+  latency: number | undefined,
+): DurationAlignedData => {
+  // A draft SLO pointed at a metric that doesn't exist (or a typo mid-edit)
+  // comes back without any series at all.
+  if (timeseries.length === 0 || timeseries[0].series.length === 0) {
+    return {data: undefined, labels: [], queries: []}
+  }
+
+  let timestamps: number[] = []
+  const data: number[][] = []
+  const labels: string[] = []
+  const queries: string[] = []
+
+  // The first series is a straight line (same latency target value for all timestamps)
+  // showing the objective.
+  if (latency !== undefined) {
+    data.push(Array(timeseries[0].series[0].values.length).fill(latency / 1000) as number[])
+    labels.push('{quantile="target"}')
+  }
+
+  timeseries.forEach((ts: Timeseries, i: number) => {
+    const [x, ...series] = ts.series
+    if (i === 0) {
+      timestamps = x.values
+    }
+
+    series.forEach((s: Series) => {
+      data.push(s.values)
+    })
+
+    labels.push(...ts.labels)
+    queries.push(ts.query)
+  })
+
+  return {data: [timestamps, ...data], labels, queries}
+}

--- a/ui/src/components/graphs/errorBudget.test.ts
+++ b/ui/src/components/graphs/errorBudget.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from 'vitest'
+import {rescaleErrorBudget} from './errorBudget'
+
+// The budget a target/unavailability pair implies, straight from the formula the
+// backend query uses. Lets the tests state the input in terms of real spend.
+const budgetFor = (target: number, unavailability: number): number =>
+  (1 - target - unavailability) / (1 - target)
+
+describe('rescaleErrorBudget', () => {
+  it('is a no-op when the target is unchanged', () => {
+    expect(rescaleErrorBudget(0.5, 0.99, 0.99)).toBe(0.5)
+  })
+
+  it('recovers the same budget the stricter target would have produced', () => {
+    // 0.5% of requests failed. Against a 99% target that's half the budget;
+    // against 99.5% it's all of it.
+    const unavailability = 0.005
+    const at99 = budgetFor(0.99, unavailability)
+    expect(at99).toBeCloseTo(0.5, 10)
+
+    const rescaled = rescaleErrorBudget(at99, 0.99, 0.995)
+    expect(rescaled).toBeCloseTo(budgetFor(0.995, unavailability), 10)
+    expect(rescaled).toBeCloseTo(0, 10)
+  })
+
+  it('goes negative when the new target is out of reach', () => {
+    const unavailability = 0.005
+    const at99 = budgetFor(0.99, unavailability)
+
+    // 0.5% unavailability against a 99.9% target overspends the budget 5x.
+    const rescaled = rescaleErrorBudget(at99, 0.99, 0.999)
+    expect(rescaled).toBeCloseTo(budgetFor(0.999, unavailability), 10)
+    expect(rescaled).toBeCloseTo(-4, 10)
+  })
+
+  it('frees budget up when the new target is looser', () => {
+    const unavailability = 0.005
+    const at99 = budgetFor(0.99, unavailability)
+
+    const rescaled = rescaleErrorBudget(at99, 0.99, 0.95)
+    expect(rescaled).toBeCloseTo(budgetFor(0.95, unavailability), 10)
+    expect(rescaled).toBeCloseTo(0.9, 10)
+  })
+
+  it('round-trips back to the original', () => {
+    const original = 0.42
+    const there = rescaleErrorBudget(original, 0.99, 0.999)
+    expect(rescaleErrorBudget(there, 0.999, 0.99)).toBeCloseTo(original, 10)
+  })
+
+  it('leaves a full budget full regardless of target', () => {
+    // Nothing spent means the whole budget is left, whatever the target is.
+    expect(rescaleErrorBudget(1, 0.99, 0.9999)).toBeCloseTo(1, 10)
+  })
+
+  it('leaves the series alone for a 100% target', () => {
+    expect(rescaleErrorBudget(0.5, 0.99, 1)).toBe(0.5)
+    expect(rescaleErrorBudget(0.5, 1, 0.99)).toBe(0.5)
+  })
+})

--- a/ui/src/components/graphs/errorBudget.test.ts
+++ b/ui/src/components/graphs/errorBudget.test.ts
@@ -53,7 +53,10 @@ describe('rescaleErrorBudget', () => {
     expect(rescaleErrorBudget(1, 0.99, 0.9999)).toBeCloseTo(1, 10)
   })
 
-  it('leaves the series alone for a 100% target', () => {
+  it('stays finite when either target leaves no budget', () => {
+    // 100% allows no failures, so there is no budget to be a percentage of. The
+    // graph is hidden in that case; the values still have to be finite because
+    // uPlot builds its fill gradient from them.
     expect(rescaleErrorBudget(0.5, 0.99, 1)).toBe(0.5)
     expect(rescaleErrorBudget(0.5, 1, 0.99)).toBe(0.5)
   })

--- a/ui/src/components/graphs/errorBudget.ts
+++ b/ui/src/components/graphs/errorBudget.ts
@@ -16,8 +16,12 @@ export const rescaleErrorBudget = (value: number, from: number, to: number): num
   const fromBudget = 1 - from
   const toBudget = 1 - to
 
-  // A 100% target leaves no budget to divide by. Nothing meaningful to show, so
-  // leave the series alone rather than turning it into infinities.
+  // Either side of the conversion needs a non-zero budget: without the one the
+  // series was built against there's no unavailability to recover, and a 100%
+  // target has no budget to express the result as a fraction of. Callers don't
+  // draw a graph in that case (see ObjectiveDetail.ErrorBudget), and the values
+  // have to stay finite regardless — uPlot builds its fill gradient from them
+  // and throws on NaN.
   if (fromBudget <= 0 || toBudget <= 0) {
     return value
   }

--- a/ui/src/components/graphs/errorBudget.ts
+++ b/ui/src/components/graphs/errorBudget.ts
@@ -1,0 +1,27 @@
+// Error budget is a pure function of the objective's target and how much of the
+// budget has been spent, and the spend doesn't depend on the target at all.
+// Pyrra's error budget query (slo.Objective.QueryErrorBudgetRaw) computes
+//
+//   budget = ((1 - target) - unavailability) / (1 - target)
+//
+// so a series computed for one target can be re-derived for another without
+// asking Prometheus again: recover the unavailability the series implies, then
+// divide by the new budget instead. This is what lets the Create SLO editor
+// answer "what if this were 99.9%" instantly while you type.
+export const rescaleErrorBudget = (value: number, from: number, to: number): number => {
+  if (from === to) {
+    return value
+  }
+
+  const fromBudget = 1 - from
+  const toBudget = 1 - to
+
+  // A 100% target leaves no budget to divide by. Nothing meaningful to show, so
+  // leave the series alone rather than turning it into infinities.
+  if (fromBudget <= 0 || toBudget <= 0) {
+    return value
+  }
+
+  const unavailability = fromBudget * (1 - value)
+  return 1 - unavailability / toBudget
+}

--- a/ui/src/components/tiles/ErrorBudgetTile.tsx
+++ b/ui/src/components/tiles/ErrorBudgetTile.tsx
@@ -28,6 +28,17 @@ const ErrorBudgetTile = ({objective, loading, success, errors, total}: ErrorBudg
       const unavailability = errors / total
       const availableBudget = (budget - unavailability) / budget
 
+      // A 100% target allows no failures at all, so there is no budget to have
+      // a percentage of — the division above is -Infinity or NaN.
+      if (budget <= 0) {
+        return (
+          <div className="rounded-lg bg-card p-9 text-card-foreground">
+            {headline}
+            <h2 className="font-sans text-[40px] font-normal mb-0">No budget</h2>
+          </div>
+        )
+      }
+
       return (
         <div className={cn('rounded-lg p-9 font-sans', availableBudget > 0 ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground')}>
           {headline}

--- a/ui/src/objectives.tsx
+++ b/ui/src/objectives.tsx
@@ -1,6 +1,6 @@
 import {type ConnectError, type Client} from '@connectrpc/connect'
 import {type QueryStatus} from '@tanstack/react-query'
-import {type GetStatusResponse, type ListResponse, type ObjectiveService} from './proto/objectives/v1alpha1/objectives_pb'
+import {type GetStatusResponse, type ListResponse, type ObjectiveService, type Timeseries} from './proto/objectives/v1alpha1/objectives_pb'
 import {timestampFromDate} from '@bufbuild/protobuf/wkt'
 import {type QueryOptions, useConnectQuery} from './query'
 
@@ -50,4 +50,62 @@ export const useObjectivesStatus = (
   })
 
   return {response: data ?? null, error: error as ConnectError, status}
+}
+
+export interface DurationTimeseriesResponse {
+  timeseries: Timeseries[]
+  error: ConnectError
+  status: QueryStatus
+}
+
+// useGraphDuration fetches the duration percentiles of a stored SLO, looked up
+// by the same expr the list and detail views use.
+export const useGraphDuration = (
+  client: Client<typeof ObjectiveService>,
+  expr: string,
+  grouping: string,
+  from: number,
+  to: number,
+  options?: QueryOptions,
+): DurationTimeseriesResponse => {
+  const {data, error, status} = useConnectQuery({
+    key: ['graphDuration', expr, grouping, from, to],
+    func: async () => {
+      return await client.graphDuration({
+        expr,
+        grouping,
+        start: timestampFromDate(new Date(from)),
+        end: timestampFromDate(new Date(to)),
+      })
+    },
+    options,
+  })
+
+  return {timeseries: data?.timeseries ?? [], error: error as ConnectError, status}
+}
+
+// usePreviewGraphDuration fetches the same percentiles for a draft SLO that
+// isn't stored yet, so the Create editor's preview can render the graph too.
+export const usePreviewGraphDuration = (
+  client: Client<typeof ObjectiveService>,
+  config: string,
+  grouping: string,
+  from: number,
+  to: number,
+  options?: QueryOptions,
+): DurationTimeseriesResponse => {
+  const {data, error, status} = useConnectQuery({
+    key: ['previewGraphDuration', config, grouping, from, to],
+    func: async () => {
+      return await client.previewGraphDuration({
+        config,
+        grouping,
+        start: timestampFromDate(new Date(from)),
+        end: timestampFromDate(new Date(to)),
+      })
+    },
+    options,
+  })
+
+  return {timeseries: data?.timeseries ?? [], error: error as ConnectError, status}
 }

--- a/ui/src/pages/Create.tsx
+++ b/ui/src/pages/Create.tsx
@@ -183,7 +183,9 @@ const Create = (): JSX.Element => {
                 />
               </Field>
 
-              <Field label="Labels" hint="Free-form key=value pairs attached to the objective.">
+              <Field
+                label="Labels"
+                hint="Metadata labels on the resource. Prefix a key with pyrra.dev/ to make it part of the objective — those show up on its detail page and are propagated to the generated rules. Unprefixed keys (like prometheus or role) only select which Prometheus picks up the PrometheusRule.">
                 <LabelsEditor value={cfg.labels} onChange={(labels) => { set({labels}); }} />
               </Field>
 
@@ -429,6 +431,7 @@ const Create = (): JSX.Element => {
               status={previewStatus}
               stale={stale}
               onRun={runPreview}
+              config={previewYaml}
               grouping={selectedGrouping ?? undefined}
               onBack={groupingObjective !== null ? backToGroupings : undefined}
             />

--- a/ui/src/pages/Create.tsx
+++ b/ui/src/pages/Create.tsx
@@ -9,7 +9,7 @@
 // preview (see ../components/create/preview.ts); until that endpoint is wired it
 // shows an "unavailable" state and the YAML view carries the workflow.
 
-import {useMemo, useState, type JSX} from 'react'
+import {useMemo, useRef, useState, type JSX} from 'react'
 import {Link} from 'react-router-dom'
 import {createClient} from '@connectrpc/connect'
 import {createConnectTransport} from '@connectrpc/connect-web'
@@ -80,8 +80,23 @@ const Create = (): JSX.Element => {
   ): void => { setCfg((c) => ({...c, [ind]: {...c[ind], ...patch}})); }
 
   const yaml = useMemo(() => buildYaml(cfg), [cfg])
-  const snapshot = useMemo(() => JSON.stringify(cfg), [cfg])
+
+  // The target is left out of the staleness snapshot: the preview recomputes
+  // availability and the error budget from it locally, so a target change alone
+  // doesn't leave anything on screen out of date.
+  const snapshot = useMemo(() => JSON.stringify({...cfg, target: ''}), [cfg])
   const stale = previewSnap !== null && previewSnap !== snapshot
+
+  // Keep the last target that parsed, so clearing the field to retype it leaves
+  // the preview on the last real value instead of blanking out mid-keystroke.
+  const lastTarget = useRef<number | undefined>(undefined)
+  const target = useMemo(() => {
+    const parsed = parseFloat(cfg.target)
+    if (Number.isFinite(parsed) && parsed >= 0 && parsed <= 100) {
+      lastTarget.current = parsed / 100
+    }
+    return lastTarget.current
+  }, [cfg.target])
 
   // Show the grouping chooser once a grouped preview succeeded and nothing is picked.
   const showGroupings = previewStatus === 'success' && groupingObjective !== null && selectedGrouping === null
@@ -432,6 +447,7 @@ const Create = (): JSX.Element => {
               stale={stale}
               onRun={runPreview}
               config={previewYaml}
+              target={target}
               grouping={selectedGrouping ?? undefined}
               onBack={groupingObjective !== null ? backToGroupings : undefined}
             />

--- a/ui/src/pages/Create.tsx
+++ b/ui/src/pages/Create.tsx
@@ -207,12 +207,22 @@ const Create = (): JSX.Element => {
               <div className="grid grid-cols-1 gap-5 sm:grid-cols-[160px_1fr]">
                 <Field label="Target" htmlFor="slo-target" hint="As a percentage.">
                   <div className="relative">
+                    {/* A number input so the arrow keys nudge the target and the
+                        preview recomputes as they do. The spinner buttons are
+                        hidden because they'd sit on top of the % suffix; the
+                        keyboard behaviour is what's wanted here. */}
                     <input
                       id="slo-target"
-                      className={cn(inputBase, 'h-9 pr-7')}
+                      type="number"
+                      min={0}
+                      max={100}
+                      step={0.1}
+                      className={cn(
+                        inputBase,
+                        'h-9 pr-7 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
+                      )}
                       value={cfg.target}
-                      inputMode="decimal"
-                      onChange={(e) => { set({target: e.target.value.replace(/[^0-9.]/g, '')}); }}
+                      onChange={(e) => { set({target: e.target.value}); }}
                     />
                     <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
                       %

--- a/ui/src/pages/Create.tsx
+++ b/ui/src/pages/Create.tsx
@@ -180,10 +180,14 @@ const Create = (): JSX.Element => {
         </div>
       </Navbar>
 
-      <div className="grid grid-cols-1 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(420px,1fr)_1fr]">
+      {/* The editor only ever needs max-w-2xl, so the column stops there instead
+          of taking half the viewport and centring the form in it — everything
+          past that point goes to the preview. It still can't take more than half
+          on narrower screens, where there's nothing to give away. */}
+      <div className="grid grid-cols-1 lg:min-h-0 lg:flex-1 lg:grid-cols-[minmax(420px,min(42rem,50%))_1fr]">
         {/* ---------------- EDITOR ---------------- */}
         <div className="border-b border-border bg-background lg:min-h-0 lg:overflow-auto lg:border-b-0 lg:border-r">
-          <div className="mx-auto max-w-2xl px-8 pt-7 pb-16">
+          <div className="max-w-2xl px-8 pt-7 pb-16">
             <h3 className="mb-6">Create SLO</h3>
 
             <section className="border-border py-5">

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -13,9 +13,10 @@ import {PrometheusService} from '../proto/prometheus/v1/prometheus_pb'
 import {useObjectivesList} from '../objectives'
 import {type Objective} from '../proto/objectives/v1alpha1/objectives_pb'
 import {formatDuration, parseDuration} from '../duration'
-import {computeTimeRangePresets} from '../timeRangePresets'
+import {computeTimeRangePresets, intervalFromDuration} from '../timeRangePresets'
 import ObjectiveDetail, {type ObjectiveDetailValue} from '../components/detail/ObjectiveDetail'
 import TimeRangeControls from '../components/detail/TimeRangeControls'
+import {useAutoReload} from '../components/detail/useAutoReload'
 
 const uPlotCursor: uPlot.Cursor = {
   y: false,
@@ -107,19 +108,7 @@ const Detail = () => {
   const duration = to - from
   const interval = intervalFromDuration(duration)
 
-  useEffect(() => {
-    if (autoReload) {
-      const id = setInterval(() => {
-        const newTo = Date.now()
-        const newFrom = newTo - duration
-        updateTimeRange(newFrom, newTo, false)
-      }, interval)
-
-      return () => {
-        clearInterval(id)
-      }
-    }
-  }, [updateTimeRange, autoReload, duration, interval])
+  useAutoReload(autoReload, duration, interval, updateTimeRange)
 
   const selectRange = (t: number) => {
     const to = Date.now()
@@ -225,27 +214,6 @@ const Detail = () => {
       </div>
     </>
   )
-}
-
-const intervalFromDuration = (duration: number): number => {
-  // map some preset duration to nicer looking intervals
-  switch (duration) {
-    case 60 * 60 * 1000: // 1h => 10s
-      return 10 * 1000
-    case 12 * 60 * 60 * 1000: // 12h => 30s
-      return 30 * 1000
-    case 24 * 60 * 60 * 1000: // 12h => 30s
-      return 90 * 1000
-  }
-
-  if (duration < 10 * 1000 * 1000) {
-    return 10 * 1000
-  }
-  if (duration < 10 * 60 * 1000 * 1000) {
-    return Math.floor(duration / 1000 / 1000) * 1000 // round to seconds
-  }
-
-  return Math.floor(duration / 60 / 1000 / 1000) * 60 * 1000
 }
 
 export default Detail

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -2,30 +2,28 @@ import {Link} from 'react-router-dom'
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {useQueryState, parseAsString} from 'nuqs'
 import {Spinner} from '@/components/ui/spinner'
-import {ToggleGroup, ToggleGroupItem} from '@/components/ui/toggle-group'
-import {cn} from '@/lib/utils'
-import {API_BASEPATH, hasObjectiveType, latencyTarget, ObjectiveType} from '../App'
+import {API_BASEPATH, hasObjectiveType, ObjectiveType} from '../App'
 import Navbar from '../components/Navbar'
 import {MetricName, parseLabels} from '../labels'
-import ErrorBudgetGraph from '../components/graphs/ErrorBudgetGraph'
-import RequestsGraph from '../components/graphs/RequestsGraph'
-import ErrorsGraph from '../components/graphs/ErrorsGraph'
 import {createConnectTransport} from '@connectrpc/connect-web'
 import {createClient} from '@connectrpc/connect'
 import {ObjectiveService} from '../proto/objectives/v1alpha1/objectives_pb'
-import AlertsTable from '../components/AlertsTable'
-import Toggle from '../components/Toggle'
-import DurationGraph from '../components/graphs/DurationGraph'
 import type uPlot from 'uplot'
 import {PrometheusService} from '../proto/prometheus/v1/prometheus_pb'
-import {replaceInterval, usePrometheusQuery, vectorErrorsTotal} from '../prometheus'
-import {useGraphDuration, useObjectivesList} from '../objectives'
+import {useObjectivesList} from '../objectives'
 import {type Objective} from '../proto/objectives/v1alpha1/objectives_pb'
 import {formatDuration, parseDuration} from '../duration'
 import {computeTimeRangePresets} from '../timeRangePresets'
-import ObjectiveTiles from '../components/tiles/ObjectiveTiles'
-import ObjectiveLabels from '../components/ObjectiveLabels'
-import {ChartArea, ChartLine, CornerDownLeft} from 'lucide-react'
+import ObjectiveDetail, {type ObjectiveDetailValue} from '../components/detail/ObjectiveDetail'
+import TimeRangeControls from '../components/detail/TimeRangeControls'
+
+const uPlotCursor: uPlot.Cursor = {
+  y: false,
+  lock: true,
+  sync: {
+    key: 'detail',
+  },
+}
 
 const Detail = () => {
   const baseUrl = API_BASEPATH ?? 'http://localhost:9099'
@@ -43,7 +41,7 @@ const Detail = () => {
   const [fromParam, setFromParam] = useQueryState('from', parseAsString)
   const [toParam, setToParam] = useQueryState('to', parseAsString)
 
-  const {from, to, groupingLabels, name, labels} = useMemo(() => {
+  const {from, to, groupingLabels, name} = useMemo(() => {
     const labels = parseLabels(expr)
     const groupingLabels = parseLabels(groupingParam)
     const name: string = labels[MetricName]
@@ -69,50 +67,19 @@ const Detail = () => {
 
     document.title = `${name} - Pyrra`
 
-    return {from, to, groupingLabels, name, labels}
+    return {from, to, groupingLabels, name}
   }, [expr, groupingParam, fromParam, toParam])
 
   const [autoReload, setAutoReload] = useState<boolean>(true)
   const [absolute, setAbsolute] = useState<boolean>(true)
-  const [customRange, setCustomRange] = useState('')
-  const [customRangeError, setCustomRangeError] = useState(false)
 
-  const {
-    response: objectiveResponse,
-    error: objectiveError,
-    status: objectiveStatus,
-  } = useObjectivesList(client, expr, groupingParam)
-
-  const objective: Objective | null = objectiveResponse?.objectives[0] ?? null
-
-  const {response: totalResponse, status: totalStatus} = usePrometheusQuery(
-    promClient,
-    objective?.queries?.countTotal ?? '',
-    to / 1000,
-    {enabled: objectiveStatus === 'success' && objective?.queries?.countTotal !== undefined},
-  )
-
-  const {response: errorResponse, status: errorStatus} = usePrometheusQuery(
-    promClient,
-    objective?.queries?.countErrors ?? '',
-    to / 1000,
-    {enabled: objectiveStatus === 'success' && objective?.queries?.countTotal !== undefined},
-  )
-
-  // Only latency objectives have a duration graph. The check has to happen up
-  // here rather than next to the graph, because hooks can't be conditional.
-  const latencyObjective =
-    objective !== null &&
-    [ObjectiveType.Latency, ObjectiveType.LatencyNative].includes(hasObjectiveType(objective))
-
-  const {timeseries: durationTimeseries, status: durationStatus} = useGraphDuration(
+  const {response: objectiveResponse, error: objectiveError} = useObjectivesList(
     client,
     expr,
     groupingParam,
-    from,
-    to,
-    {enabled: latencyObjective},
   )
+
+  const objective: Objective | null = objectiveResponse?.objectives[0] ?? null
 
   const updateTimeRange = useCallback(
     (from: number, to: number, absolute: boolean) => {
@@ -128,11 +95,14 @@ const Detail = () => {
     [setFromParam, setToParam],
   )
 
-  const updateTimeRangeSelect = (min: number, max: number, absolute: boolean) => {
-    // when selecting time ranges with the mouse we want to disable the auto refresh
-    setAutoReload(false)
-    updateTimeRange(min, max, absolute)
-  }
+  const updateTimeRangeSelect = useCallback(
+    (min: number, max: number, absolute: boolean) => {
+      // when selecting time ranges with the mouse we want to disable the auto refresh
+      setAutoReload(false)
+      updateTimeRange(min, max, absolute)
+    },
+    [updateTimeRange],
+  )
 
   const duration = to - from
   const interval = intervalFromDuration(duration)
@@ -151,21 +121,39 @@ const Detail = () => {
     }
   }, [updateTimeRange, autoReload, duration, interval])
 
-  const handleTimeRangeClick = (t: number) => () => {
+  const selectRange = (t: number) => {
     const to = Date.now()
     const from = to - t
     updateTimeRange(from, to, false)
   }
 
-  const handleCustomRangeSubmit = () => {
-    const ms = parseDuration(customRange)
-    if (ms !== null && ms > 0) {
-      setCustomRangeError(false)
-      handleTimeRangeClick(ms)()
-    } else if (customRange !== '') {
-      setCustomRangeError(true)
+  const objectiveType = objective !== null ? hasObjectiveType(objective) : ObjectiveType.Ratio
+
+  const detail = useMemo<ObjectiveDetailValue | null>(() => {
+    if (objective === null || objective.labels === undefined) {
+      return null
     }
-  }
+    return {
+      objective,
+      objectiveType,
+      promClient,
+      grouping: groupingLabels,
+      from,
+      to,
+      absolute,
+      uPlotCursor,
+      updateTimeRange: updateTimeRangeSelect,
+    }
+  }, [
+    objective,
+    objectiveType,
+    promClient,
+    groupingLabels,
+    from,
+    to,
+    absolute,
+    updateTimeRangeSelect,
+  ])
 
   if (objectiveError !== null) {
     return (
@@ -192,36 +180,15 @@ const Detail = () => {
     )
   }
 
-  if (objective.labels === undefined) {
+  if (detail === null) {
     return <></>
   }
 
   const windowMs = Number(objective.window?.seconds ?? 0) * 1000
   const timeRanges = computeTimeRangePresets(windowMs > 0 ? windowMs : 28 * 24 * 3600 * 1000)
 
-  const objectiveType = hasObjectiveType(objective)
   const objectiveTypeLatency =
     objectiveType === ObjectiveType.Latency || objectiveType === ObjectiveType.LatencyNative
-
-  const loading: boolean =
-    totalStatus === 'pending' ||
-    errorStatus === 'pending'
-
-  const success: boolean = totalStatus === 'success' && errorStatus === 'success'
-
-  const {errors, total} = vectorErrorsTotal(totalResponse, errorResponse)
-
-  const hasLabels = Object.keys({...objective.labels, ...groupingLabels}).some(
-    (k) => k !== MetricName,
-  )
-
-  const uPlotCursor: uPlot.Cursor = {
-    y: false,
-    lock: true,
-    sync: {
-      key: 'detail',
-    },
-  }
 
   return (
     <>
@@ -233,171 +200,27 @@ const Detail = () => {
 
       <div className="mt-[100px]">
         <div className="container-responsive">
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full 3xl:w-10/12 3xl:mx-auto">
-              <h3>{name}</h3>
-              <ObjectiveLabels labels={objective.labels} grouping={groupingLabels} />
-            </div>
-            {objective.description !== undefined && objective.description !== '' ? (
-              <div
-                className="w-full md:w-1/2 3xl:w-5/12 3xl:ml-[8.33%]"
-                style={{marginTop: hasLabels ? 12 : 0}}>
-                <p>{objective.description}</p>
-              </div>
-            ) : (
-              <></>
-            )}
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full 3xl:w-10/12 3xl:mx-auto">
-              <ObjectiveTiles
-                objective={objective}
-                loading={loading}
-                success={success}
-                errors={errors}
-                total={total}
-              />
-            </div>
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full text-center py-8 bg-[linear-gradient(0deg,transparent_45%,var(--muted)_50%,transparent_55%)]">
-              <div className="mx-auto flex flex-col items-center gap-5 bg-background sm:w-2/3 md:w-1/2 xl:flex-row xl:justify-center">
-                <div className="flex gap-5 justify-center">
-                  <div className="flex items-center">
-                    <div className="relative">
-                      <input
-                        type="text"
-                        value={customRange}
-                        onChange={(e) => {
-                          setCustomRange(e.target.value)
-                          setCustomRangeError(false)
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter') handleCustomRangeSubmit()
-                        }}
-                        onBlur={handleCustomRangeSubmit}
-                        placeholder={formatDuration(timeRanges[0] * 2)}
-                        className={cn(
-                          'h-8 w-14 rounded-l-lg rounded-r-none border border-r-0 border-input bg-muted/50 shadow-inner pl-2 pr-5 text-sm font-medium outline-none transition-all placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:z-10',
-                          customRangeError && 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20'
-                        )}
-                      />
-                      {customRange !== '' && <CornerDownLeft size={11} className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" />}
-                    </div>
-                    <ToggleGroup variant="outline" value={[String(to - from)]} onValueChange={(val) => { if (val.length > 0) { setCustomRange(''); setCustomRangeError(false); handleTimeRangeClick(Number(val[val.length - 1]))() } }}>
-                      {timeRanges.map((t: number, i: number) => (
-                        <ToggleGroupItem key={t} value={String(t)} variant="outline" aria-label={formatDuration(t)} className={i === 0 ? 'rounded-l-none!' : undefined}>
-                          {formatDuration(t)}
-                        </ToggleGroupItem>
-                      ))}
-                    </ToggleGroup>
-                  </div>
-                  <Toggle
-                    checked={autoReload}
-                    onChange={() => { setAutoReload(!autoReload) }}
-                    onText={formatDuration(interval)}
-                  />
-                </div>
-                <ToggleGroup variant="outline" value={[absolute ? 'absolute' : 'relative']} onValueChange={(val) => { if (val.length > 0) setAbsolute(val[val.length - 1] === 'absolute') }}>
-                  <ToggleGroupItem value="absolute" variant="outline" aria-label="Absolute scale">
-                    <ChartArea size={16} color={absolute ? 'white' : 'currentColor'} />
-                    <span className="ml-2">Absolute</span>
-                  </ToggleGroupItem>
-                  <ToggleGroupItem value="relative" variant="outline" aria-label="Relative scale">
-                    <ChartLine size={16} color={!absolute ? 'white' : 'currentColor'} />
-                    <span className="ml-2">Relative</span>
-                  </ToggleGroupItem>
-                </ToggleGroup>
-              </div>
-            </div>
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full">
-              {objective.queries?.graphErrorBudget !== undefined ? (
-                <ErrorBudgetGraph
-                  client={promClient}
-                  query={objective.queries.graphErrorBudget}
-                  from={from}
-                  to={to}
-                  uPlotCursor={uPlotCursor}
-                  updateTimeRange={updateTimeRangeSelect}
-                  absolute={absolute}
-                />
-              ) : (
-                <></>
-              )}
-            </div>
-          </div>
-          <div className="mb-24 flex flex-wrap -mx-3">
-            <div className={cn('w-full px-3', objectiveTypeLatency ? '3xl:w-1/3' : 'md:w-1/2')}>
-              {objective.queries?.graphRequests !== undefined ? (
-                <RequestsGraph
-                  client={promClient}
-                  query={replaceInterval(objective.queries.graphRequests, from, to)}
-                  from={from}
-                  to={to}
-                  uPlotCursor={uPlotCursor}
-                  type={objectiveType}
-                  updateTimeRange={updateTimeRangeSelect}
-                  absolute={absolute}
-                />
-              ) : (
-                <></>
-              )}
-            </div>
-            <div className={cn('w-full px-3', objectiveTypeLatency ? '3xl:w-1/3' : 'md:w-1/2')}>
-              {objective.queries?.graphErrors !== undefined ? (
-                <ErrorsGraph
-                  client={promClient}
-                  type={objectiveType}
-                  query={replaceInterval(objective.queries.graphErrors, from, to)}
-                  from={from}
-                  to={to}
-                  uPlotCursor={uPlotCursor}
-                  updateTimeRange={updateTimeRangeSelect}
-                  absolute={absolute}
-                />
-              ) : (
-                <></>
-              )}
-            </div>
-            {objectiveTypeLatency && (
-              <div className="w-full px-3 3xl:w-1/3">
-                <DurationGraph
-                  timeseries={durationTimeseries}
-                  loading={durationStatus === 'pending'}
-                  from={from}
-                  to={to}
-                  uPlotCursor={uPlotCursor}
-                  updateTimeRange={updateTimeRangeSelect}
-                  target={objective.target}
-                  latency={latencyTarget(objective)}
-                />
-              </div>
-            )}
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full">
-              <h4>Multi Burn Rate Alerts</h4>
-              <AlertsTable
-                client={client}
-                promClient={promClient}
-                objective={objective}
-                grouping={groupingLabels}
-                from={from}
-                to={to}
-                uPlotCursor={uPlotCursor}
-              />
-            </div>
-          </div>
-          <div className="mb-24 flex flex-wrap">
-            <div className="w-full">
-              <h4>Config</h4>
-              <pre className="rounded bg-muted p-5 overflow-auto max-w-full">
-                <code>{objective.config}</code>
-              </pre>
-            </div>
-          </div>
+          <ObjectiveDetail.Provider value={detail}>
+            <ObjectiveDetail.Header />
+            <ObjectiveDetail.Tiles />
+            <TimeRangeControls
+              timeRanges={timeRanges}
+              from={from}
+              to={to}
+              interval={interval}
+              autoReload={autoReload}
+              setAutoReload={setAutoReload}
+              absolute={absolute}
+              setAbsolute={setAbsolute}
+              onSelectRange={selectRange}
+            />
+            <ObjectiveDetail.ErrorBudget />
+            <ObjectiveDetail.GraphRow>
+              {objectiveTypeLatency && <ObjectiveDetail.Duration client={client} expr={expr} />}
+            </ObjectiveDetail.GraphRow>
+            <ObjectiveDetail.Alerts client={client} />
+            <ObjectiveDetail.Config />
+          </ObjectiveDetail.Provider>
         </div>
       </div>
     </>

--- a/ui/src/pages/Detail.tsx
+++ b/ui/src/pages/Detail.tsx
@@ -19,7 +19,7 @@ import DurationGraph from '../components/graphs/DurationGraph'
 import type uPlot from 'uplot'
 import {PrometheusService} from '../proto/prometheus/v1/prometheus_pb'
 import {replaceInterval, usePrometheusQuery, vectorErrorsTotal} from '../prometheus'
-import {useObjectivesList} from '../objectives'
+import {useGraphDuration, useObjectivesList} from '../objectives'
 import {type Objective} from '../proto/objectives/v1alpha1/objectives_pb'
 import {formatDuration, parseDuration} from '../duration'
 import {computeTimeRangePresets} from '../timeRangePresets'
@@ -97,6 +97,21 @@ const Detail = () => {
     objective?.queries?.countErrors ?? '',
     to / 1000,
     {enabled: objectiveStatus === 'success' && objective?.queries?.countTotal !== undefined},
+  )
+
+  // Only latency objectives have a duration graph. The check has to happen up
+  // here rather than next to the graph, because hooks can't be conditional.
+  const latencyObjective =
+    objective !== null &&
+    [ObjectiveType.Latency, ObjectiveType.LatencyNative].includes(hasObjectiveType(objective))
+
+  const {timeseries: durationTimeseries, status: durationStatus} = useGraphDuration(
+    client,
+    expr,
+    groupingParam,
+    from,
+    to,
+    {enabled: latencyObjective},
   )
 
   const updateTimeRange = useCallback(
@@ -349,9 +364,8 @@ const Detail = () => {
             {objectiveTypeLatency && (
               <div className="w-full px-3 3xl:w-1/3">
                 <DurationGraph
-                  client={client}
-                  labels={labels}
-                  grouping={groupingLabels}
+                  timeseries={durationTimeseries}
+                  loading={durationStatus === 'pending'}
                   from={from}
                   to={to}
                   uPlotCursor={uPlotCursor}

--- a/ui/src/timeRangePresets.test.ts
+++ b/ui/src/timeRangePresets.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {computeTimeRangePresets} from './timeRangePresets'
+import {computeTimeRangePresets, previewTimeRangePresets} from './timeRangePresets'
 
 const ms = {
   h: 3600 * 1000,
@@ -61,5 +61,48 @@ describe('computeTimeRangePresets', () => {
   it('handles very large window (1y = 365d)', () => {
     const result = computeTimeRangePresets(365 * ms.d)
     expect(result).toEqual([365 * ms.d, 4 * ms.w, 1 * ms.w, 1 * ms.d, 12 * ms.h, 1 * ms.h])
+  })
+})
+
+describe('previewTimeRangePresets', () => {
+  const standard = [4 * ms.w, 1 * ms.w, 1 * ms.d, 12 * ms.h, 1 * ms.h]
+
+  it('keeps the standard set when the window is already one of them', () => {
+    expect(previewTimeRangePresets(1 * ms.w)).toEqual(standard)
+    expect(previewTimeRangePresets(4 * ms.w)).toEqual(standard)
+    expect(previewTimeRangePresets(1 * ms.d)).toEqual(standard)
+  })
+
+  it('slots an unlisted window in by length', () => {
+    expect(previewTimeRangePresets(2 * ms.w)).toEqual([
+      4 * ms.w,
+      2 * ms.w,
+      1 * ms.w,
+      1 * ms.d,
+      12 * ms.h,
+      1 * ms.h,
+    ])
+    expect(previewTimeRangePresets(6 * ms.h)).toEqual([
+      4 * ms.w,
+      1 * ms.w,
+      1 * ms.d,
+      12 * ms.h,
+      6 * ms.h,
+      1 * ms.h,
+    ])
+  })
+
+  it('keeps windows longer than every standard preset at the front', () => {
+    expect(previewTimeRangePresets(8 * ms.w)).toEqual([8 * ms.w, ...standard])
+  })
+
+  // Unlike the detail page, presets longer than the window are kept — the
+  // window is still being edited, so the buttons shouldn't move around.
+  it('does not drop presets longer than the window', () => {
+    expect(previewTimeRangePresets(12 * ms.h)).toEqual(standard)
+  })
+
+  it('falls back to the standard set for a missing window', () => {
+    expect(previewTimeRangePresets(0)).toEqual(standard)
   })
 })

--- a/ui/src/timeRangePresets.ts
+++ b/ui/src/timeRangePresets.ts
@@ -3,7 +3,7 @@ const DAY = 24 * HOUR
 const WEEK = 7 * DAY
 
 // Standard presets in descending order, matching the current hardcoded values in Detail.tsx.
-const STANDARD_PRESETS: number[] = [
+export const STANDARD_PRESETS: number[] = [
   4 * WEEK, // 4w
   1 * WEEK, // 1w
   1 * DAY, // 1d
@@ -25,4 +25,48 @@ export const computeTimeRangePresets = (windowMs: number): number[] => {
   // element of STANDARD_PRESETS that equals windowMs – we skip those via the
   // strict-less-than filter above and just prepend the window.
   return [windowMs, ...smaller]
+}
+
+/**
+ * Time range presets for the Create SLO preview: always the standard set, plus
+ * the objective's own window when that isn't one of them, slotted in by length.
+ *
+ * Unlike the detail page this doesn't drop the presets longer than the window.
+ * The window is a field you're still editing, and buttons rearranging under the
+ * cursor as you type is worse than occasionally offering a range longer than
+ * the window itself.
+ */
+export const previewTimeRangePresets = (windowMs: number): number[] => {
+  if (windowMs <= 0 || STANDARD_PRESETS.includes(windowMs)) {
+    return STANDARD_PRESETS
+  }
+
+  return [...STANDARD_PRESETS, windowMs].sort((a, b) => b - a)
+}
+
+/**
+ * How often a time range of the given length should auto-refresh, in ms.
+ *
+ * The presets get hand-picked intervals; anything else is refreshed at roughly
+ * a thousandth of its length, which is about one interval per pixel of graph.
+ */
+export const intervalFromDuration = (duration: number): number => {
+  // map some preset duration to nicer looking intervals
+  switch (duration) {
+    case 60 * 60 * 1000: // 1h => 10s
+      return 10 * 1000
+    case 12 * 60 * 60 * 1000: // 12h => 30s
+      return 30 * 1000
+    case 24 * 60 * 60 * 1000: // 12h => 30s
+      return 90 * 1000
+  }
+
+  if (duration < 10 * 1000 * 1000) {
+    return 10 * 1000
+  }
+  if (duration < 10 * 60 * 1000 * 1000) {
+    return Math.floor(duration / 1000 / 1000) * 1000 // round to seconds
+  }
+
+  return Math.floor(duration / 60 / 1000 / 1000) * 60 * 1000
 }


### PR DESCRIPTION
How much error budget is left is a pure function of the target and of how much has been spent, and the spend does not depend on the target at all. So moving the target recomputes the tiles and re-derives the error budget graph locally, and asking what 99.9% would cost answers immediately instead of waiting for a round trip.

The target input takes five decimal places, and the arrow keys walk the targets people actually write rather than adding a fixed step.
