### PR TITLE
feat(ui): show percentages at the precision that fits

### DIFF
--- a/ui/src/components/create/target.test.ts
+++ b/ui/src/components/create/target.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it} from 'vitest'
+import {nextTarget, TARGET_LADDER} from './target'
+
+describe('nextTarget', () => {
+  it('walks up the nines', () => {
+    expect(nextTarget('99', 'up')).toBe('99.5')
+    expect(nextTarget('99.5', 'up')).toBe('99.9')
+    expect(nextTarget('99.9', 'up')).toBe('99.95')
+    expect(nextTarget('99.95', 'up')).toBe('99.99')
+    expect(nextTarget('99.99', 'up')).toBe('99.995')
+  })
+
+  it('walks back down the same rungs', () => {
+    expect(nextTarget('99.995', 'down')).toBe('99.99')
+    expect(nextTarget('99.99', 'down')).toBe('99.95')
+    expect(nextTarget('99.5', 'down')).toBe('99')
+    expect(nextTarget('99', 'down')).toBe('95')
+  })
+
+  it('moves to the neighbouring rung from a value in between', () => {
+    expect(nextTarget('99.42', 'up')).toBe('99.5')
+    expect(nextTarget('99.42', 'down')).toBe('99')
+  })
+
+  it('stops at the ends', () => {
+    expect(nextTarget('99.99999', 'up')).toBeUndefined()
+    expect(nextTarget('0', 'down')).toBeUndefined()
+  })
+
+  it('starts at 99 when there is nothing to step from', () => {
+    expect(nextTarget('', 'up')).toBe('99')
+    expect(nextTarget('', 'down')).toBe('99')
+  })
+
+  it('never exceeds five decimal places', () => {
+    for (const rung of TARGET_LADDER) {
+      const decimals = rung.split('.')[1]?.length ?? 0
+      expect(decimals).toBeLessThanOrEqual(5)
+    }
+  })
+
+  it('is sorted ascending, so find/findLast pick the true neighbour', () => {
+    const values = TARGET_LADDER.map(parseFloat)
+    expect(values).toEqual([...values].sort((a, b) => a - b))
+  })
+})

--- a/ui/src/components/create/target.ts
+++ b/ui/src/components/create/target.ts
@@ -1,0 +1,41 @@
+// The targets SLOs are actually written with. Arrow keys on the target input
+// walk these rather than adding a fixed increment: the useful move from 99 is to
+// 99.5 or 99.9, not to 99.1, and the step that's useful at 99 is a thousand
+// times too big at 99.999.
+//
+// Kept as strings because that's how the editor stores the target — writing
+// 99.995 back out through a float is how you end up with 99.99499999999999.
+export const TARGET_LADDER: string[] = [
+  '0',
+  '50',
+  '75',
+  '90',
+  '95',
+  '99',
+  '99.5',
+  '99.9',
+  '99.95',
+  '99.99',
+  '99.995',
+  '99.999',
+  '99.9995',
+  '99.9999',
+  '99.99995',
+  '99.99999',
+]
+
+// The rung to move to from the current value. A value between rungs moves to the
+// next one in that direction, so a typed 99.42 goes up to 99.5 and down to 99.
+// Returns undefined at either end of the ladder.
+export const nextTarget = (current: string, direction: 'up' | 'down'): string | undefined => {
+  const value = parseFloat(current)
+
+  if (!Number.isFinite(value)) {
+    // Nothing sensible to step from — start at the most common target.
+    return '99'
+  }
+
+  return direction === 'up'
+    ? TARGET_LADDER.find((rung) => parseFloat(rung) > value)
+    : TARGET_LADDER.findLast((rung) => parseFloat(rung) < value)
+}

--- a/ui/src/components/tiles/AvailabilityTile.tsx
+++ b/ui/src/components/tiles/AvailabilityTile.tsx
@@ -39,9 +39,9 @@ const AvailabilityTile = ({
         objectiveType === ObjectiveType.Latency || objectiveType === ObjectiveType.LatencyNative
 
       return (
-        <div className={cn('@container rounded-lg p-9 font-sans', percentage > objective.target ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground')}>
+        <div className={cn('rounded-lg p-9 font-sans', percentage > objective.target ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground')}>
           {headline}
-          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">
+          <h2 className="block font-sans text-[40px] font-normal mb-0">
             <PercentValue value={percentage} />
           </h2>
           <table className="opacity-50 font-medium">

--- a/ui/src/components/tiles/AvailabilityTile.tsx
+++ b/ui/src/components/tiles/AvailabilityTile.tsx
@@ -3,6 +3,7 @@ import {Spinner} from '@/components/ui/spinner'
 import {cn} from '@/lib/utils'
 import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
 import {hasObjectiveType, ObjectiveType} from '../../App'
+import PercentValue from './PercentValue'
 
 interface AvailabilityTileProps {
   objective: Objective
@@ -38,9 +39,11 @@ const AvailabilityTile = ({
         objectiveType === ObjectiveType.Latency || objectiveType === ObjectiveType.LatencyNative
 
       return (
-        <div className={cn('rounded-lg p-9 font-sans', percentage > objective.target ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground')}>
+        <div className={cn('@container rounded-lg p-9 font-sans', percentage > objective.target ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground')}>
           {headline}
-          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">{(100 * percentage).toFixed(3)}%</h2>
+          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">
+            <PercentValue value={percentage} />
+          </h2>
           <table className="opacity-50 font-medium">
             <tbody>
               <tr>

--- a/ui/src/components/tiles/ErrorBudgetTile.tsx
+++ b/ui/src/components/tiles/ErrorBudgetTile.tsx
@@ -41,9 +41,9 @@ const ErrorBudgetTile = ({objective, loading, success, errors, total}: ErrorBudg
       }
 
       return (
-        <div className={cn('@container rounded-lg p-9 font-sans', availableBudget > 0 ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground')}>
+        <div className={cn('rounded-lg p-9 font-sans', availableBudget > 0 ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground')}>
           {headline}
-          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">
+          <h2 className="block font-sans text-[40px] font-normal mb-0">
             <PercentValue value={availableBudget} />
           </h2>
         </div>

--- a/ui/src/components/tiles/ErrorBudgetTile.tsx
+++ b/ui/src/components/tiles/ErrorBudgetTile.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {Spinner} from '@/components/ui/spinner'
 import {cn} from '@/lib/utils'
 import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
+import PercentValue from './PercentValue'
 
 interface ErrorBudgetTileProps {
   objective: Objective
@@ -40,9 +41,11 @@ const ErrorBudgetTile = ({objective, loading, success, errors, total}: ErrorBudg
       }
 
       return (
-        <div className={cn('rounded-lg p-9 font-sans', availableBudget > 0 ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground')}>
+        <div className={cn('@container rounded-lg p-9 font-sans', availableBudget > 0 ? 'bg-success text-success-foreground' : 'bg-destructive text-destructive-foreground')}>
           {headline}
-          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">{(100 * availableBudget).toFixed(3)}%</h2>
+          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">
+            <PercentValue value={availableBudget} />
+          </h2>
         </div>
       )
     } else {

--- a/ui/src/components/tiles/ObjectiveTile.tsx
+++ b/ui/src/components/tiles/ObjectiveTile.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {hasObjectiveType, ObjectiveType, renderLatencyTarget} from '../../App'
 import {formatDuration} from '../../duration'
+import {formatTargetPercent} from '../../percent'
 import {type Objective} from '../../proto/objectives/v1alpha1/objectives_pb'
 
 interface ObjectiveTileProps {
@@ -14,7 +15,7 @@ const ObjectiveTile = ({objective}: ObjectiveTileProps): React.JSX.Element => {
       return (
         <div className="rounded-lg bg-card p-9 text-card-foreground">
           <h6 className="font-sans text-xl font-semibold opacity-50">Objective</h6>
-          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">{(100 * objective.target).toFixed(3)}%</h2>
+          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">{formatTargetPercent(objective.target)}%</h2>
           <>in {formatDuration(Number(objective.window?.seconds) * 1000)}</>
         </div>
       )
@@ -22,7 +23,7 @@ const ObjectiveTile = ({objective}: ObjectiveTileProps): React.JSX.Element => {
       return (
         <div className="rounded-lg bg-card p-9 text-card-foreground">
           <h6 className="font-sans text-xl font-semibold opacity-50">Objective</h6>
-          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">{(100 * objective.target).toFixed(3)}%</h2>
+          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">{formatTargetPercent(objective.target)}%</h2>
           <>in {formatDuration(Number(objective.window?.seconds) * 1000)}</>
         </div>
       )
@@ -31,7 +32,7 @@ const ObjectiveTile = ({objective}: ObjectiveTileProps): React.JSX.Element => {
       return (
         <div className="rounded-lg bg-card p-9 text-card-foreground">
           <h6 className="font-sans text-xl font-semibold opacity-50">Objective</h6>
-          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">{(100 * objective.target).toFixed(3)}%</h2>
+          <h2 className="inline-block mr-2 font-sans text-[40px] font-normal mb-0">{formatTargetPercent(objective.target)}%</h2>
           <>in {formatDuration(Number(objective.window?.seconds) * 1000)}</>
           <br />
           <p className="opacity-50 font-medium">faster than {renderLatencyTarget(objective)}</p>

--- a/ui/src/components/tiles/PercentValue.tsx
+++ b/ui/src/components/tiles/PercentValue.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+interface PercentValueProps {
+  // The measured value as a fraction, e.g. 0.9876543.
+  value: number
+}
+
+// A measured percentage rendered at every precision it might need, with the
+// container query picking one. Which fits depends on how wide the tile is —
+// the Create editor's preview pane is a very different width from the detail
+// page — and that isn't something the component can know by itself.
+//
+// All three are in the DOM, but the ones that don't fit are display:none, which
+// takes them out of the accessibility tree too, so only the visible one is
+// announced. Unlike the objective's target, these are measurements, so dropping
+// digits to fit loses nothing that was ever exact.
+//
+// The breakpoints come from measuring the rendered text at this size, against
+// the container's *content* box — which is what a size container query resolves
+// against, so the tile's padding is already subtracted and these are narrower
+// than the tile widths they correspond to.
+//
+// They're sized for the widest thing that lands here, which is a badly breached
+// error budget rather than an availability: -569.19533% needs 253px where
+// 99.85384% needs 223. Three decimals is what every tile showed before this was
+// responsive, so the middle (and by far most common) tier keeps it, and no
+// width ends up showing more digits than it did before.
+const PercentValue = ({value}: PercentValueProps): React.JSX.Element => {
+  const percent = 100 * value
+
+  return (
+    <>
+      <span className="@[175px]:hidden">{percent.toFixed(1)}</span>
+      <span className="hidden @[175px]:inline @[255px]:hidden">{percent.toFixed(3)}</span>
+      <span className="hidden @[255px]:inline">{percent.toFixed(5)}</span>%
+    </>
+  )
+}
+
+export default PercentValue

--- a/ui/src/components/tiles/PercentValue.tsx
+++ b/ui/src/components/tiles/PercentValue.tsx
@@ -1,39 +1,80 @@
 import React from 'react'
+import {cn} from '@/lib/utils'
 
 interface PercentValueProps {
   // The measured value as a fraction, e.g. 0.9876543.
   value: number
+  // Positioning for the container this renders. It needs a width that doesn't
+  // come from its own contents (see below), so inside a flex row pass flex-1.
+  className?: string
 }
 
-// A measured percentage rendered at every precision it might need, with the
-// container query picking one. Which fits depends on how wide the tile is —
-// the Create editor's preview pane is a very different width from the detail
-// page — and that isn't something the component can know by itself.
+// How wide each precision needs to be, in em, measured as rendered including the
+// trailing %. Which set applies depends on how many characters the number has:
+// -569.20000% is 1.1em wider than 33.08000% at the same precision, and using one
+// set for both would either overflow the long ones or short-change the rest.
 //
-// All three are in the DOM, but the ones that don't fit are display:none, which
-// takes them out of the accessibility tree too, so only the visible one is
-// announced. Unlike the objective's target, these are measurements, so dropping
+// Keyed by the length of the five-decimal string, which is the longest thing
+// that can appear: 33.08000 is 8, -569.20000 is 10.
+//
+// The classes have to be written out rather than built, because Tailwind finds
+// them by scanning the source.
+// One decimal is the floor, not zero. An SLO's availability lives in the nines,
+// where rounding to whole percent collapses everything worth knowing: 99.9%
+// becomes 100%, which reads as a perfectly healthy objective rather than a
+// breached one. Below the one-decimal threshold the number overflows its
+// container, which is visibly wrong rather than quietly wrong.
+const BREAKPOINTS = {
+  // "99.85384" and shorter — 1/3/5 decimals need 3.09em / 4.34em / 5.60em
+  short: {
+    one: '@[4.4em]:hidden',
+    three: 'hidden @[4.4em]:inline @[5.7em]:hidden',
+    five: 'hidden @[5.7em]:inline',
+  },
+  // "100.00000", "-569.20000" — up to 4.15em / 5.41em / 6.67em
+  medium: {
+    one: '@[5.5em]:hidden',
+    three: 'hidden @[5.5em]:inline @[6.8em]:hidden',
+    five: 'hidden @[6.8em]:inline',
+  },
+  // "-1234.50000" and beyond, for a thoroughly blown budget
+  long: {
+    one: '@[6.3em]:hidden',
+    three: 'hidden @[6.3em]:inline @[7.6em]:hidden',
+    five: 'hidden @[7.6em]:inline',
+  },
+}
+
+// A measured percentage rendered at every precision it might need, with a
+// container query picking the one that fits. The same value appears at 40px in
+// a detail tile and at 14px in a list cell, and how many digits fit is a
+// question about the space it lands in, which the component can't know.
+//
+// The breakpoints are in em, which a container query resolves against the
+// container's own font-size — so because this container inherits the size the
+// digits render at, the thresholds hold at every font size and there's nothing
+// to pass in.
+//
+// Every precision is in the DOM, but the ones that don't fit are display:none,
+// which takes them out of the accessibility tree too, so only the visible one is
+// announced. Unlike an objective's target, these are measurements — dropping
 // digits to fit loses nothing that was ever exact.
 //
-// The breakpoints come from measuring the rendered text at this size, against
-// the container's *content* box — which is what a size container query resolves
-// against, so the tile's padding is already subtracted and these are narrower
-// than the tile widths they correspond to.
-//
-// They're sized for the widest thing that lands here, which is a badly breached
-// error budget rather than an availability: -569.19533% needs 253px where
-// 99.85384% needs 223. Three decimals is what every tile showed before this was
-// responsive, so the middle (and by far most common) tier keeps it, and no
-// width ends up showing more digits than it did before.
-const PercentValue = ({value}: PercentValueProps): React.JSX.Element => {
+// Note the container is block-level and must get its width from its parent:
+// inline-size containment makes an element's width independent of its contents,
+// so a shrink-to-fit parent would collapse it to nothing.
+const PercentValue = ({value, className}: PercentValueProps): React.JSX.Element => {
   const percent = 100 * value
+  const five = percent.toFixed(5)
+  const width = five.length <= 8 ? 'short' : five.length <= 10 ? 'medium' : 'long'
+  const breakpoints = BREAKPOINTS[width]
 
   return (
-    <>
-      <span className="@[175px]:hidden">{percent.toFixed(1)}</span>
-      <span className="hidden @[175px]:inline @[255px]:hidden">{percent.toFixed(3)}</span>
-      <span className="hidden @[255px]:inline">{percent.toFixed(5)}</span>%
-    </>
+    <span className={cn('@container block', className)}>
+      <span className={breakpoints.one}>{percent.toFixed(1)}</span>
+      <span className={breakpoints.three}>{percent.toFixed(3)}</span>
+      <span className={breakpoints.five}>{five}</span>%
+    </span>
   )
 }
 

--- a/ui/src/components/tiles/PercentValue.tsx
+++ b/ui/src/components/tiles/PercentValue.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {cn} from '@/lib/utils'
+import {formatPercent} from '../../percent'
 
 interface PercentValueProps {
   // The measured value as a fraction, e.g. 0.9876543.
@@ -19,11 +20,13 @@ interface PercentValueProps {
 //
 // The classes have to be written out rather than built, because Tailwind finds
 // them by scanning the source.
-// One decimal is the floor, not zero. An SLO's availability lives in the nines,
-// where rounding to whole percent collapses everything worth knowing: 99.9%
-// becomes 100%, which reads as a perfectly healthy objective rather than a
-// breached one. Below the one-decimal threshold the number overflows its
-// container, which is visibly wrong rather than quietly wrong.
+// Each tier drops its trailing zeros, so a value with nothing after the point
+// renders as 99 rather than 99.0 and needs no decimal place at all. That's the
+// only way whole percent ever shows: rounding 99.9 down to 99 — or up to 100 —
+// would be a different objective, so it doesn't happen.
+//
+// A side effect is that tiers collapse when the extra digits are zeros. 99 is
+// the same string at every precision, and which one CSS picks stops mattering.
 const BREAKPOINTS = {
   // "99.85384" and shorter — 1/3/5 decimals need 3.09em / 4.34em / 5.60em
   short: {
@@ -71,9 +74,9 @@ const PercentValue = ({value, className}: PercentValueProps): React.JSX.Element 
 
   return (
     <span className={cn('@container block', className)}>
-      <span className={breakpoints.one}>{percent.toFixed(1)}</span>
-      <span className={breakpoints.three}>{percent.toFixed(3)}</span>
-      <span className={breakpoints.five}>{five}</span>%
+      <span className={breakpoints.one}>{formatPercent(percent, 1)}</span>
+      <span className={breakpoints.three}>{formatPercent(percent, 3)}</span>
+      <span className={breakpoints.five}>{formatPercent(percent, 5)}</span>%
     </span>
   )
 }

--- a/ui/src/pages/Create.tsx
+++ b/ui/src/pages/Create.tsx
@@ -24,6 +24,7 @@ import {DEFAULT_CONFIG, buildYaml, yamlFilename, type CreateConfig, type SLIType
 import {previewObjective, PreviewUnavailableError, type PreviewStatus} from '../components/create/preview'
 import DetailPreview from '../components/create/DetailPreview'
 import GroupingsTable from '../components/create/GroupingsTable'
+import {nextTarget} from '../components/create/target'
 import {type Labels, labelsString} from '../labels'
 import {type Objective} from '../proto/objectives/v1alpha1/objectives_pb'
 import {PrometheusService} from '../proto/prometheus/v1/prometheus_pb'
@@ -214,13 +215,23 @@ const Create = (): JSX.Element => {
                     {/* A number input so the arrow keys nudge the target and the
                         preview recomputes as they do. The spinner buttons are
                         hidden because they'd sit on top of the % suffix; the
-                        keyboard behaviour is what's wanted here. */}
+                        keyboard behaviour is what's wanted here.
+
+                        step="any" so five decimal places can be typed; the arrow
+                        keys walk TARGET_LADDER instead, because no single step
+                        is useful at both 99 and 99.999. */}
                     <input
                       id="slo-target"
                       type="number"
                       min={0}
                       max={100}
-                      step={0.1}
+                      step="any"
+                      onKeyDown={(e) => {
+                        if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return
+                        e.preventDefault()
+                        const rung = nextTarget(cfg.target, e.key === 'ArrowUp' ? 'up' : 'down')
+                        if (rung !== undefined) set({target: rung})
+                      }}
                       className={cn(
                         inputBase,
                         'h-9 pr-7 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',

--- a/ui/src/pages/List.tsx
+++ b/ui/src/pages/List.tsx
@@ -32,6 +32,8 @@ import {
 } from '@tanstack/react-table'
 import {type Duration} from '@bufbuild/protobuf/wkt'
 import {useObjectivesList} from '../objectives'
+import {formatTargetPercent} from '../percent'
+import PercentValue from '../components/tiles/PercentValue'
 import {ArrowDown, ArrowUp, ArrowUpDown, ChevronDown, Columns2, Plus, Search, TriangleAlert} from 'lucide-react'
 import {Badge} from '@/components/ui/badge'
 import {buttonVariants} from '@/components/ui/button'
@@ -315,7 +317,9 @@ const columns = [
   columnHelper.accessor('objective', {
     id: 'objective',
     header: 'Objective',
-    cell: (props) => `${(100 * props.getValue()).toFixed(2)}%`,
+    // The target is an exact value someone wrote down, so it's trimmed rather
+    // than rounded: 99%, not 99.00%.
+    cell: (props) => `${formatTargetPercent(props.getValue())}%`,
   }),
   columnHelper.accessor('latency', {
     id: 'latency',
@@ -374,14 +378,12 @@ const columns = [
       const totalVisible = props.table.getColumn('total')?.getIsVisible() ?? false
 
       return (
-        <>
-          <span className={cn(v <= target && 'text-[#b10d0d]')}>
-            {(100 * v).toFixed(2)}%
-          </span>
+        <div className={cn('flex items-baseline gap-1', v <= target && 'text-[#b10d0d]')}>
+          <PercentValue value={v} className="flex-1" />
           {!totalVisible && (
             <VolumeWarningTooltip id={props.cell.id} objective={objective} total={total} />
           )}
-        </>
+        </div>
       )
     },
     sortingFn: sortingNumberNull,
@@ -395,9 +397,9 @@ const columns = [
         return 'No data'
       }
       return (
-        <span className={cn(v < 0 && 'text-[#b10d0d]')}>
-          {(100 * v).toFixed(2)}%
-        </span>
+        <div className={cn(v < 0 && 'text-[#b10d0d]')}>
+          <PercentValue value={v} />
+        </div>
       )
     },
     sortingFn: sortingNumberNull,

--- a/ui/src/percent.test.ts
+++ b/ui/src/percent.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'vitest'
+import {formatTargetPercent} from './percent'
+
+describe('formatTargetPercent', () => {
+  it('drops the padding a fixed precision would add', () => {
+    expect(formatTargetPercent(0.99)).toBe('99')
+    expect(formatTargetPercent(0.995)).toBe('99.5')
+    expect(formatTargetPercent(0.999)).toBe('99.9')
+    expect(formatTargetPercent(1)).toBe('100')
+  })
+
+  it('keeps every digit that carries information', () => {
+    expect(formatTargetPercent(0.9999999)).toBe('99.99999')
+    expect(formatTargetPercent(0.999995)).toBe('99.9995')
+    expect(formatTargetPercent(0.9995)).toBe('99.95')
+  })
+
+  it('survives the float error that 100x introduces', () => {
+    // 99.999 / 100 * 100 doesn't come back exactly, and naive toString would
+    // render 99.99899999999999.
+    expect(formatTargetPercent(99.999 / 100)).toBe('99.999')
+    expect(formatTargetPercent(99.995 / 100)).toBe('99.995')
+    expect(formatTargetPercent(99.9 / 100)).toBe('99.9')
+  })
+
+  it('leaves a bare zero alone', () => {
+    // The trailing-zero strip must not eat the only digit there is.
+    expect(formatTargetPercent(0)).toBe('0')
+  })
+})

--- a/ui/src/percent.test.ts
+++ b/ui/src/percent.test.ts
@@ -1,5 +1,40 @@
 import {describe, expect, it} from 'vitest'
-import {formatTargetPercent} from './percent'
+import {formatPercent, formatTargetPercent} from './percent'
+
+describe('formatPercent', () => {
+  it('drops a decimal place entirely when the decimals are zeros', () => {
+    // What lets a narrow container show 99% without rounding anything away.
+    expect(formatPercent(99, 1)).toBe('99')
+    expect(formatPercent(99, 3)).toBe('99')
+    expect(formatPercent(99, 5)).toBe('99')
+    expect(formatPercent(100, 1)).toBe('100')
+  })
+
+  it('never rounds a real digit away to get there', () => {
+    // 99.9 at whole percent would read as 100 — a different objective.
+    expect(formatPercent(99.9, 1)).toBe('99.9')
+    expect(formatPercent(99.9, 3)).toBe('99.9')
+    expect(formatPercent(0.5, 1)).toBe('0.5')
+  })
+
+  it('collapses the tiers when the extra precision is all zeros', () => {
+    const value = 99.5
+    expect(formatPercent(value, 1)).toBe('99.5')
+    expect(formatPercent(value, 3)).toBe('99.5')
+    expect(formatPercent(value, 5)).toBe('99.5')
+  })
+
+  it('still rounds where the precision genuinely runs out', () => {
+    expect(formatPercent(98.76543, 1)).toBe('98.8')
+    expect(formatPercent(98.76543, 3)).toBe('98.765')
+    expect(formatPercent(98.76543, 5)).toBe('98.76543')
+  })
+
+  it('handles negatives', () => {
+    expect(formatPercent(-569.2, 3)).toBe('-569.2')
+    expect(formatPercent(-569, 5)).toBe('-569')
+  })
+})
 
 describe('formatTargetPercent', () => {
   it('drops the padding a fixed precision would add', () => {

--- a/ui/src/percent.ts
+++ b/ui/src/percent.ts
@@ -1,0 +1,14 @@
+// The most decimal places we ever show. Targets are authored by hand and rarely
+// go past five nines.
+export const MAX_PERCENT_DECIMALS = 5
+
+// Renders an objective's target as a percentage, dropping the trailing zeros a
+// fixed precision would pad it with: 99, not 99.00000, and 99.5, not 99.50000.
+//
+// This only ever removes zeros — a target is an exact value someone wrote down,
+// so unlike a measurement it must never be rounded to fit.
+export const formatTargetPercent = (fraction: number): string =>
+  (100 * fraction)
+    .toFixed(MAX_PERCENT_DECIMALS)
+    .replace(/(\.\d*?)0+$/, '$1')
+    .replace(/\.$/, '')

--- a/ui/src/percent.ts
+++ b/ui/src/percent.ts
@@ -2,13 +2,18 @@
 // go past five nines.
 export const MAX_PERCENT_DECIMALS = 5
 
-// Renders an objective's target as a percentage, dropping the trailing zeros a
-// fixed precision would pad it with: 99, not 99.00000, and 99.5, not 99.50000.
-//
-// This only ever removes zeros — a target is an exact value someone wrote down,
-// so unlike a measurement it must never be rounded to fit.
+// Drops the zeros a fixed precision pads a number with: 99.00000 becomes 99, and
+// 99.50000 becomes 99.5. Purely cosmetic — it only ever removes zeros, so it
+// can't change what the number says. That's the difference between showing 99%
+// for 99.00000% and showing it for 99.9%, which would be a different objective.
+export const trimTrailingZeros = (value: string): string =>
+  value.replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '')
+
+// Renders a percentage at the given precision with its padding removed.
+export const formatPercent = (percent: number, decimals: number): string =>
+  trimTrailingZeros(percent.toFixed(decimals))
+
+// Renders an objective's target as a percentage. A target is an exact value
+// someone wrote down, so unlike a measurement it's never rounded to fit.
 export const formatTargetPercent = (fraction: number): string =>
-  (100 * fraction)
-    .toFixed(MAX_PERCENT_DECIMALS)
-    .replace(/(\.\d*?)0+$/, '$1')
-    .replace(/\.$/, '')
+  formatPercent(100 * fraction, MAX_PERCENT_DECIMALS)


### PR DESCRIPTION
The same value shows up at 40px in a detail tile and at 14px in a table cell, and how many digits fit is a question about the space it lands in. Every precision is rendered and a container query picks the one that fits, sized in em so one set of thresholds holds at any font size.

Trailing zeros are dropped, so 99.00000% reads as 99%. A real digit is never rounded away to make something fit, since 99.9% shown as 100% would be a different objective.
