### PR TITLE
filesystem: add --reload-url flag for a custom reload endpoint

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -89,7 +89,19 @@ Objectives:
 	return objectives
 }
 
-func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.Client, configFiles, prometheusFolder string, genericRules, enablePrometheus3Migration bool, pyrraExternalURL *url.URL) int {
+// reloadEndpoint returns the URL that Pyrra POSTs to when triggering a reload
+// of the generated rules. When reloadURL is set it takes precedence over the
+// Prometheus client's default /-/reload endpoint, which is needed when the
+// reload endpoint sits behind a route prefix or on a separate component such as
+// Thanos Rule.
+func reloadEndpoint(promClient api.Client, reloadURL *url.URL) *url.URL {
+	if reloadURL != nil && reloadURL.String() != "" {
+		return reloadURL
+	}
+	return promClient.URL("/-/reload", nil)
+}
+
+func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.Client, configFiles, prometheusFolder string, genericRules, enablePrometheus3Migration bool, pyrraExternalURL, reloadURL *url.URL) int {
 	reconcilesTotal := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "pyrra_filesystem_reconciles_total",
 		Help: "The total amount of reconciles.",
@@ -222,7 +234,7 @@ func cmdFilesystem(logger log.Logger, reg *prometheus.Registry, promClient api.C
 							// Eventually we trigger a reload and then start the outer loop again
 							// waiting for updates or termination.
 							level.Debug(logger).Log("msg", "reloading Prometheus now")
-							url := promClient.URL("/-/reload", nil)
+							url := reloadEndpoint(promClient, reloadURL)
 							resp, body, err := promClient.Do(ctx, &http.Request{Method: http.MethodPost, URL: url})
 							if err != nil {
 								level.Warn(logger).Log("msg", "failed to reload Prometheus")

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -1,13 +1,30 @@
 package main
 
 import (
+	"net/url"
 	"testing"
 
+	"github.com/prometheus/client_golang/api"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pyrra-dev/pyrra/slo"
 )
+
+func TestReloadEndpoint(t *testing.T) {
+	promClient, err := api.NewClient(api.Config{Address: "http://localhost:9090"})
+	require.NoError(t, err)
+
+	// Without an override the default Prometheus /-/reload endpoint is used.
+	require.Equal(t, "http://localhost:9090/-/reload", reloadEndpoint(promClient, nil).String())
+
+	// An empty override (kong's default for an unset *url.URL flag) is ignored.
+	require.Equal(t, "http://localhost:9090/-/reload", reloadEndpoint(promClient, &url.URL{}).String())
+
+	// A configured override takes precedence over the Prometheus URL.
+	override := &url.URL{Scheme: "http", Host: "localhost:17902", Path: "/rule/-/reload"}
+	require.Equal(t, "http://localhost:17902/rule/-/reload", reloadEndpoint(promClient, override).String())
+}
 
 func TestMatchObjectives(t *testing.T) {
 	obj1 := slo.Objective{Labels: labels.FromStrings("foo", "bar")}

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ var CLI struct {
 	Filesystem struct {
 		ConfigFiles                string   `default:"/etc/pyrra/*.yaml" help:"The folder where Pyrra finds the config files to use. Any non yaml files will be ignored."`
 		PrometheusURL              *url.URL `default:"http://localhost:9090" help:"The URL to the Prometheus to query."`
+		ReloadURL                  *url.URL `default:"" help:"The URL to POST to when reloading the generated rules. Defaults to the Prometheus URL's /-/reload endpoint. Set this when the reload endpoint lives behind a route prefix or on a separate component like Thanos Rule."`
 		PrometheusFolder           string   `default:"/etc/prometheus/pyrra/" help:"The folder where Pyrra writes the generates Prometheus rules and alerts."`
 		GenericRules               bool     `default:"false" help:"Enabled generic recording rules generation to make it easier for tools like Grafana."`
 		EnablePrometheus3Migration bool     `default:"true" help:"Enable Prometheus 3 migration mode that makes rules compatible with both Prometheus 2 and 3. Enabled by default; pass --enable-prometheus-3-migration=false to opt out."`
@@ -265,6 +266,7 @@ func main() {
 			CLI.Filesystem.GenericRules,
 			CLI.Filesystem.EnablePrometheus3Migration,
 			CLI.Filesystem.ExternalURL,
+			CLI.Filesystem.ReloadURL,
 		)
 	case "kubernetes":
 		code = cmdKubernetes(


### PR DESCRIPTION
Adds a `--reload-url` flag to the filesystem component so the reload can target something other than the Prometheus URL's /-/reload endpoint, which is needed when running against Thanos Rule behind a route prefix. When unset the behaviour is unchanged. Fixes #986.